### PR TITLE
Improve login experience with SMS OTP and UX enhancements

### DIFF
--- a/src/components/Auth/AuthModal.tsx
+++ b/src/components/Auth/AuthModal.tsx
@@ -1,7 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
 import { Modal } from '../Modal/Modal';
 import { useAuth } from '../../contexts/AuthContext';
 import { supabase } from '../../lib/supabase';
+import { OtpInput } from './OtpInput';
 
 interface AuthModalProps {
   isOpen: boolean;
@@ -9,32 +11,148 @@ interface AuthModalProps {
   defaultIsSignUp?: boolean;
 }
 
+type AuthMethod = 'phone' | 'email';
+type OtpStep = 'phone_entry' | 'otp_verify';
+
+const RESEND_COOLDOWN_SECONDS = 60;
+
+function Spinner() {
+  return (
+    <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white inline-block" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+    </svg>
+  );
+}
+
+function mapErrorMessage(err: unknown): string {
+  if (!(err instanceof Error)) return 'An unexpected error occurred';
+
+  const msg = err.message;
+
+  // Network errors
+  if (msg.includes('Failed to fetch') || msg.includes('NetworkError') || msg === 'fetch') {
+    return 'Unable to connect. Please check your internet connection and try again.';
+  }
+
+  // Email/password auth errors
+  if (msg.includes('Email not confirmed')) {
+    return 'Please check your email to confirm your account before signing in.';
+  }
+  if (msg.includes('Invalid login credentials')) {
+    return 'Invalid email or password.';
+  }
+  if (msg.includes('Email rate limit exceeded')) {
+    return 'Too many attempts. Please try again later.';
+  }
+
+  // Phone/OTP errors
+  if (msg.includes('Phone number') || msg.includes('Invalid phone') || msg.includes('phone')) {
+    return 'Please enter a valid phone number with country code (e.g., +1 555 000 0000).';
+  }
+  if (msg.includes('Token has expired') || msg.includes('otp_expired')) {
+    return 'Code expired. Please request a new one.';
+  }
+  if (msg.includes('Invalid otp') || msg.includes('invalid token') || msg.includes('Token is invalid')) {
+    return 'Incorrect code. Please try again.';
+  }
+
+  // Rate limiting (generic)
+  if (msg.includes('rate limit')) {
+    return 'Too many attempts. Please wait a moment and try again.';
+  }
+
+  return msg;
+}
+
 export function AuthModal({ isOpen, onClose, defaultIsSignUp = false }: AuthModalProps) {
+  // Shared state
+  const [authMethod, setAuthMethod] = useState<AuthMethod>('phone');
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Email/password state
   const [isSignUp, setIsSignUp] = useState(defaultIsSignUp);
   const [isForgotPassword, setIsForgotPassword] = useState(false);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
-  const [message, setMessage] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-  const { signIn, signUp } = useAuth();
+  const [showPassword, setShowPassword] = useState(false);
+  const [signUpSuccess, setSignUpSuccess] = useState(false);
 
-  // Reset state when modal opens or defaultIsSignUp changes
-  React.useEffect(() => {
+  // Phone OTP state
+  const [phone, setPhone] = useState('');
+  const [otpStep, setOtpStep] = useState<OtpStep>('phone_entry');
+  const [resendCooldown, setResendCooldown] = useState(0);
+  const cooldownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const { signIn, signUp, signInWithPhone, verifyPhoneOtp } = useAuth();
+
+  // Clean up cooldown interval
+  useEffect(() => {
+    return () => {
+      if (cooldownRef.current) clearInterval(cooldownRef.current);
+    };
+  }, []);
+
+  // Reset all state when modal opens
+  useEffect(() => {
     if (isOpen) {
+      setAuthMethod('phone');
+      setError('');
+      setMessage('');
+      setIsLoading(false);
       setIsSignUp(defaultIsSignUp);
       setIsForgotPassword(false);
       setEmail('');
       setPassword('');
-      setError('');
-      setMessage('');
-      setIsLoading(false);
+      setShowPassword(false);
+      setSignUpSuccess(false);
+      setPhone('');
+      setOtpStep('phone_entry');
+      setResendCooldown(0);
+      if (cooldownRef.current) {
+        clearInterval(cooldownRef.current);
+        cooldownRef.current = null;
+      }
     }
   }, [isOpen, defaultIsSignUp]);
 
+  const startCooldown = useCallback(() => {
+    setResendCooldown(RESEND_COOLDOWN_SECONDS);
+    if (cooldownRef.current) clearInterval(cooldownRef.current);
+    cooldownRef.current = setInterval(() => {
+      setResendCooldown(prev => {
+        if (prev <= 1) {
+          if (cooldownRef.current) clearInterval(cooldownRef.current);
+          cooldownRef.current = null;
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  }, []);
+
+  const switchAuthMethod = (method: AuthMethod) => {
+    setAuthMethod(method);
+    setError('');
+    setMessage('');
+    setEmail('');
+    setPassword('');
+    setShowPassword(false);
+    setSignUpSuccess(false);
+    setPhone('');
+    setOtpStep('phone_entry');
+    setResendCooldown(0);
+    if (cooldownRef.current) {
+      clearInterval(cooldownRef.current);
+      cooldownRef.current = null;
+    }
+  };
+
   // Check if Supabase is configured
   const isSupabaseConfigured = Boolean(
-    import.meta.env.VITE_SUPABASE_URL && 
+    import.meta.env.VITE_SUPABASE_URL &&
     import.meta.env.VITE_SUPABASE_ANON_KEY
   );
 
@@ -42,18 +160,80 @@ export function AuthModal({ isOpen, onClose, defaultIsSignUp = false }: AuthModa
     return (
       <Modal isOpen={isOpen} onClose={onClose} title="Connect to Supabase">
         <div className="space-y-4 text-gray-300">
-          <p>
-            To enable authentication and data persistence, you need to connect your Supabase project.
-          </p>
-          <p>
-            Click the "Connect to Supabase" button in the top right corner to get started.
-          </p>
+          <p>To enable authentication and data persistence, you need to connect your Supabase project.</p>
+          <p>Click the "Connect to Supabase" button in the top right corner to get started.</p>
         </div>
       </Modal>
     );
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  // --- Phone OTP handlers ---
+
+  const handleSendOtp = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setMessage('');
+    setIsLoading(true);
+
+    // Basic client-side phone validation
+    const cleaned = phone.replace(/[\s()-]/g, '');
+    if (!cleaned.startsWith('+') || cleaned.replace(/\D/g, '').length < 10) {
+      setError('Please enter a valid phone number with country code (e.g., +1 555 000 0000).');
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      await signInWithPhone(cleaned);
+      setOtpStep('otp_verify');
+      startCooldown();
+    } catch (err) {
+      console.error('Phone auth error:', err);
+      setError(mapErrorMessage(err));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleVerifyOtp = async (code: string) => {
+    setError('');
+    setIsLoading(true);
+
+    const cleaned = phone.replace(/[\s()-]/g, '');
+
+    try {
+      await verifyPhoneOtp(cleaned, code);
+      onClose();
+    } catch (err) {
+      console.error('OTP verification error:', err);
+      setError(mapErrorMessage(err));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleResendOtp = async () => {
+    if (resendCooldown > 0) return;
+    setError('');
+    setIsLoading(true);
+
+    const cleaned = phone.replace(/[\s()-]/g, '');
+
+    try {
+      await signInWithPhone(cleaned);
+      setMessage('A new code has been sent.');
+      startCooldown();
+    } catch (err) {
+      console.error('Resend OTP error:', err);
+      setError(mapErrorMessage(err));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // --- Email handlers ---
+
+  const handleEmailSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
     setMessage('');
@@ -64,39 +244,27 @@ export function AuthModal({ isOpen, onClose, defaultIsSignUp = false }: AuthModa
         const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
           redirectTo: `${window.location.origin}/reset-password`
         });
-        
+
         if (resetError) {
           if (resetError.message.includes('rate limit')) {
             throw new Error('Too many reset attempts. Please try again later.');
           }
           throw resetError;
         }
-        
+
         setMessage('If an account exists with this email, you will receive password reset instructions.');
         setEmail('');
       } else if (isSignUp) {
         await signUp(email, password);
-        onClose();
+        setSignUpSuccess(true);
+        setMessage('Account created! Check your email to confirm your account.');
       } else {
         await signIn(email, password);
         onClose();
       }
     } catch (err) {
       console.error('Auth error:', err);
-      if (err instanceof Error) {
-        // Handle specific error cases
-        if (err.message.includes('Email not confirmed')) {
-          setError('Please check your email to confirm your account before signing in.');
-        } else if (err.message.includes('Invalid login credentials')) {
-          setError('Invalid email or password.');
-        } else if (err.message.includes('Email rate limit exceeded')) {
-          setError('Too many attempts. Please try again later.');
-        } else {
-          setError(err.message);
-        }
-      } else {
-        setError('An unexpected error occurred');
-      }
+      setError(mapErrorMessage(err));
     } finally {
       setIsLoading(false);
     }
@@ -107,114 +275,277 @@ export function AuthModal({ isOpen, onClose, defaultIsSignUp = false }: AuthModa
     setError('');
     setMessage('');
     setPassword('');
+    setSignUpSuccess(false);
   };
 
-  const handleBack = () => {
+  const handleBackToSignIn = () => {
     setIsForgotPassword(false);
+    setIsSignUp(false);
     setError('');
     setMessage('');
+    setSignUpSuccess(false);
   };
 
+  // --- Determine modal title ---
+
+  let title: string;
+  if (authMethod === 'phone') {
+    title = otpStep === 'otp_verify' ? 'Enter Verification Code' : 'Sign In with Phone';
+  } else if (isForgotPassword) {
+    title = 'Reset Password';
+  } else if (signUpSuccess) {
+    title = 'Check Your Email';
+  } else {
+    title = isSignUp ? 'Create Account' : 'Sign In';
+  }
+
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={onClose}
-      title={isForgotPassword ? 'Reset Password' : (isSignUp ? 'Create Account' : 'Sign In')}
-    >
-      <form onSubmit={handleSubmit} className="space-y-4">
+    <Modal isOpen={isOpen} onClose={onClose} title={title}>
+      <div className="space-y-4">
+        {/* Auth method tabs */}
+        <div className="flex border-b border-gray-700">
+          <button
+            type="button"
+            onClick={() => switchAuthMethod('phone')}
+            className={`flex-1 py-2 text-sm font-medium transition-colors ${
+              authMethod === 'phone'
+                ? 'text-blue-400 border-b-2 border-blue-400'
+                : 'text-gray-400 hover:text-gray-300'
+            }`}
+          >
+            Phone
+          </button>
+          <button
+            type="button"
+            onClick={() => switchAuthMethod('email')}
+            className={`flex-1 py-2 text-sm font-medium transition-colors ${
+              authMethod === 'email'
+                ? 'text-blue-400 border-b-2 border-blue-400'
+                : 'text-gray-400 hover:text-gray-300'
+            }`}
+          >
+            Email
+          </button>
+        </div>
+
+        {/* Error display */}
         {error && (
-          <div className="p-3 bg-red-900/30 border border-red-500 rounded text-red-500">
+          <div
+            className="p-3 bg-red-900/30 border border-red-500 rounded text-red-500"
+            role="alert"
+            aria-live="polite"
+          >
             {error}
           </div>
         )}
-        
+
+        {/* Success/info message display */}
         {message && (
-          <div className="p-3 bg-green-900/30 border border-green-500 rounded text-green-500">
+          <div
+            className="p-3 bg-green-900/30 border border-green-500 rounded text-green-500"
+            aria-live="polite"
+          >
             {message}
           </div>
         )}
-        
-        <div>
-          <label htmlFor="email" className="block text-sm font-medium text-gray-300 mb-1">
-            Email
-          </label>
-          <input
-            type="email"
-            id="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="w-full px-3 py-2 bg-gray-700 rounded-md text-white"
-            required
-            disabled={isLoading}
-          />
-        </div>
 
-        {!isForgotPassword && (
-          <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-1">
-              Password
-            </label>
-            <input
-              type="password"
-              id="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="w-full px-3 py-2 bg-gray-700 rounded-md text-white"
-              required
+        {/* ===== Phone OTP Flow ===== */}
+        {authMethod === 'phone' && otpStep === 'phone_entry' && (
+          <form onSubmit={handleSendOtp} className="space-y-4">
+            <div>
+              <label htmlFor="phone" className="block text-sm font-medium text-gray-300 mb-1">
+                Phone Number
+              </label>
+              <input
+                type="tel"
+                id="phone"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                className="w-full px-3 py-2 bg-gray-700 rounded-md text-white"
+                placeholder="+1 (555) 000-0000"
+                required
+                disabled={isLoading}
+              />
+              <p className="mt-1 text-xs text-gray-500">Include your country code (e.g., +1 for US)</p>
+            </div>
+
+            <button
+              type="submit"
               disabled={isLoading}
-              minLength={6}
-            />
+              className="w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:bg-blue-800 disabled:cursor-not-allowed"
+              aria-busy={isLoading}
+            >
+              {isLoading ? <><Spinner /> Sending Code...</> : 'Send Code'}
+            </button>
+          </form>
+        )}
+
+        {authMethod === 'phone' && otpStep === 'otp_verify' && (
+          <div className="space-y-4">
+            <p className="text-sm text-gray-400 text-center">
+              We sent a 6-digit code to <span className="text-white font-medium">{phone}</span>
+            </p>
+
+            <OtpInput onComplete={handleVerifyOtp} disabled={isLoading} />
+
+            {isLoading && (
+              <div className="flex items-center justify-center text-sm text-gray-400">
+                <Spinner /> Verifying...
+              </div>
+            )}
+
+            <div className="flex flex-col items-center gap-2 pt-2">
+              <div className="text-sm">
+                {resendCooldown > 0 ? (
+                  <span className="text-gray-500">Resend code in {resendCooldown}s</span>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={handleResendOtp}
+                    disabled={isLoading}
+                    className="text-blue-400 hover:text-blue-300 disabled:opacity-50"
+                  >
+                    Resend code
+                  </button>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  setOtpStep('phone_entry');
+                  setError('');
+                  setMessage('');
+                }}
+                className="text-sm text-gray-400 hover:text-gray-300"
+                disabled={isLoading}
+              >
+                Use a different phone number
+              </button>
+            </div>
           </div>
         )}
 
-        <div className="flex justify-between items-center pt-4">
-          <div className="space-x-4">
-            {isForgotPassword ? (
-              <button
-                type="button"
-                onClick={handleBack}
-                className="text-blue-400 hover:text-blue-300"
+        {/* ===== Email Flow ===== */}
+        {authMethod === 'email' && !signUpSuccess && (
+          <form onSubmit={handleEmailSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-300 mb-1">
+                Email
+              </label>
+              <input
+                type="email"
+                id="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full px-3 py-2 bg-gray-700 rounded-md text-white"
+                required
                 disabled={isLoading}
-              >
-                Back to Sign In
-              </button>
-            ) : (
-              <>
-                <button
-                  type="button"
-                  onClick={() => setIsSignUp(!isSignUp)}
-                  className="text-blue-400 hover:text-blue-300"
-                  disabled={isLoading}
-                >
-                  {isSignUp ? 'Already have an account?' : 'Need an account?'}
-                </button>
-                {!isSignUp && (
+              />
+            </div>
+
+            {!isForgotPassword && (
+              <div>
+                <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-1">
+                  Password
+                </label>
+                <div className="relative">
+                  <input
+                    type={showPassword ? 'text' : 'password'}
+                    id="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="w-full px-3 py-2 pr-10 bg-gray-700 rounded-md text-white"
+                    required
+                    disabled={isLoading}
+                    minLength={6}
+                  />
                   <button
                     type="button"
-                    onClick={handleForgotPassword}
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white transition-colors"
+                    aria-label={showPassword ? 'Hide password' : 'Show password'}
+                    tabIndex={-1}
+                  >
+                    {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                  </button>
+                </div>
+              </div>
+            )}
+
+            <div className="flex justify-between items-center pt-4">
+              <div className="space-x-4">
+                {isForgotPassword ? (
+                  <button
+                    type="button"
+                    onClick={handleBackToSignIn}
                     className="text-blue-400 hover:text-blue-300"
                     disabled={isLoading}
                   >
-                    Forgot Password?
+                    Back to Sign In
                   </button>
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setIsSignUp(!isSignUp);
+                        setError('');
+                        setMessage('');
+                      }}
+                      className="text-blue-400 hover:text-blue-300"
+                      disabled={isLoading}
+                    >
+                      {isSignUp ? 'Already have an account?' : 'Need an account?'}
+                    </button>
+                    {!isSignUp && (
+                      <button
+                        type="button"
+                        onClick={handleForgotPassword}
+                        className="text-blue-400 hover:text-blue-300"
+                        disabled={isLoading}
+                      >
+                        Forgot Password?
+                      </button>
+                    )}
+                  </>
                 )}
-              </>
-            )}
+              </div>
+
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:bg-blue-800 disabled:cursor-not-allowed"
+                aria-busy={isLoading}
+              >
+                {isLoading ? (
+                  <>
+                    <Spinner />
+                    {isForgotPassword ? 'Sending...' : (isSignUp ? 'Creating...' : 'Signing In...')}
+                  </>
+                ) : (
+                  isForgotPassword ? 'Reset Password' : (isSignUp ? 'Create Account' : 'Sign In')
+                )}
+              </button>
+            </div>
+          </form>
+        )}
+
+        {/* ===== Sign-up success state ===== */}
+        {authMethod === 'email' && signUpSuccess && (
+          <div className="space-y-4 text-center">
+            <p className="text-gray-300">
+              We've sent a confirmation link to <span className="text-white font-medium">{email}</span>. Please check your inbox and click the link to activate your account.
+            </p>
+            <button
+              type="button"
+              onClick={handleBackToSignIn}
+              className="text-blue-400 hover:text-blue-300"
+            >
+              Back to Sign In
+            </button>
           </div>
-          
-          <button
-            type="submit"
-            disabled={isLoading}
-            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:bg-blue-800 disabled:cursor-not-allowed"
-          >
-            {isLoading ? (
-              isForgotPassword ? 'Sending...' : (isSignUp ? 'Creating...' : 'Signing In...')
-            ) : (
-              isForgotPassword ? 'Reset Password' : (isSignUp ? 'Create Account' : 'Sign In')
-            )}
-          </button>
-        </div>
-      </form>
+        )}
+      </div>
     </Modal>
   );
 }

--- a/src/components/Auth/OtpInput.tsx
+++ b/src/components/Auth/OtpInput.tsx
@@ -1,0 +1,96 @@
+import React, { useRef, useEffect, KeyboardEvent, ClipboardEvent } from 'react';
+
+interface OtpInputProps {
+  length?: number;
+  onComplete: (code: string) => void;
+  disabled?: boolean;
+}
+
+export function OtpInput({ length = 6, onComplete, disabled = false }: OtpInputProps) {
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const valuesRef = useRef<string[]>(Array(length).fill(''));
+
+  useEffect(() => {
+    // Focus first input on mount
+    inputRefs.current[0]?.focus();
+  }, []);
+
+  const triggerComplete = (values: string[]) => {
+    const code = values.join('');
+    if (code.length === length) {
+      onComplete(code);
+    }
+  };
+
+  const handleChange = (index: number, value: string) => {
+    // Only allow single digit
+    const digit = value.replace(/\D/g, '').slice(-1);
+    valuesRef.current[index] = digit;
+
+    const input = inputRefs.current[index];
+    if (input) input.value = digit;
+
+    if (digit && index < length - 1) {
+      inputRefs.current[index + 1]?.focus();
+    }
+
+    triggerComplete(valuesRef.current);
+  };
+
+  const handleKeyDown = (index: number, e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Backspace') {
+      if (valuesRef.current[index]) {
+        valuesRef.current[index] = '';
+        const input = inputRefs.current[index];
+        if (input) input.value = '';
+      } else if (index > 0) {
+        valuesRef.current[index - 1] = '';
+        const prevInput = inputRefs.current[index - 1];
+        if (prevInput) {
+          prevInput.value = '';
+          prevInput.focus();
+        }
+      }
+      e.preventDefault();
+    }
+  };
+
+  const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    const pasted = e.clipboardData.getData('text').replace(/\D/g, '').slice(0, length);
+    if (!pasted) return;
+
+    const digits = pasted.split('');
+    digits.forEach((digit, i) => {
+      valuesRef.current[i] = digit;
+      const input = inputRefs.current[i];
+      if (input) input.value = digit;
+    });
+
+    // Focus the next empty input or the last one
+    const nextIndex = Math.min(digits.length, length - 1);
+    inputRefs.current[nextIndex]?.focus();
+
+    triggerComplete(valuesRef.current);
+  };
+
+  return (
+    <div className="flex gap-2 justify-center">
+      {Array.from({ length }, (_, i) => (
+        <input
+          key={i}
+          ref={(el) => { inputRefs.current[i] = el; }}
+          type="text"
+          inputMode="numeric"
+          maxLength={1}
+          disabled={disabled}
+          className="w-11 h-13 text-center text-xl font-mono bg-gray-700 border border-gray-600 rounded-md text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
+          onChange={(e) => handleChange(i, e.target.value)}
+          onKeyDown={(e) => handleKeyDown(i, e)}
+          onPaste={i === 0 ? handlePaste : undefined}
+          aria-label={`Digit ${i + 1} of ${length}`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -33,6 +33,7 @@ export function Modal({ isOpen, onClose, children, title, size = 'default' }: Mo
           <button
             onClick={onClose}
             className="text-gray-400 hover:text-white transition-colors"
+            aria-label="Close"
           >
             <X size={24} />
           </button>

--- a/src/components/SidePanel/ChangePasswordPanel.tsx
+++ b/src/components/SidePanel/ChangePasswordPanel.tsx
@@ -22,8 +22,10 @@ export function ChangePasswordPanel({ onBack }: ChangePasswordPanelProps) {
 
     try {
       // First verify the current password
+      const { data: { user } } = await supabase.auth.getUser();
+      const email = user?.email || '';
       const { error: signInError } = await supabase.auth.signInWithPassword({
-        email: supabase.auth.getUser().then(res => res.data.user?.email || ''),
+        email,
         password: currentPassword
       });
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -7,6 +7,8 @@ interface AuthContextType {
   signIn: (email: string, password: string) => Promise<void>;
   signUp: (email: string, password: string) => Promise<void>;
   signOut: () => Promise<void>;
+  signInWithPhone: (phone: string) => Promise<void>;
+  verifyPhoneOtp: (phone: string, token: string) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -64,6 +66,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
+  const signInWithPhone = async (phone: string) => {
+    const { error } = await supabase.auth.signInWithOtp({ phone });
+    if (error) throw error;
+  };
+
+  const verifyPhoneOtp = async (phone: string, token: string) => {
+    const { error } = await supabase.auth.verifyOtp({ phone, token, type: 'sms' });
+    if (error) throw error;
+  };
+
   const signOut = async () => {
     try {
       const { error } = await supabase.auth.signOut();
@@ -77,7 +89,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, signIn, signUp, signOut }}>
+    <AuthContext.Provider value={{ user, signIn, signUp, signOut, signInWithPhone, verifyPhoneOtp }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
- Add SMS OTP passwordless authentication as the primary sign-in method with phone/email tab toggle, 6-digit OTP input with auto-advance/paste support, resend with 60s cooldown timer, and comprehensive error handling
- Add network error detection to show friendly messages instead of raw "Failed to fetch" errors
- Add password visibility toggle (eye icon) on password fields
- Fix sign-up to show email confirmation feedback instead of closing modal
- Add accessibility attributes (aria-live, role="alert", aria-label, aria-busy)
- Add loading spinner SVG to submit buttons
- Expand AuthContext with signInWithPhone and verifyPhoneOtp methods
- Fix ChangePasswordPanel bug where email was passed as a Promise instead of a resolved string
- Add aria-label to Modal close button

https://claude.ai/code/session_01S4ycXMGrvHBbkpgcovJarr