### PR TITLE
Reorganize routing: make homepage the root path and editor the /editor path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,7 +84,7 @@ export function App() {
       }
       setDraftHydrated(true);
       if (routeState?.timelineId) {
-        routerNavigate('/', { replace: true, state: {} });
+        routerNavigate('/editor', { replace: true, state: {} });
       }
     }
   }, [user, draftHydrated]);
@@ -139,7 +139,7 @@ export function App() {
         switchTimeline(state.timelineId);
       }
       // Clear the state so refreshing doesn't re-trigger
-      routerNavigate('/', { replace: true, state: {} });
+      routerNavigate('/editor', { replace: true, state: {} });
     }
   }, [location.state, user]);
 

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom';
 import { App } from './App';
 import { Homepage } from './components/Homepage/Homepage';
 import { TimelineViewer } from './components/TimelineViewer/TimelineViewer';
@@ -6,15 +6,19 @@ import { TimelineViewer } from './components/TimelineViewer/TimelineViewer';
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <App />
+    element: <Homepage />
   },
   {
-    path: '/timelines',
-    element: <Homepage />
+    path: '/editor',
+    element: <App />
   },
   {
     path: '/view/:timelineId',
     element: <TimelineViewer />
+  },
+  {
+    path: '/timelines',
+    element: <Navigate to="/" replace />
   }
 ]);
 

--- a/src/components/Header/GlobalNav.tsx
+++ b/src/components/Header/GlobalNav.tsx
@@ -77,7 +77,7 @@ export function GlobalNav({
             <BreadcrumbList>
               <BreadcrumbItem>
                 <BreadcrumbLink asChild>
-                  <button onClick={() => navigate('/timelines')}>
+                  <button onClick={() => navigate('/')}>
                     Timelines
                   </button>
                 </BreadcrumbLink>

--- a/src/components/Homepage/Homepage.tsx
+++ b/src/components/Homepage/Homepage.tsx
@@ -35,11 +35,11 @@ export function Homepage() {
   const metadata = useTimelineMetadata(timelineIds);
 
   const handleTileClick = (timelineId: string) => {
-    navigate('/', { state: { timelineId } });
+    navigate('/editor', { state: { timelineId } });
   };
 
   const handleGetStarted = () => {
-    navigate('/', { state: { timelineId: 'new', skipCreationScreen: true } });
+    navigate('/editor', { state: { timelineId: 'new', skipCreationScreen: true } });
   };
 
   const handleAuthClick = (signUp: boolean) => {


### PR DESCRIPTION
## Summary
This PR reorganizes the application's routing structure to improve navigation hierarchy. The homepage is now the root path (`/`), while the timeline editor is accessible at `/editor`. A redirect has been added for the legacy `/timelines` path to maintain backward compatibility.

## Key Changes
- **Route restructuring**: Swapped the root path (`/`) and `/timelines` routes
  - `/` now displays the `Homepage` component (previously at `/timelines`)
  - `/editor` now displays the `App` component (previously at `/`)
  - Added a redirect from `/timelines` to `/` for backward compatibility

- **Navigation updates**: Updated all internal navigation calls to use the new routes
  - `Homepage.tsx`: Updated tile click and "Get Started" handlers to navigate to `/editor`
  - `App.tsx`: Updated post-hydration and state-based navigation to use `/editor`
  - `GlobalNav.tsx`: Updated breadcrumb navigation to use `/` instead of `/timelines`

## Implementation Details
- The redirect from `/timelines` to `/` uses React Router's `Navigate` component with the `replace` option to maintain clean browser history
- All state-based navigation (passing `timelineId` through route state) continues to work as before, just with updated destination paths
- The changes maintain the same component functionality while improving the URL structure and user-facing navigation

https://claude.ai/code/session_01BnDLcSmMX4WJ6SxTu7KZDX