### PR TITLE
Replace custom events with direct callback props for auth modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,17 +40,10 @@ export function App() {
 
   const { saveStatus, lastSavedTime, handleChange } = useAutosave(timelineData);
 
-  useEffect(() => {
-    const handleOpenAuthModal = (e: CustomEvent<{ isSignUp: boolean }>) => {
-      setIsSignUp(e.detail.isSignUp);
-      setShowAuthModal(true);
-    };
-
-    window.addEventListener('open-auth-modal', handleOpenAuthModal as EventListener);
-    return () => {
-      window.removeEventListener('open-auth-modal', handleOpenAuthModal as EventListener);
-    };
-  }, []);
+  const handleAuthClick = (signUp: boolean) => {
+    setIsSignUp(signUp);
+    setShowAuthModal(true);
+  };
 
   // Trigger autosave when timeline data changes
   useEffect(() => {
@@ -145,6 +138,7 @@ export function App() {
         onEventsChange={setEvents}
         showSidePanel={showSidePanel}
         onCloseSidePanel={() => setShowSidePanel(false)}
+        onAuthClick={handleAuthClick}
         scale={scale}
         onScaleChange={handleScaleChange}
         saveStatus={saveStatus}

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -28,6 +28,7 @@ interface HeaderProps {
   onEventsChange: (events: TimelineEvent[]) => void;
   showSidePanel: boolean;
   onCloseSidePanel: () => void;
+  onAuthClick: (isSignUp: boolean) => void;
   scale: 'large' | 'small';
   onScaleChange: (scale: 'large' | 'small') => void;
   saveStatus: SaveStatus;
@@ -50,6 +51,7 @@ export function Header({
   onEventsChange,
   showSidePanel,
   onCloseSidePanel,
+  onAuthClick,
   scale,
   onScaleChange,
   saveStatus,
@@ -116,11 +118,12 @@ export function Header({
         defaultIsSignUp={isSignUp}
       />
 
-      <SidePanel 
-        isOpen={showSidePanel} 
-        onClose={onCloseSidePanel} 
+      <SidePanel
+        isOpen={showSidePanel}
+        onClose={onCloseSidePanel}
         timelineId={timelineId}
         onTimelineSwitch={onTimelineSwitch}
+        onAuthClick={onAuthClick}
       />
 
       <TimelineSettingsPanel

--- a/src/components/SidePanel/SidePanel.tsx
+++ b/src/components/SidePanel/SidePanel.tsx
@@ -17,13 +17,15 @@ interface SidePanelProps {
   onClose: () => void;
   timelineId: string | null;
   onTimelineSwitch: (timelineId: string) => void;
+  onAuthClick: (isSignUp: boolean) => void;
 }
 
-export function SidePanel({ 
-  isOpen, 
+export function SidePanel({
+  isOpen,
   onClose,
   timelineId,
-  onTimelineSwitch
+  onTimelineSwitch,
+  onAuthClick
 }: SidePanelProps) {
   const [currentPanel, setCurrentPanel] = useState<SubPanel>('main');
   const { user } = useAuth();
@@ -69,7 +71,7 @@ export function SidePanel({
   };
 
   const handleAuthClick = (signUp: boolean) => {
-    window.dispatchEvent(new CustomEvent('open-auth-modal', { detail: { isSignUp: signUp } }));
+    onAuthClick(signUp);
     onClose();
   };
 


### PR DESCRIPTION
## Summary
Refactored the authentication modal trigger mechanism from using custom window events to using direct callback props. This improves code maintainability and follows React best practices by using explicit prop drilling instead of implicit event-based communication.

## Key Changes
- Removed `useEffect` hook that listened for `open-auth-modal` custom events in `App.tsx`
- Created `handleAuthClick` callback function in `App.tsx` to directly manage auth modal state
- Added `onAuthClick` prop to `Header` component and passed it through to `SidePanel`
- Updated `SidePanel` to call the `onAuthClick` callback instead of dispatching custom window events
- Minor formatting improvements (whitespace cleanup in component props)

## Implementation Details
- The `handleAuthClick` function in `App.tsx` sets both `isSignUp` state and `showAuthModal` visibility
- The callback is passed down through the component hierarchy: `App` → `Header` → `SidePanel`
- This eliminates the need for global event listeners and makes the data flow more explicit and testable
- No functional changes to the user experience; this is purely a refactoring for better code organization

https://claude.ai/code/session_01WBVi2SmEjyebTbBqi5jMPP