### PR TITLE
Convert "Build with AI" card from div to button with navigation

### DIFF
--- a/src/components/Homepage/Homepage.tsx
+++ b/src/components/Homepage/Homepage.tsx
@@ -240,14 +240,15 @@ export function Homepage() {
                 </p>
               </button>
 
-              <div
+              <button
+                onClick={() => navigate('/editor', { state: { timelineId: 'new' } })}
                 className="flex-1 flex flex-col gap-1 bg-neutral-950 rounded-xl border border-neutral-800 p-4 text-left cursor-pointer hover:border-neutral-600 transition-colors"
               >
                 <h3 className="header-xsmall text-[#dadee5]">Build with AI</h3>
                 <p className="font-avenir text-sm leading-5 text-[#9b9ea3]">
                   Use AI as a jump start to build out a timeline of any well-known individual or event.
                 </p>
-              </div>
+              </button>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
Converted the "Build with AI" card from a non-semantic `<div>` element to a proper `<button>` element with click navigation functionality.

## Key Changes
- Changed the "Build with AI" card container from `<div>` to `<button>` for better semantic HTML and accessibility
- Added `onClick` handler that navigates to the editor with a new timeline (`/editor?state={timelineId: 'new'}`)
- Maintained all existing styling and visual appearance through the className attribute

## Implementation Details
- The button now properly handles navigation using the `navigate` function with state parameters
- This change improves accessibility by using a semantic button element instead of a div with cursor-pointer styling
- The navigation state passes `timelineId: 'new'` to indicate a fresh timeline creation in the editor

https://claude.ai/code/session_01PM7VUCXV3ydxZ48wkZbKVJ