### PR TITLE
Redesign timeline header as centered vertical stack

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -89,14 +89,14 @@ export function Header({
   return (
     <>
       <header>
-        <div className="px-[120px] pt-[40px] pb-8 flex items-center justify-between">
+        <div className="px-[120px] pt-[40px] pb-8 flex flex-col items-center relative">
           <TimelineTitle
             title={title}
             description={description}
             events={events}
             onTitleChange={onTitleChange}
           />
-          <div className="shrink-0">
+          <div className="absolute right-8 top-[40px] shrink-0">
             <SaveStatusIndicator status={saveStatus} lastSaved={lastSavedTime} />
           </div>
         </div>

--- a/src/components/TimelineTitle/TimelineTitle.tsx
+++ b/src/components/TimelineTitle/TimelineTitle.tsx
@@ -21,50 +21,43 @@ export function TimelineTitle({
   const isEditable = !!onTitleChange;
 
   return (
-    <div className="flex items-center gap-5 py-2">
-      {/* Stats column */}
-      <div className="flex flex-col gap-1 shrink-0">
-        <span className="font-mono text-sm font-light leading-[140%] text-gray-300">
-          {timelineRange}
-        </span>
+    <div className="flex flex-col items-center gap-3">
+      {/* Title pill */}
+      <div className="border border-[#333] rounded-2xl px-8 py-4">
+        {isEditable ? (
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => onTitleChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                (e.target as HTMLInputElement).blur();
+              }
+            }}
+            className="bg-transparent text-[48px] leading-[115%] text-[#F3F3F3] font-['Aleo'] font-medium tracking-[-0.01em] border-none outline-none focus:outline-none caret-white min-w-0 text-center"
+            style={{ width: `${Math.max(title.length, 1)}ch` }}
+          />
+        ) : (
+          <h1 className="text-[48px] leading-[115%] text-[#F3F3F3] text-center">
+            {title}
+          </h1>
+        )}
+      </div>
+
+      {/* Stats row */}
+      <div className="flex items-center gap-8">
         <span className="font-mono text-sm font-light leading-[140%] text-gray-300">
           {events.length} {events.length === 1 ? 'event' : 'events'}
         </span>
+        <span className="font-mono text-sm font-light leading-[140%] text-gray-300">
+          {timelineRange}
+        </span>
       </div>
 
-      {/* Divider */}
-      <div className="w-px self-stretch bg-[#1E1E1E]" />
-
-      {/* Title column */}
-      {isEditable ? (
-        <input
-          type="text"
-          value={title}
-          onChange={(e) => onTitleChange(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              (e.target as HTMLInputElement).blur();
-            }
-          }}
-          className="bg-transparent text-[48px] leading-[115%] text-[#F3F3F3] shrink-0 font-['Aleo'] font-medium tracking-[-0.01em] border-none outline-none focus:outline-none caret-white min-w-0"
-          style={{ width: `${Math.max(title.length, 1)}ch` }}
-        />
-      ) : (
-        <h1 className="text-[48px] leading-[115%] text-[#F3F3F3] shrink-0">
-          {title}
-        </h1>
-      )}
-
       {hasDescription && (
-        <>
-          {/* Divider */}
-          <div className="w-px self-stretch bg-[#1E1E1E]" />
-
-          {/* Description column */}
-          <p className="font-mono text-xs font-light leading-[140%] text-gray-300 max-w-[560px]">
-            {description}
-          </p>
-        </>
+        <p className="font-mono text-xs font-light leading-[140%] text-gray-300 max-w-[560px] text-center">
+          {description}
+        </p>
       )}
     </div>
   );

--- a/src/components/TimelineViewer/TimelineViewer.tsx
+++ b/src/components/TimelineViewer/TimelineViewer.tsx
@@ -150,7 +150,7 @@ export function TimelineViewer() {
       </div>
 
       {/* Timeline Content */}
-      <div className="px-[120px] pt-[40px] pb-8">
+      <div className="px-[120px] pt-[40px] pb-8 flex flex-col items-center">
         <TimelineTitle
           title={timeline.title}
           description={timeline.description}


### PR DESCRIPTION
- Title in a rounded bordered pill, centered on page
- Stats (event count + year range) displayed side by side below
- Removed horizontal 3-column layout and vertical dividers
- SaveStatusIndicator positioned absolutely at top-right
- Present mode (TimelineViewer) matches the centered layout

https://claude.ai/code/session_01WBVi2SmEjyebTbBqi5jMPP