### PR TITLE
Redesign timeline title as horizontal metadata bar

### DIFF
--- a/src/components/FloatingToolbar/FloatingToolbar.tsx
+++ b/src/components/FloatingToolbar/FloatingToolbar.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Columns3, Layers, Settings } from 'lucide-react';
+import { Plus, Columns3, Layers, Settings } from 'lucide-react';
 
 interface FloatingToolbarProps {
+  onAddEventClick: () => void;
   onEventsClick: () => void;
   onCategoriesClick: () => void;
   onSettingsClick: () => void;
@@ -20,12 +21,12 @@ function ToolbarButton({ icon, label, isActive, onClick }: ToolbarButtonProps) {
     <button
       onClick={onClick}
       className={`
-        relative flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium
+        flex items-center gap-2 px-5 py-3 rounded-xl text-sm font-medium
         transition-all duration-200 ease-out
         focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500
         ${isActive
-          ? 'bg-white/15 text-white'
-          : 'text-gray-300 hover:bg-white/10 hover:text-white hover:scale-105 active:scale-95 active:bg-white/5'
+          ? 'bg-[#2A2A2A] text-white'
+          : 'bg-[#1A1A1A] text-white hover:bg-[#252525] active:bg-[#151515]'
         }
       `}
     >
@@ -40,9 +41,12 @@ function MobileToolbarButton({ icon, label, isActive, onClick }: ToolbarButtonPr
     <button
       onClick={onClick}
       className={`
-        flex flex-col items-center gap-1 px-3 py-1 rounded-lg text-xs font-medium
+        flex flex-col items-center gap-1 px-3 py-2 rounded-xl text-[11px] font-medium
         transition-all duration-200 ease-out
-        ${isActive ? 'text-white' : 'text-gray-400'}
+        ${isActive
+          ? 'bg-[#2A2A2A] text-white'
+          : 'bg-[#1A1A1A] text-gray-300'
+        }
       `}
     >
       {icon}
@@ -52,6 +56,7 @@ function MobileToolbarButton({ icon, label, isActive, onClick }: ToolbarButtonPr
 }
 
 export function FloatingToolbar({
+  onAddEventClick,
   onEventsClick,
   onCategoriesClick,
   onSettingsClick,
@@ -59,9 +64,15 @@ export function FloatingToolbar({
 }: FloatingToolbarProps) {
   return (
     <>
-      {/* Desktop: Floating pill toolbar */}
+      {/* Desktop */}
       <div className="sticky top-[44px] z-30 hidden md:flex justify-center py-3">
-        <div className="inline-flex items-center gap-1 px-2 py-1.5 bg-white/10 backdrop-blur-xl border border-white/15 rounded-2xl shadow-[0_8px_32px_rgba(0,0,0,0.4),inset_0_1px_0_rgba(255,255,255,0.1)] animate-toolbar-in">
+        <div className="inline-flex items-center gap-3">
+          <ToolbarButton
+            icon={<Plus size={18} />}
+            label="Add Event"
+            isActive={false}
+            onClick={onAddEventClick}
+          />
           <ToolbarButton
             icon={<Columns3 size={18} />}
             label="Events"
@@ -84,21 +95,27 @@ export function FloatingToolbar({
       </div>
 
       {/* Mobile: Fixed bottom bar */}
-      <div className="fixed bottom-0 left-0 right-0 z-30 flex md:hidden justify-around items-center px-4 pt-2 pb-6 bg-white/10 backdrop-blur-xl border-t border-white/15">
+      <div className="fixed bottom-0 left-0 right-0 z-30 flex md:hidden justify-center items-center gap-2 px-4 pt-2 pb-6 bg-black">
         <MobileToolbarButton
-          icon={<Columns3 size={22} />}
+          icon={<Plus size={20} />}
+          label="Add"
+          isActive={false}
+          onClick={onAddEventClick}
+        />
+        <MobileToolbarButton
+          icon={<Columns3 size={20} />}
           label="Events"
           isActive={activePanel === 'events'}
           onClick={onEventsClick}
         />
         <MobileToolbarButton
-          icon={<Layers size={22} />}
+          icon={<Layers size={20} />}
           label="Categories"
           isActive={activePanel === 'categories'}
           onClick={onCategoriesClick}
         />
         <MobileToolbarButton
-          icon={<Settings size={22} />}
+          icon={<Settings size={20} />}
           label="Settings"
           isActive={activePanel === 'settings'}
           onClick={onSettingsClick}

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -76,7 +76,7 @@ export function Header({
   return (
     <>
       <header>
-        <div className="pl-[32px] pr-8 pt-8 pb-5 flex items-center justify-between">
+        <div className="px-[120px] pt-[40px] pb-8 flex items-center justify-between">
           <TimelineTitle
             title={title}
             description={description}

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -76,16 +76,14 @@ export function Header({
   return (
     <>
       <header>
-        <div className="pl-[32px] pr-8 pt-12 pb-8">
-          <div className="flex flex-wrap items-start justify-between gap-4">
-            <TimelineTitle 
-              title={title} 
-              description={description}
-              events={events}
-            />
-            <div className="flex-shrink-0">
-              <SaveStatusIndicator status={saveStatus} lastSaved={lastSavedTime} />
-            </div>
+        <div className="pl-[32px] pr-8 pt-8 pb-5 flex items-center justify-between">
+          <TimelineTitle
+            title={title}
+            description={description}
+            events={events}
+          />
+          <div className="shrink-0">
+            <SaveStatusIndicator status={saveStatus} lastSaved={lastSavedTime} />
           </div>
         </div>
 

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -94,6 +94,7 @@ export function Header({
             title={title}
             description={description}
             events={events}
+            onTitleChange={onTitleChange}
           />
           <div className="shrink-0">
             <SaveStatusIndicator status={saveStatus} lastSaved={lastSavedTime} />

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -6,6 +6,8 @@ import { TimelineSettingsPanel } from '../Settings/TimelineSettingsPanel';
 import { EventTableEditor } from '../EventTableEditor/EventTableEditor';
 import { CategoriesPanel } from '../Categories/CategoriesPanel';
 import { FloatingToolbar } from '../FloatingToolbar/FloatingToolbar';
+import { Modal } from '../Modal/Modal';
+import { EventForm } from '../EventForm/EventForm';
 import { TimelineEvent, CategoryConfig } from '../../types/event';
 import { useAuth } from '../../contexts/AuthContext';
 import { AuthModal } from '../Auth/AuthModal';
@@ -65,8 +67,19 @@ export function Header({
   };
 
   const closePanel = () => setActivePanel(null);
+  const [showAddEventModal, setShowAddEventModal] = useState(false);
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [isSignUp, setIsSignUp] = useState(false);
+
+  const handleAddEventClick = () => {
+    setActivePanel(null);
+    setShowAddEventModal(true);
+  };
+
+  const handleAddEventSubmit = (event: Omit<TimelineEvent, 'id'>) => {
+    onAddEvent(event);
+    setShowAddEventModal(false);
+  };
 
   const handleAuthClick = (signUp: boolean) => {
     setIsSignUp(signUp);
@@ -88,6 +101,7 @@ export function Header({
         </div>
 
         <FloatingToolbar
+          onAddEventClick={handleAddEventClick}
           onEventsClick={() => togglePanel('events')}
           onCategoriesClick={() => togglePanel('categories')}
           onSettingsClick={() => togglePanel('settings')}
@@ -95,7 +109,20 @@ export function Header({
         />
       </header>
 
-      <AuthModal 
+      {showAddEventModal && (
+        <Modal
+          isOpen={showAddEventModal}
+          onClose={() => setShowAddEventModal(false)}
+          title="Add New Event"
+        >
+          <EventForm
+            onSubmit={handleAddEventSubmit}
+            categories={categories.filter(c => c.visible)}
+          />
+        </Modal>
+      )}
+
+      <AuthModal
         isOpen={showAuthModal}
         onClose={() => setShowAuthModal(false)}
         defaultIsSignUp={isSignUp}

--- a/src/components/TimelineTitle/TimelineTitle.tsx
+++ b/src/components/TimelineTitle/TimelineTitle.tsx
@@ -1,20 +1,21 @@
 import { TimelineEvent } from '../../types/event';
 import { getTimelineYearRange } from '../../utils/timelineUtils';
-import { DEFAULT_TIMELINE_DESCRIPTION } from '../../constants/defaults';
 
 interface TimelineTitleProps {
   title: string;
   description: string;
   events: TimelineEvent[];
+  showDescription?: boolean;
 }
 
-export function TimelineTitle({ 
-  title, 
+export function TimelineTitle({
+  title,
   description,
-  events
+  events,
+  showDescription = false
 }: TimelineTitleProps) {
   const timelineRange = getTimelineYearRange(events);
-  const displayDescription = description || DEFAULT_TIMELINE_DESCRIPTION;
+  const hasDescription = showDescription && description.trim().length > 0;
 
   return (
     <div className="flex items-center gap-5 py-2">
@@ -32,17 +33,21 @@ export function TimelineTitle({
       <div className="w-px self-stretch bg-[#1E1E1E]" />
 
       {/* Title column */}
-      <h1 className="text-[32px] leading-[115%] text-[#F3F3F3] shrink-0">
+      <h1 className="text-[48px] leading-[115%] text-[#F3F3F3] shrink-0">
         {title}
       </h1>
 
-      {/* Divider */}
-      <div className="w-px self-stretch bg-[#1E1E1E]" />
+      {hasDescription && (
+        <>
+          {/* Divider */}
+          <div className="w-px self-stretch bg-[#1E1E1E]" />
 
-      {/* Description column */}
-      <p className="font-mono text-xs font-light leading-[140%] text-gray-300 max-w-[560px]">
-        {displayDescription}
-      </p>
+          {/* Description column */}
+          <p className="font-mono text-xs font-light leading-[140%] text-gray-300 max-w-[560px]">
+            {description}
+          </p>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/TimelineTitle/TimelineTitle.tsx
+++ b/src/components/TimelineTitle/TimelineTitle.tsx
@@ -20,10 +20,10 @@ export function TimelineTitle({
     <div className="flex items-center gap-5 py-2">
       {/* Stats column */}
       <div className="flex flex-col gap-1 shrink-0">
-        <span className="font-mono text-xs font-light leading-[140%] text-gray-300">
+        <span className="font-mono text-sm font-light leading-[140%] text-gray-300">
           {timelineRange}
         </span>
-        <span className="font-mono text-xs font-light leading-[140%] text-gray-300">
+        <span className="font-mono text-sm font-light leading-[140%] text-gray-300">
           {events.length} {events.length === 1 ? 'event' : 'events'}
         </span>
       </div>

--- a/src/components/TimelineTitle/TimelineTitle.tsx
+++ b/src/components/TimelineTitle/TimelineTitle.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { TimelineEvent } from '../../types/event';
 import { getTimelineYearRange } from '../../utils/timelineUtils';
 import { DEFAULT_TIMELINE_DESCRIPTION } from '../../constants/defaults';
@@ -18,14 +17,30 @@ export function TimelineTitle({
   const displayDescription = description || DEFAULT_TIMELINE_DESCRIPTION;
 
   return (
-    <div className="flex-1 max-w-[800px] p-[24px_40px_32px_24px] bg-dark rounded-2xl">
-      <div className="text-gray-400 text-sm mb-1">
-        {timelineRange}
+    <div className="flex items-center gap-5 py-2">
+      {/* Stats column */}
+      <div className="flex flex-col gap-1 shrink-0">
+        <span className="font-mono text-xs font-light leading-[140%] text-gray-300">
+          {timelineRange}
+        </span>
+        <span className="font-mono text-xs font-light leading-[140%] text-gray-300">
+          {events.length} {events.length === 1 ? 'event' : 'events'}
+        </span>
       </div>
-      <h1 className="text-[48px] text-[#FBFBFB]">
+
+      {/* Divider */}
+      <div className="w-px self-stretch bg-[#1E1E1E]" />
+
+      {/* Title column */}
+      <h1 className="text-[32px] leading-[115%] text-[#F3F3F3] shrink-0">
         {title}
       </h1>
-      <p className="text-base text-gray-300 mt-2">
+
+      {/* Divider */}
+      <div className="w-px self-stretch bg-[#1E1E1E]" />
+
+      {/* Description column */}
+      <p className="font-mono text-xs font-light leading-[140%] text-gray-300 max-w-[560px]">
         {displayDescription}
       </p>
     </div>

--- a/src/components/TimelineTitle/TimelineTitle.tsx
+++ b/src/components/TimelineTitle/TimelineTitle.tsx
@@ -6,16 +6,19 @@ interface TimelineTitleProps {
   description: string;
   events: TimelineEvent[];
   showDescription?: boolean;
+  onTitleChange?: (title: string) => void;
 }
 
 export function TimelineTitle({
   title,
   description,
   events,
-  showDescription = false
+  showDescription = false,
+  onTitleChange
 }: TimelineTitleProps) {
   const timelineRange = getTimelineYearRange(events);
   const hasDescription = showDescription && description.trim().length > 0;
+  const isEditable = !!onTitleChange;
 
   return (
     <div className="flex items-center gap-5 py-2">
@@ -33,9 +36,24 @@ export function TimelineTitle({
       <div className="w-px self-stretch bg-[#1E1E1E]" />
 
       {/* Title column */}
-      <h1 className="text-[48px] leading-[115%] text-[#F3F3F3] shrink-0">
-        {title}
-      </h1>
+      {isEditable ? (
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => onTitleChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              (e.target as HTMLInputElement).blur();
+            }
+          }}
+          className="bg-transparent text-[48px] leading-[115%] text-[#F3F3F3] shrink-0 font-['Aleo'] font-medium tracking-[-0.01em] border-none outline-none focus:outline-none caret-white min-w-0"
+          style={{ width: `${Math.max(title.length, 1)}ch` }}
+        />
+      ) : (
+        <h1 className="text-[48px] leading-[115%] text-[#F3F3F3] shrink-0">
+          {title}
+        </h1>
+      )}
 
       {hasDescription && (
         <>

--- a/src/components/TimelineViewer/TimelineViewer.tsx
+++ b/src/components/TimelineViewer/TimelineViewer.tsx
@@ -150,11 +150,12 @@ export function TimelineViewer() {
       </div>
 
       {/* Timeline Content */}
-      <div className="pl-[32px] pr-8 pt-8 pb-5">
+      <div className="px-[120px] pt-[40px] pb-8">
         <TimelineTitle
           title={timeline.title}
           description={timeline.description}
           events={timeline.events}
+          showDescription
         />
       </div>
 

--- a/src/components/TimelineViewer/TimelineViewer.tsx
+++ b/src/components/TimelineViewer/TimelineViewer.tsx
@@ -150,8 +150,8 @@ export function TimelineViewer() {
       </div>
 
       {/* Timeline Content */}
-      <div className="pl-[32px] pr-8 pt-12 pb-8">
-        <TimelineTitle 
+      <div className="pl-[32px] pr-8 pt-8 pb-5">
+        <TimelineTitle
           title={timeline.title}
           description={timeline.description}
           events={timeline.events}

--- a/src/index.css
+++ b/src/index.css
@@ -18,7 +18,7 @@
   }
 }
 
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=Droid+Serif:wght@400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400&family=Droid+Serif:wght@400&display=swap');
 
 @layer utilities {
   .scrollbar-hide {

--- a/src/index.css
+++ b/src/index.css
@@ -11,14 +11,14 @@
   }
 
   h1 {
-    font-family: 'Droid Serif', serif;
+    font-family: 'Aleo', serif;
     letter-spacing: -0.01em;
     line-height: 1.15;
-    font-weight: 400;
+    font-weight: 500;
   }
 }
 
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400&family=Droid+Serif:wght@400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Aleo:wght@500&family=IBM+Plex+Mono:wght@300;400&display=swap');
 
 @layer utilities {
   .scrollbar-hide {


### PR DESCRIPTION
Replace vertical card layout with horizontal 3-column layout: stats (year range + event count) | title | description, separated by thin dividers. Load IBM Plex Mono light weight for stats and description text.

https://claude.ai/code/session_01WBVi2SmEjyebTbBqi5jMPP