### PR TITLE
Add dedicated Timelines homepage with timeline management

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,73 @@
+# Plan: Create Timelines Homepage
+
+## Overview
+Create a dedicated Timelines homepage that serves as a landing page when users click the "Timelines" breadcrumb in the `GlobalNav`. Currently "Timelines" is static text — this plan turns it into a navigable link to a new `/timelines` route.
+
+## Current State
+- **Routes**: `/` (editor), `/view/:timelineId` (viewer)
+- **Breadcrumb**: `GlobalNav.tsx` renders `<span>Timelines</span>` as non-clickable text
+- **Timeline list**: Currently lives inside `SidePanel.tsx` as a slide-out drawer
+- **Data**: `useTimelines` hook fetches user's timelines from Supabase, `TimelineList` renders them
+
+## Implementation Steps
+
+### 1. Create the `TimelinesPage` component
+**File**: `src/components/TimelinesPage/TimelinesPage.tsx`
+
+Build a full-page component that displays the user's timelines. This is the page users see when they click "Timelines" in the breadcrumb.
+
+**Content for logged-in users:**
+- Page heading: "Timelines"
+- Grid/list of the user's timelines (reuse data from `useTimelines` hook)
+- Each timeline card shows: title, last updated date
+- Clicking a card navigates to `/` and loads that timeline
+- "Create new timeline" button (respecting the 3-timeline max)
+
+**Content for logged-out users:**
+- Page heading: "Timelines"
+- Prompt to sign in / sign up to access timelines
+- Auth modal triggers for sign-in/sign-up
+
+### 2. Add the `/timelines` route
+**File**: `src/Router.tsx`
+
+Add a new route entry:
+```tsx
+{
+  path: '/timelines',
+  element: <TimelinesPage />
+}
+```
+
+This keeps `/` as the existing editor and adds `/timelines` as the new homepage.
+
+### 3. Make the "Timelines" breadcrumb a clickable link
+**File**: `src/components/Header/GlobalNav.tsx`
+
+Replace the static `<span>Timelines</span>` with a `<Link to="/timelines">` from React Router. This applies to both the logged-in breadcrumb path ("Timelines / Title") and the logged-out label. The link should have hover styling consistent with the existing nav design (`text-gray-400 hover:text-white`).
+
+### 4. Wrap the editor (`App`) route in the router context
+**File**: `src/Router.tsx`
+
+The `App` component currently sits at `/`. To support navigation from `/timelines` to a specific timeline at `/`, pass timeline selection state via URL search params or route state. The simplest approach: when a user clicks a timeline on the homepage, navigate to `/?timeline={id}` and have `App` pick up the `timeline` param to auto-load it.
+
+Alternatively, keep the existing `App` behavior (which auto-loads the user's timeline on mount via `useTimeline`) and simply use `navigate('/')` — the app will load the most recently updated timeline by default.
+
+### 5. Handle timeline selection from the homepage
+**File**: `src/App.tsx` (minor adjustment)
+
+When navigating from the Timelines homepage to a specific timeline, use React Router's `useSearchParams` or `useLocation` state to receive the selected timeline ID. Call `loadTimeline(id)` to switch to it. This mirrors the existing `handleTimelineSwitch` logic.
+
+## Files Changed
+| File | Change |
+|------|--------|
+| `src/components/TimelinesPage/TimelinesPage.tsx` | **New** — Homepage component |
+| `src/Router.tsx` | Add `/timelines` route |
+| `src/components/Header/GlobalNav.tsx` | Make "Timelines" a `<Link>` |
+| `src/App.tsx` | Read timeline ID from URL params to support deep-linking from homepage |
+
+## Design Decisions
+- **Reuse `useTimelines` hook** — no new data-fetching logic needed
+- **Keep SidePanel** — the side panel remains for quick access from the editor; the homepage is a separate, full-page experience
+- **Dark theme** — matches existing app: black background, gray-800 cards, white text, blue-600 accent buttons
+- **Minimal scope** — no new database tables, API calls, or auth changes needed

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Header } from './components/Layout/Header';
 import { GlobalNav } from './components/Header/GlobalNav';
 import { TimelineContainer } from './components/Timeline/TimelineContainer';
@@ -23,6 +24,8 @@ export function App() {
   const { scale, currentScale, handleScaleChange } = useTimelineScale();
   const { user } = useAuth();
   const { saveTimeline, timelineId, loadTimeline, error: timelineError, retryInitialLoad } = useTimeline();
+  const location = useLocation();
+  const routerNavigate = useNavigate();
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [showSampleTimeline, setShowSampleTimeline] = useState(false);
   const [pendingSwitchTimelineId, setPendingSwitchTimelineId] = useState<string | null>(null);
@@ -33,6 +36,7 @@ export function App() {
   const [draftHydrated, setDraftHydrated] = useState(false);
   const [nudgeDismissed, setNudgeDismissed] = useState(false);
   const { loadDraft, saveDraft, clearDraft } = useLocalDraft();
+  const handledRouteStateRef = useRef(false);
 
   const timelineData = {
     id: timelineId,
@@ -108,6 +112,17 @@ export function App() {
       }
     }
   }, [user, draftHydrated]);
+
+  // Handle navigation from Homepage with a specific timeline to load
+  useEffect(() => {
+    const state = location.state as { timelineId?: string } | null;
+    if (state?.timelineId && user && !handledRouteStateRef.current) {
+      handledRouteStateRef.current = true;
+      switchTimeline(state.timelineId);
+      // Clear the state so refreshing doesn't re-trigger
+      routerNavigate('/', { replace: true, state: {} });
+    }
+  }, [location.state, user]);
 
   const handleTimelineSwitch = async (newTimelineId: string) => {
     if (saveStatus === 'saving') {

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,11 +1,16 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { App } from './App';
+import { Homepage } from './components/Homepage/Homepage';
 import { TimelineViewer } from './components/TimelineViewer/TimelineViewer';
 
 const router = createBrowserRouter([
   {
     path: '/',
     element: <App />
+  },
+  {
+    path: '/timelines',
+    element: <Homepage />
   },
   {
     path: '/view/:timelineId',

--- a/src/components/Header/GlobalNav.tsx
+++ b/src/components/Header/GlobalNav.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { PanelLeft, Play, X, Video } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { Modal } from '../Modal/Modal';
 
@@ -23,6 +24,7 @@ export function GlobalNav({
   onTitleChange
 }: GlobalNavProps) {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isVideoTutorialOpen, setIsVideoTutorialOpen] = useState(false);
 
@@ -64,12 +66,22 @@ export function GlobalNav({
           </button>
           {user ? (
             <div className="flex items-center text-sm">
-              <span className="text-gray-400">Timelines</span>
+              <button
+                onClick={() => navigate('/timelines')}
+                className="text-gray-400 hover:text-white transition-colors"
+              >
+                Timelines
+              </button>
               <span className="text-gray-500 mx-1.5">/</span>
               <span className="text-white font-medium">{title}</span>
             </div>
           ) : (
-            <span className="text-gray-400 text-sm">Timelines</span>
+            <button
+              onClick={() => navigate('/timelines')}
+              className="text-gray-400 hover:text-white transition-colors text-sm"
+            >
+              Timelines
+            </button>
           )}
         </div>
 

--- a/src/components/Homepage/EmptyState.tsx
+++ b/src/components/Homepage/EmptyState.tsx
@@ -1,0 +1,55 @@
+import { Plus } from 'lucide-react';
+
+interface EmptyStateProps {
+  variant: 'logged-out' | 'no-timelines';
+  onSignInClick?: () => void;
+  onSignUpClick?: () => void;
+  onCreateClick?: () => void;
+}
+
+export function EmptyState({ variant, onSignInClick, onSignUpClick, onCreateClick }: EmptyStateProps) {
+  if (variant === 'logged-out') {
+    return (
+      <div className="text-center py-12">
+        <h3 className="text-lg font-medium text-white mb-2">
+          Sign in to access your timelines
+        </h3>
+        <p className="text-gray-400 mb-6">
+          Create up to 3 timelines and access them from anywhere
+        </p>
+        <div className="space-y-2 max-w-xs mx-auto">
+          <button
+            onClick={onSignInClick}
+            className="w-full py-2 px-4 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+          >
+            Sign In
+          </button>
+          <button
+            onClick={onSignUpClick}
+            className="w-full py-2 px-4 bg-gray-700 text-white rounded-md hover:bg-gray-600 transition-colors"
+          >
+            Create Account
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-center py-12">
+      <h3 className="text-lg font-medium text-white mb-2">
+        No timelines yet
+      </h3>
+      <p className="text-gray-400 mb-6">
+        Create your first timeline to get started
+      </p>
+      <button
+        onClick={onCreateClick}
+        className="inline-flex items-center gap-2 py-2 px-4 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+      >
+        <Plus size={18} />
+        Create Your First Timeline
+      </button>
+    </div>
+  );
+}

--- a/src/components/Homepage/Homepage.tsx
+++ b/src/components/Homepage/Homepage.tsx
@@ -1,0 +1,128 @@
+import { useState, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Plus } from 'lucide-react';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTimelines } from '../../hooks/useTimelines';
+import { useTimelineMetadata } from '../../hooks/useTimelineMetadata';
+import { AuthModal } from '../Auth/AuthModal';
+import { HomepageNav } from './HomepageNav';
+import { TimelineTile } from './TimelineTile';
+import { EmptyState } from './EmptyState';
+
+const MAX_TIMELINES = 3;
+
+export function Homepage() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const { timelines, isLoading, error, loadTimelines } = useTimelines();
+  const [showAuthModal, setShowAuthModal] = useState(false);
+  const [isSignUp, setIsSignUp] = useState(false);
+
+  const timelineIds = useMemo(
+    () => timelines.map(t => t.id),
+    [timelines]
+  );
+  const metadata = useTimelineMetadata(timelineIds);
+
+  const handleTileClick = (timelineId: string) => {
+    navigate('/', { state: { timelineId } });
+  };
+
+  const handleCreateTimeline = () => {
+    navigate('/', { state: { timelineId: 'new' } });
+  };
+
+  const handleAuthClick = (signUp: boolean) => {
+    setIsSignUp(signUp);
+    setShowAuthModal(true);
+  };
+
+  const canCreate = timelines.length < MAX_TIMELINES;
+
+  const renderContent = () => {
+    if (!user) {
+      return (
+        <EmptyState
+          variant="logged-out"
+          onSignInClick={() => handleAuthClick(false)}
+          onSignUpClick={() => handleAuthClick(true)}
+        />
+      );
+    }
+
+    if (isLoading) {
+      return (
+        <div className="text-gray-400 text-center py-8">Loading timelines...</div>
+      );
+    }
+
+    if (error) {
+      return (
+        <div className="text-center py-8">
+          <p className="text-red-400 mb-4">{error}</p>
+          <button
+            onClick={() => loadTimelines()}
+            className="px-4 py-2 bg-gray-700 text-white rounded-md hover:bg-gray-600 transition-colors"
+          >
+            Try Again
+          </button>
+        </div>
+      );
+    }
+
+    if (timelines.length === 0) {
+      return (
+        <EmptyState
+          variant="no-timelines"
+          onCreateClick={handleCreateTimeline}
+        />
+      );
+    }
+
+    return (
+      <div className="flex flex-col gap-4">
+        {timelines.map(timeline => {
+          const meta = metadata.get(timeline.id);
+          return (
+            <TimelineTile
+              key={timeline.id}
+              title={timeline.title}
+              eventCount={meta?.eventCount ?? 0}
+              yearRange={meta?.yearRange ?? ''}
+              onClick={() => handleTileClick(timeline.id)}
+            />
+          );
+        })}
+        {canCreate && (
+          <button
+            onClick={handleCreateTimeline}
+            className="w-full flex items-center justify-center gap-2 bg-[#1A1A1A] text-gray-400 hover:bg-[#252525] hover:text-white rounded-xl px-5 py-6 text-sm font-medium transition-all duration-200 ease-out border border-dashed border-gray-600 hover:border-gray-500"
+          >
+            <Plus size={18} />
+            Create New Timeline
+          </button>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="min-h-screen bg-black text-white">
+      <HomepageNav
+        onSignInClick={() => handleAuthClick(false)}
+        onSignUpClick={() => handleAuthClick(true)}
+      />
+      <main className="max-w-2xl mx-auto px-8 pt-16 pb-20">
+        <h1 className="text-[48px] leading-[115%] text-[#F3F3F3] font-['Aleo'] font-medium tracking-[-0.01em] mb-12">
+          Timelines
+        </h1>
+        {renderContent()}
+      </main>
+      <AuthModal
+        isOpen={showAuthModal}
+        onClose={() => setShowAuthModal(false)}
+        defaultIsSignUp={isSignUp}
+      />
+    </div>
+  );
+}

--- a/src/components/Homepage/HomepageNav.tsx
+++ b/src/components/Homepage/HomepageNav.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { X } from 'lucide-react';
+import { useAuth } from '../../contexts/AuthContext';
+import { supabase } from '../../lib/supabase';
+
+interface HomepageNavProps {
+  onSignInClick: () => void;
+  onSignUpClick: () => void;
+}
+
+export function HomepageNav({ onSignInClick, onSignUpClick }: HomepageNavProps) {
+  const { user } = useAuth();
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
+
+  const handleFeedbackClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsHelpOpen(true);
+  };
+
+  const handleEmailClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const mailtoLink = "mailto:alex@timeline.academy?subject=" + encodeURIComponent("I'm a timeline.academy user. Here's my feedback");
+    window.location.href = mailtoLink;
+  };
+
+  const handleSignOut = async () => {
+    try {
+      await supabase.auth.signOut();
+    } catch (error) {
+      console.error('Error signing out:', error);
+    }
+  };
+
+  return (
+    <div className="bg-black">
+      <div className="mx-auto px-8 py-2 flex justify-between items-center">
+        {/* Left side */}
+        <span className="text-gray-400 text-sm">Timelines</span>
+
+        {/* Right side */}
+        <div className="flex items-center gap-4">
+          <button
+            onClick={handleFeedbackClick}
+            className="text-gray-400 hover:text-white transition-colors text-sm"
+          >
+            Feedback
+          </button>
+
+          {user ? (
+            <button
+              onClick={handleSignOut}
+              className="text-gray-400 hover:text-white transition-colors text-sm"
+            >
+              Sign Out
+            </button>
+          ) : (
+            <>
+              <button
+                onClick={onSignInClick}
+                className="text-gray-400 hover:text-white transition-colors text-sm"
+              >
+                Sign In
+              </button>
+              <button
+                onClick={onSignUpClick}
+                className="px-4 py-1.5 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-sm"
+              >
+                Create Account
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Feedback Panel */}
+      <div
+        className={`fixed inset-0 bg-black/50 z-40 transition-opacity duration-250 ease-in-out ${
+          isHelpOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+        onClick={() => setIsHelpOpen(false)}
+      />
+
+      <div
+        className={`fixed right-0 top-0 h-full w-[400px] min-w-[360px] bg-gray-800 z-50 shadow-xl transform transition-transform duration-250 ease-in-out ${
+          isHelpOpen ? 'translate-x-0' : 'translate-x-full'
+        }`}
+      >
+        <div className="flex justify-between items-center px-6 py-4 border-b border-gray-700">
+          <h2 className="text-xl font-semibold text-white">Feedback</h2>
+          <button
+            onClick={() => setIsHelpOpen(false)}
+            className="text-gray-400 hover:text-white transition-colors p-2 rounded-full hover:bg-gray-700"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="p-6 text-gray-300 space-y-4">
+          <p className="text-white font-medium">Hi, I'm Alex.</p>
+
+          <p>
+            I'm obsessed with timelines and how they transform the way we understand information. They turn isolated moments into visual stories that reveal hidden patterns and connections.
+          </p>
+
+          <p>
+            Timeline.academy is my attempt to create the timeline tool I've always wanted - one that's visually clean, simple to manage, and functionally intuitive.
+          </p>
+
+          <p>
+            I'm looking for feedback! The best products grow through their community. I'd love to hear your thoughts on how to make timeline.academy better – your feedback will help shape its future.
+          </p>
+
+          <p>
+            Thanks!
+          </p>
+
+          <div className="pt-4 space-y-3">
+            <button
+              onClick={handleEmailClick}
+              className="w-full py-2 px-4 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+            >
+              Give Feedback
+            </button>
+
+            <a
+              href="https://buymeacoffee.com/ttjs81madp"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-full py-2 px-4 bg-gray-700 text-white rounded-md hover:bg-gray-600 transition-colors flex items-center justify-center gap-2"
+            >
+              Buy me a coffee
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Homepage/TimelineTile.tsx
+++ b/src/components/Homepage/TimelineTile.tsx
@@ -1,0 +1,27 @@
+import { DEFAULT_TIMELINE_TITLE } from '../../constants/defaults';
+
+interface TimelineTileProps {
+  title: string;
+  eventCount: number;
+  yearRange: string;
+  onClick: () => void;
+}
+
+export function TimelineTile({ title, eventCount, yearRange, onClick }: TimelineTileProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="w-full text-left bg-[#1A1A1A] text-white hover:bg-[#252525] active:bg-[#151515] rounded-xl px-5 py-6 transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+    >
+      <div className="flex items-center justify-between">
+        <span className="font-medium text-base">
+          {title || DEFAULT_TIMELINE_TITLE}
+        </span>
+        <div className="flex items-center gap-4 font-mono text-xs font-light text-gray-400">
+          <span>{eventCount} {eventCount === 1 ? 'event' : 'events'}</span>
+          {yearRange && <span>{yearRange}</span>}
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/src/hooks/useTimelineMetadata.ts
+++ b/src/hooks/useTimelineMetadata.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '../lib/supabase';
+import { getTimelineYearRange } from '../utils/timelineUtils';
+import { TimelineCategory } from '../types/event';
+
+export interface TimelineMetadata {
+  eventCount: number;
+  yearRange: string;
+}
+
+export function useTimelineMetadata(timelineIds: string[]): Map<string, TimelineMetadata> {
+  const [metadata, setMetadata] = useState<Map<string, TimelineMetadata>>(new Map());
+
+  useEffect(() => {
+    if (timelineIds.length === 0) {
+      setMetadata(new Map());
+      return;
+    }
+
+    const fetchMetadata = async () => {
+      const { data, error } = await supabase
+        .from('events')
+        .select('timeline_id, start_date, end_date')
+        .in('timeline_id', timelineIds);
+
+      if (error) {
+        console.error('Error fetching timeline metadata:', error);
+        return;
+      }
+
+      const result = new Map<string, TimelineMetadata>();
+
+      // Initialize all timelines with defaults (so 0-event timelines get entries)
+      for (const id of timelineIds) {
+        result.set(id, {
+          eventCount: 0,
+          yearRange: new Date().getFullYear().toString(),
+        });
+      }
+
+      // Group events by timeline_id
+      const eventsByTimeline = new Map<string, Array<{ start_date: string; end_date: string }>>();
+      for (const event of data || []) {
+        const existing = eventsByTimeline.get(event.timeline_id) || [];
+        existing.push(event);
+        eventsByTimeline.set(event.timeline_id, existing);
+      }
+
+      // Compute metadata per timeline
+      for (const [timelineId, events] of eventsByTimeline) {
+        const asTimelineEvents = events.map(e => ({
+          id: '',
+          title: '',
+          startDate: e.start_date,
+          endDate: e.end_date || e.start_date,
+          category: 'personal' as TimelineCategory,
+        }));
+
+        result.set(timelineId, {
+          eventCount: events.length,
+          yearRange: getTimelineYearRange(asTimelineEvents),
+        });
+      }
+
+      setMetadata(result);
+    };
+
+    fetchMetadata();
+  }, [JSON.stringify(timelineIds)]);
+
+  return metadata;
+}


### PR DESCRIPTION
## Summary
This PR introduces a new dedicated Timelines homepage (`/timelines`) that serves as a landing page for users to view, manage, and create timelines. The "Timelines" breadcrumb in the navigation is now a clickable link that routes to this new homepage.

## Key Changes

- **New Homepage Component** (`src/components/Homepage/Homepage.tsx`): Full-page component displaying user's timelines with support for:
  - Logged-out state with sign-in/sign-up prompts
  - Logged-in state showing timeline list with metadata
  - Empty state when user has no timelines
  - Create new timeline button (respecting 3-timeline max)
  - Navigation to editor when timeline is selected

- **New Navigation Component** (`src/components/Homepage/HomepageNav.tsx`): Header bar for the homepage featuring:
  - Feedback panel with personal message from creator
  - Sign in/Sign up buttons for logged-out users
  - Sign out button for logged-in users
  - Email feedback link and "Buy me a coffee" support link

- **Timeline Display Components**:
  - `TimelineTile.tsx`: Reusable card component showing timeline title, event count, and year range
  - `EmptyState.tsx`: Flexible empty state component for both logged-out and no-timelines scenarios

- **New Hook** (`src/hooks/useTimelineMetadata.ts`): Fetches and computes metadata (event count, year range) for multiple timelines in a single query

- **Router Updates** (`src/Router.tsx`): Added `/timelines` route pointing to the new Homepage component

- **Navigation Updates** (`src/components/Header/GlobalNav.tsx`): Made "Timelines" breadcrumb clickable, routing to `/timelines` for both logged-in and logged-out states

- **App Integration** (`src/App.tsx`): Added support for receiving timeline selection from the homepage via route state, allowing deep-linking to specific timelines

## Implementation Details

- Reuses existing `useTimelines` hook for fetching user's timelines
- Metadata fetching is optimized with a single Supabase query grouped by timeline
- Timeline selection from homepage passes state through React Router to auto-load the selected timeline in the editor
- Maintains existing dark theme design with consistent styling
- No new database tables or API changes required

https://claude.ai/code/session_01DiBFVRQ1Yc3JJHNSsbG58W