### PR TITLE
Redesign EventTableEditor with drag-reorder categories and date picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,14 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.13",
@@ -23,6 +28,7 @@
         "date-fns": "^3.3.1",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
+        "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.22.0",
         "tailwind-merge": "^3.5.0",
@@ -360,6 +366,73 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1394,6 +1467,61 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -4330,6 +4458,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-day-picker": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
+      "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "date-fns": "^2.28.0 || ^3.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -5568,6 +5710,50 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "requires": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "requires": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "requires": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -6109,6 +6295,38 @@
           "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
           "requires": {
             "@radix-ui/react-slot": "1.2.4"
+          }
+        }
+      }
+    },
+    "@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "requires": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "dependencies": {
+        "@radix-ui/react-slot": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+          "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+          "requires": {
+            "@radix-ui/react-compose-refs": "1.1.2"
           }
         }
       }
@@ -8001,6 +8219,12 @@
       "requires": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "react-day-picker": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
+      "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
+      "requires": {}
     },
     "react-dom": {
       "version": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
@@ -25,6 +30,7 @@
     "date-fns": "^3.3.1",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
+    "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.0",
     "tailwind-merge": "^3.5.0",

--- a/src/components/EventTableEditor/EventTableEditor.tsx
+++ b/src/components/EventTableEditor/EventTableEditor.tsx
@@ -97,7 +97,7 @@ function SortableTab({
       style={style}
       onClick={onClick}
       className={`
-        group relative flex items-center justify-between w-full min-w-[146px] py-[9px] pl-[11px] pr-[3px] rounded-[10px]
+        group relative flex items-center justify-between w-full py-[9px] pl-[11px] pr-[3px] rounded-[10px]
         backdrop-blur-[12px] shadow-[0px_8px_32px_rgba(0,0,0,0.4)] text-left
         font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-all
         ${isActive
@@ -333,12 +333,12 @@ export function EventTableEditor({
           {/* Content Area: Sidebar + Table */}
           <div className="flex gap-6 mt-6" style={{ height: 'min(500px, calc(100vh - 280px))' }}>
             {/* Category Sidebar */}
-            <div className="w-[146px] shrink-0 bg-[#242526] rounded-[12px] p-2 flex flex-col gap-[2px] overflow-y-auto">
+            <div className="w-[162px] shrink-0 bg-[#242526] rounded-[12px] p-2 flex flex-col gap-[2px] overflow-y-auto">
               {/* All Categories tab (pinned, not draggable) */}
               <button
                 onClick={() => setActiveCategory(null)}
                 className={`
-                  w-full min-w-[146px] py-[9px] pl-[11px] pr-[3px] rounded-[10px]
+                  w-full py-[9px] pl-[11px] pr-[3px] rounded-[10px]
                   backdrop-blur-[12px] shadow-[0px_8px_32px_rgba(0,0,0,0.4)] text-left
                   font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-all
                   ${activeCategory === null

--- a/src/components/EventTableEditor/EventTableEditor.tsx
+++ b/src/components/EventTableEditor/EventTableEditor.tsx
@@ -377,12 +377,12 @@ export function EventTableEditor({
             <div className="flex-1 flex flex-col min-w-0">
               {/* Header Row */}
               <div
-                className="flex items-center px-4 pb-2 gap-[22px] border-b border-[rgba(210,210,210,0.2)]"
+                className="flex items-center pl-[16px] pr-[10px] pb-2 gap-[22px] border-b border-[rgba(210,210,210,0.2)]"
                 style={{ fontFamily: "'JetBrains Mono', monospace", fontWeight: 300, fontSize: '12px', lineHeight: '1.4', color: '#9b9ea3' }}
               >
-                <div className="w-[246px] shrink-0">Title <span className="text-destructive">*</span></div>
-                <div className="w-[96px] shrink-0">Start Date <span className="text-destructive">*</span></div>
-                <div className="w-[96px] shrink-0">End Date</div>
+                <div className="w-[240px] shrink-0">Title <span className="text-destructive">*</span></div>
+                <div className="w-[90px] shrink-0">Start Date <span className="text-destructive">*</span></div>
+                <div className="w-[90px] shrink-0">End Date</div>
                 <div className="flex-1">Category <span className="text-destructive">*</span></div>
                 <div className="w-[32px] shrink-0"></div>
               </div>

--- a/src/components/EventTableEditor/EventTableEditor.tsx
+++ b/src/components/EventTableEditor/EventTableEditor.tsx
@@ -334,11 +334,11 @@ export function EventTableEditor({
             <div className="relative flex items-center">
               {/* Glass pill indicator */}
               <div
-                className="absolute top-1/2 -translate-y-1/2 h-[44px] border border-[rgba(255,255,255,0.15)] rounded-[12px] shadow-[0px_8px_32px_rgba(0,0,0,0.4)] pointer-events-none transition-all duration-200"
+                className="absolute top-1/2 -translate-y-1/2 h-[44px] border border-[rgba(255,255,255,0.15)] rounded-[12px] shadow-[0px_8px_32px_rgba(0,0,0,0.4)] pointer-events-none"
                 style={{
-                  left: activePageTab === 'events' ? 0 : undefined,
-                  right: activePageTab === 'categories' ? 0 : undefined,
+                  left: activePageTab === 'events' ? '0px' : '99px',
                   width: activePageTab === 'events' ? '99px' : '139px',
+                  transition: 'left 320ms ease-out, width 320ms ease-out',
                 }}
               >
                 <div className="absolute inset-0 backdrop-blur-[12px] bg-[rgba(255,255,255,0.1)] rounded-[12px]" />

--- a/src/components/EventTableEditor/EventTableEditor.tsx
+++ b/src/components/EventTableEditor/EventTableEditor.tsx
@@ -98,8 +98,8 @@ function SortableTab({
       onClick={onClick}
       className={`
         group relative flex items-center justify-between w-full py-[9px] pl-[11px] pr-[3px] rounded-[10px]
-        backdrop-blur-[12px] text-left
-        font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-all
+        text-left
+        font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-colors
         ${isActive
           ? 'border border-transparent bg-[rgba(37,99,235,0.4)] text-[#dadee5]'
           : 'border border-transparent bg-transparent text-[#c9ced4] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
@@ -495,8 +495,8 @@ export function EventTableEditor({
                     onClick={() => setActiveCategory(null)}
                     className={`
                       w-full py-[9px] pl-[11px] pr-[3px] rounded-[10px]
-                      backdrop-blur-[12px] text-left
-                      font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-all
+                      text-left
+                      font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-colors
                       ${activeCategory === null
                         ? 'border border-transparent bg-[rgba(37,99,235,0.4)] text-[#dadee5]'
                         : 'border border-transparent bg-transparent text-[#c9ced4] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'

--- a/src/components/EventTableEditor/EventTableEditor.tsx
+++ b/src/components/EventTableEditor/EventTableEditor.tsx
@@ -259,16 +259,19 @@ export function EventTableEditor({
   const [activeCategory, setActiveCategory] = useState<string | null>(null)
   const [emptyRows, setEmptyRows] = useState<DraftEvent[]>([])
   const [draftEvents, setDraftEvents] = useState<TimelineEvent[]>(events)
+  const [draftCategories, setDraftCategories] = useState<CategoryConfig[]>(categories)
   const [hasChanges, setHasChanges] = useState(false)
   const MAX_EMPTY_ROWS = 10
 
   React.useEffect(() => {
     if (isOpen) {
       setDraftEvents(events)
+      setDraftCategories(categories)
       setEmptyRows([])
       setHasChanges(false)
+      setActivePageTab('events')
     }
-  }, [isOpen, events])
+  }, [isOpen, events, categories])
 
   const displayEvents = useMemo(() => {
     const filteredEvents = activeCategory
@@ -288,8 +291,9 @@ export function EventTableEditor({
       const hasAnyField = Boolean(row.title.trim() || row.startDate || row.category)
       return hasAnyField ? isValidEvent(row) : true
     })
-    return allEventsValid && allEmptyRowsValid
-  }, [draftEvents, emptyRows, hasChanges])
+    const allCategoriesValid = draftCategories.every(c => c.label.trim())
+    return allEventsValid && allEmptyRowsValid && allCategoriesValid
+  }, [draftEvents, draftCategories, emptyRows, hasChanges])
 
   const handleDeleteEvent = (eventId: string) => {
     setDraftEvents(draftEvents.filter(event => event.id !== eventId))
@@ -335,6 +339,7 @@ export function EventTableEditor({
   const handleApplyChanges = () => {
     if (!canApplyChanges) return
     onEventsChange(draftEvents)
+    onCategoriesChange(draftCategories)
     onClose()
   }
 
@@ -351,10 +356,11 @@ export function EventTableEditor({
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event
     if (over && active.id !== over.id) {
-      const oldIndex = categories.findIndex(c => c.id === active.id)
-      const newIndex = categories.findIndex(c => c.id === over.id)
-      const reordered = arrayMove(categories, oldIndex, newIndex)
-      onCategoriesChange(reordered)
+      const oldIndex = draftCategories.findIndex(c => c.id === active.id)
+      const newIndex = draftCategories.findIndex(c => c.id === over.id)
+      const reordered = arrayMove(draftCategories, oldIndex, newIndex)
+      setDraftCategories(reordered)
+      setHasChanges(true)
     }
   }
 
@@ -362,8 +368,8 @@ export function EventTableEditor({
   const [editingLabels, setEditingLabels] = useState<Record<string, string>>({})
 
   useEffect(() => {
-    setEditingLabels(categories.reduce((acc, cat) => ({ ...acc, [cat.id]: cat.label }), {} as Record<string, string>))
-  }, [categories])
+    setEditingLabels(draftCategories.reduce((acc, cat) => ({ ...acc, [cat.id]: cat.label }), {} as Record<string, string>))
+  }, [draftCategories])
 
   const handleCategoryLabelChange = useCallback((catId: string, value: string) => {
     setEditingLabels(prev => ({ ...prev, [catId]: value }))
@@ -372,49 +378,54 @@ export function EventTableEditor({
   const handleCategoryLabelBlur = useCallback((catId: string) => {
     const trimmed = (editingLabels[catId] || '').trim()
     if (!trimmed) {
-      const cat = categories.find(c => c.id === catId)
+      const cat = draftCategories.find(c => c.id === catId)
       if (cat) setEditingLabels(prev => ({ ...prev, [catId]: cat.label }))
       return
     }
-    const isDuplicate = categories.some(c => c.id !== catId && c.label.toLowerCase() === trimmed.toLowerCase())
+    const isDuplicate = draftCategories.some(c => c.id !== catId && c.label.toLowerCase() === trimmed.toLowerCase())
     if (isDuplicate) {
-      const cat = categories.find(c => c.id === catId)
+      const cat = draftCategories.find(c => c.id === catId)
       if (cat) setEditingLabels(prev => ({ ...prev, [catId]: cat.label }))
       return
     }
-    onCategoriesChange(categories.map(c => c.id === catId ? { ...c, label: trimmed } : c))
-  }, [categories, editingLabels, onCategoriesChange])
+    setDraftCategories(draftCategories.map(c => c.id === catId ? { ...c, label: trimmed } : c))
+    setHasChanges(true)
+  }, [draftCategories, editingLabels])
 
   const handleCategoryColorChange = useCallback((catId: string, color: string) => {
-    onCategoriesChange(categories.map(c => c.id === catId ? { ...c, color } : c))
-  }, [categories, onCategoriesChange])
+    setDraftCategories(draftCategories.map(c => c.id === catId ? { ...c, color } : c))
+    setHasChanges(true)
+  }, [draftCategories])
 
   const handleCategoryVisibilityToggle = useCallback((catId: string) => {
-    onCategoriesChange(categories.map(c => c.id === catId ? { ...c, visible: !c.visible } : c))
-  }, [categories, onCategoriesChange])
+    setDraftCategories(draftCategories.map(c => c.id === catId ? { ...c, visible: !c.visible } : c))
+    setHasChanges(true)
+  }, [draftCategories])
 
   const handleCategoryDelete = useCallback((catId: string) => {
-    if (categories.length <= 1) return
-    onCategoriesChange(categories.filter(c => c.id !== catId))
-  }, [categories, onCategoriesChange])
+    if (draftCategories.length <= 1) return
+    setDraftCategories(draftCategories.filter(c => c.id !== catId))
+    setHasChanges(true)
+  }, [draftCategories])
 
   const handleAddCategory = useCallback(() => {
-    if (categories.length >= 4) return
+    if (draftCategories.length >= 4) return
     let uniqueName = 'New Category'
     let counter = 1
-    while (categories.some(c => c.label.toLowerCase() === uniqueName.toLowerCase())) {
+    while (draftCategories.some(c => c.label.toLowerCase() === uniqueName.toLowerCase())) {
       uniqueName = `New Category ${counter}`
       counter++
     }
     const newCat: CategoryConfig = {
       id: uniqueName.toLowerCase().replace(/\s+/g, '_') as CategoryConfig['id'],
       label: uniqueName,
-      color: COLOR_PALETTE[categories.length % COLOR_PALETTE.length].value,
+      color: COLOR_PALETTE[draftCategories.length % COLOR_PALETTE.length].value,
       visible: true,
     }
-    onCategoriesChange([...categories, newCat])
+    setDraftCategories([...draftCategories, newCat])
     setEditingLabels(prev => ({ ...prev, [newCat.id]: newCat.label }))
-  }, [categories, onCategoriesChange])
+    setHasChanges(true)
+  }, [draftCategories])
 
   const isEmptyRow = (id: string) => emptyRows.some(row => row.id === id)
 
@@ -503,10 +514,10 @@ export function EventTableEditor({
                     modifiers={[restrictToVerticalAxis, restrictToParentElement]}
                   >
                     <SortableContext
-                      items={categories.map(c => c.id)}
+                      items={draftCategories.map(c => c.id)}
                       strategy={verticalListSortingStrategy}
                     >
-                      {categories.map(cat => (
+                      {draftCategories.map(cat => (
                         <SortableTab
                           key={cat.id}
                           category={cat}
@@ -612,7 +623,7 @@ export function EventTableEditor({
                                 <SelectValue placeholder="Select category" />
                               </SelectTrigger>
                               <SelectContent className="bg-[#242526] border border-[rgba(210,210,210,0.2)] rounded-lg">
-                                {categories.map(cat => (
+                                {draftCategories.map(cat => (
                                   <SelectItem
                                     key={cat.id}
                                     value={cat.id}
@@ -661,7 +672,7 @@ export function EventTableEditor({
 
                 {/* Scrollable category rows */}
                 <div className="flex-1 overflow-y-auto pt-1 pb-5 space-y-2">
-                  {categories.map(cat => (
+                  {draftCategories.map(cat => (
                     <div
                       key={cat.id}
                       className={`flex items-center rounded-[4px] pt-[6px] pb-[5px] ${cat.visible ? 'bg-[#242526]' : 'bg-[#151617]'}`}
@@ -701,7 +712,7 @@ export function EventTableEditor({
                           </button>
                           <button
                             onClick={() => handleCategoryDelete(cat.id)}
-                            disabled={categories.length <= 1}
+                            disabled={draftCategories.length <= 1}
                             className={`${glassButtonClass} disabled:opacity-50 disabled:pointer-events-none`}
                           >
                             Delete
@@ -732,7 +743,7 @@ export function EventTableEditor({
             ) : (
               <button
                 onClick={handleAddCategory}
-                disabled={categories.length >= 4}
+                disabled={draftCategories.length >= 4}
                 className={`${glassButtonClass} disabled:opacity-50 disabled:pointer-events-none`}
               >
                 Add Category

--- a/src/components/EventTableEditor/EventTableEditor.tsx
+++ b/src/components/EventTableEditor/EventTableEditor.tsx
@@ -204,6 +204,7 @@ export function EventTableEditor({
   categories,
   onCategoriesChange,
 }: EventTableEditorProps) {
+  const [activePageTab, setActivePageTab] = useState<'events' | 'categories'>('events')
   const [activeCategory, setActiveCategory] = useState<string | null>(null)
   const [emptyRows, setEmptyRows] = useState<DraftEvent[]>([])
   const [draftEvents, setDraftEvents] = useState<TimelineEvent[]>(events)
@@ -325,13 +326,45 @@ export function EventTableEditor({
         <DialogPrimitive.Content
           className="fixed left-[50%] top-[50%] z-50 w-full max-w-[960px] translate-x-[-50%] translate-y-[-50%] bg-[#171717] border border-[rgba(210,210,210,0.2)] rounded-[20px] p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]"
         >
-          {/* Title */}
-          <DialogPrimitive.Title className="text-center font-['Aleo',serif] font-normal text-[24px] leading-[1.4] text-[#c9ced4]">
-            Events
-          </DialogPrimitive.Title>
+          {/* Accessible title (sr-only) */}
+          <DialogPrimitive.Title className="sr-only">Events</DialogPrimitive.Title>
+
+          {/* Page Tabs */}
+          <div className="flex items-center justify-center h-[48px]">
+            <div className="relative flex items-center">
+              {/* Glass pill indicator */}
+              <div
+                className="absolute top-1/2 -translate-y-1/2 h-[44px] border border-[rgba(255,255,255,0.15)] rounded-[12px] shadow-[0px_8px_32px_rgba(0,0,0,0.4)] pointer-events-none transition-all duration-200"
+                style={{
+                  left: activePageTab === 'events' ? 0 : undefined,
+                  right: activePageTab === 'categories' ? 0 : undefined,
+                  width: activePageTab === 'events' ? '99px' : '139px',
+                }}
+              >
+                <div className="absolute inset-0 backdrop-blur-[12px] bg-[rgba(255,255,255,0.1)] rounded-[12px]" />
+                <div className="absolute inset-0 rounded-[inherit] shadow-[inset_0px_1px_0px_rgba(255,255,255,0.1)]" />
+              </div>
+              <button
+                onClick={() => setActivePageTab('events')}
+                className="relative flex items-start h-[44px] px-[12px] py-[5px] rounded-[4px]"
+              >
+                <span className={`font-['Aleo',serif] font-normal text-[24px] leading-[1.4] whitespace-nowrap transition-colors ${activePageTab === 'events' ? 'text-[#dadee5]' : 'text-[#9b9ea3]'}`}>
+                  Events
+                </span>
+              </button>
+              <button
+                onClick={() => setActivePageTab('categories')}
+                className="relative flex items-start h-[44px] px-[12px] py-[5px] rounded-[4px] cursor-pointer"
+              >
+                <span className={`font-['Aleo',serif] font-normal text-[24px] leading-[1.4] whitespace-nowrap transition-colors ${activePageTab === 'categories' ? 'text-[#dadee5]' : 'text-[#9b9ea3]'}`}>
+                  Categories
+                </span>
+              </button>
+            </div>
+          </div>
 
           {/* Content Area: Sidebar + Table */}
-          <div className="flex gap-6 mt-6" style={{ height: 'min(500px, calc(100vh - 280px))' }}>
+          <div className="flex gap-[16px] mt-8" style={{ height: 'min(520px, calc(100vh - 280px))' }}>
             {/* Category Sidebar */}
             <div className="w-[162px] shrink-0 bg-[#242526] rounded-[12px] p-2 flex flex-col gap-[2px] overflow-y-auto">
               {/* All Categories tab (pinned, not draggable) */}
@@ -500,7 +533,7 @@ export function EventTableEditor({
           </div>
 
           {/* Footer */}
-          <div className="flex justify-between items-center mt-6">
+          <div className="flex justify-between items-center mt-8">
             {/* Add Event (left) */}
             <button
               onClick={handleAddRow}
@@ -544,7 +577,7 @@ export function EventTableEditor({
                   disabled:opacity-50 disabled:pointer-events-none
                 "
               >
-                Save Changes
+                Save
               </button>
             </div>
           </div>

--- a/src/components/EventTableEditor/EventTableEditor.tsx
+++ b/src/components/EventTableEditor/EventTableEditor.tsx
@@ -98,11 +98,11 @@ function SortableTab({
       onClick={onClick}
       className={`
         group relative flex items-center justify-between w-full py-[9px] pl-[11px] pr-[3px] rounded-[10px]
-        backdrop-blur-[12px] shadow-[0px_8px_32px_rgba(0,0,0,0.4)] text-left
+        backdrop-blur-[12px] text-left
         font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-all
         ${isActive
-          ? 'border border-transparent bg-[rgba(37,99,235,0.4)] text-[#dadee5] shadow-[0px_8px_32px_rgba(0,0,0,0.4)]'
-          : 'border border-transparent bg-transparent text-[#c9ced4] shadow-[0px_8px_32px_rgba(0,0,0,0.4)] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
+          ? 'border border-transparent bg-[rgba(37,99,235,0.4)] text-[#dadee5]'
+          : 'border border-transparent bg-transparent text-[#c9ced4] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
         }
         ${isDragging ? 'shadow-[0px_12px_40px_rgba(0,0,0,0.6)]' : ''}
       `}
@@ -339,11 +339,11 @@ export function EventTableEditor({
                 onClick={() => setActiveCategory(null)}
                 className={`
                   w-full py-[9px] pl-[11px] pr-[3px] rounded-[10px]
-                  backdrop-blur-[12px] shadow-[0px_8px_32px_rgba(0,0,0,0.4)] text-left
+                  backdrop-blur-[12px] text-left
                   font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-all
                   ${activeCategory === null
-                    ? 'border border-transparent bg-[rgba(37,99,235,0.4)] text-[#dadee5] shadow-[0px_8px_32px_rgba(0,0,0,0.4)]'
-                    : 'border border-transparent bg-transparent text-[#c9ced4] shadow-[0px_8px_32px_rgba(0,0,0,0.4)] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
+                    ? 'border border-transparent bg-[rgba(37,99,235,0.4)] text-[#dadee5]'
+                    : 'border border-transparent bg-transparent text-[#c9ced4] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
                   }
                 `}
               >

--- a/src/components/EventTableEditor/EventTableEditor.tsx
+++ b/src/components/EventTableEditor/EventTableEditor.tsx
@@ -1,34 +1,199 @@
-import React, { useState, useMemo } from 'react';
-import { TimelineEvent, CategoryConfig } from '../../types/event';
-import { Trash2, Plus } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import React, { useState, useMemo } from 'react'
+import { TimelineEvent, CategoryConfig } from '../../types/event'
+import { Trash2, GripVertical } from 'lucide-react'
+import { format } from 'date-fns'
 import {
   Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  DialogOverlay,
+  DialogPortal,
+} from '@/components/ui/dialog'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Calendar } from '@/components/ui/calendar'
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import type { DragEndEvent } from '@dnd-kit/core'
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { restrictToVerticalAxis, restrictToParentElement } from '@dnd-kit/modifiers'
 
 interface EventTableEditorProps {
-  isOpen: boolean;
-  onClose: () => void;
-  events: TimelineEvent[];
-  onEventsChange: (events: TimelineEvent[]) => void;
-  categories: CategoryConfig[];
+  isOpen: boolean
+  onClose: () => void
+  events: TimelineEvent[]
+  onEventsChange: (events: TimelineEvent[]) => void
+  categories: CategoryConfig[]
+  onCategoriesChange: (categories: CategoryConfig[]) => void
 }
 
 interface DraftEvent extends Omit<TimelineEvent, 'id'> {
-  id: string;
+  id: string
+}
+
+// Date conversion helpers
+const parseDate = (dateStr: string): Date | undefined => {
+  if (!dateStr) return undefined
+  return new Date(dateStr + 'T00:00:00')
+}
+
+const formatDateToString = (date: Date): string => {
+  return format(date, 'yyyy-MM-dd')
+}
+
+const formatDateDisplay = (dateStr: string): string => {
+  if (!dateStr) return ''
+  const date = parseDate(dateStr)
+  if (!date) return ''
+  return format(date, 'MM/dd/yyyy')
+}
+
+// Sortable Tab component
+function SortableTab({
+  category,
+  isActive,
+  onClick,
+}: {
+  category: CategoryConfig
+  isActive: boolean
+  onClick: () => void
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: category.id })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    ...(isDragging ? { scale: '1.02', zIndex: 10 } : {}),
+  }
+
+  return (
+    <button
+      ref={setNodeRef}
+      style={style}
+      onClick={onClick}
+      className={`
+        group relative flex items-center justify-between w-full min-w-[146px] py-[9px] pl-[11px] pr-[3px] rounded-[10px]
+        backdrop-blur-[12px] shadow-[0px_8px_32px_rgba(0,0,0,0.4)] text-left
+        font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-all
+        ${isActive
+          ? 'border border-transparent bg-[rgba(37,99,235,0.4)] text-[#dadee5] shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]'
+          : 'border border-transparent bg-transparent text-[#c9ced4] shadow-[inset_0px_1px_0px_rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
+        }
+        ${isDragging ? 'shadow-[0px_12px_40px_rgba(0,0,0,0.6)]' : ''}
+      `}
+      {...attributes}
+    >
+      <span className="truncate">{category.label}</span>
+      <span
+        {...listeners}
+        className={`
+          flex items-center justify-center w-[18px] h-[18px] cursor-grab active:cursor-grabbing
+          opacity-0 group-hover:opacity-100 transition-opacity
+          ${isDragging ? 'opacity-100' : ''}
+        `}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <GripVertical size={18} className="text-[#9b9ea3]" />
+      </span>
+    </button>
+  )
+}
+
+// Date Picker Cell component
+function DatePickerCell({
+  value,
+  onChange,
+  placeholder,
+  disabledBefore,
+  isEmpty,
+  isFilled,
+}: {
+  value: string
+  onChange: (date: string) => void
+  placeholder: string
+  disabledBefore?: Date
+  isEmpty: boolean
+  isFilled: boolean
+}) {
+  const [open, setOpen] = useState(false)
+
+  const handleSelect = (date: Date | undefined) => {
+    if (date) {
+      onChange(formatDateToString(date))
+      setOpen(false)
+    }
+  }
+
+  const cellBg = isEmpty && !isFilled
+    ? 'bg-[#151617]'
+    : 'bg-transparent hover:bg-[#151617]'
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          className={`
+            w-full text-left px-[6px] py-[5px] rounded-[4px] cursor-pointer
+            font-['Avenir',sans-serif] font-normal text-[14px] leading-[20px]
+            ${cellBg}
+            ${value ? 'text-[#c9ced4]' : 'text-[#6b6e73]'}
+            transition-colors
+          `}
+        >
+          {value ? formatDateDisplay(value) : placeholder}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-auto bg-[#242526] border border-[rgba(210,210,210,0.2)] rounded-lg shadow-md p-0"
+        align="start"
+      >
+        <Calendar
+          mode="single"
+          selected={parseDate(value)}
+          onSelect={handleSelect}
+          disabled={disabledBefore ? { before: disabledBefore } : undefined}
+          initialFocus
+          className="rounded-lg"
+          classNames={{
+            day_selected: "bg-[rgba(37,99,235,0.8)] text-white hover:bg-[rgba(37,99,235,0.9)] focus:bg-[rgba(37,99,235,0.9)]",
+            day_today: "ring-1 ring-[#9b9ea3] text-[#c9ced4]",
+            day: "h-8 w-8 p-0 font-normal text-[#c9ced4] hover:bg-[#151617] rounded-md inline-flex items-center justify-center aria-selected:opacity-100",
+            head_cell: "text-[#9b9ea3] w-8 font-normal text-[0.8rem]",
+            caption_label: "text-[#c9ced4] text-sm font-medium",
+            nav_button: "h-7 w-7 bg-transparent hover:bg-[#151617] rounded-md p-0 opacity-70 hover:opacity-100 inline-flex items-center justify-center border border-[rgba(210,210,210,0.2)]",
+            cell: "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-[rgba(37,99,235,0.2)] [&:has([aria-selected])]:rounded-md",
+            day_outside: "text-[#6b6e73] opacity-50 aria-selected:opacity-100",
+            day_disabled: "text-[#6b6e73] opacity-30",
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  )
 }
 
 export function EventTableEditor({
@@ -37,54 +202,55 @@ export function EventTableEditor({
   events,
   onEventsChange,
   categories,
+  onCategoriesChange,
 }: EventTableEditorProps) {
-  const [activeCategory, setActiveCategory] = useState<string | null>(null);
-  const [emptyRows, setEmptyRows] = useState<DraftEvent[]>([]);
-  const [draftEvents, setDraftEvents] = useState<TimelineEvent[]>(events);
-  const [hasChanges, setHasChanges] = useState(false);
-  const MAX_EMPTY_ROWS = 10;
+  const [activeCategory, setActiveCategory] = useState<string | null>(null)
+  const [emptyRows, setEmptyRows] = useState<DraftEvent[]>([])
+  const [draftEvents, setDraftEvents] = useState<TimelineEvent[]>(events)
+  const [hasChanges, setHasChanges] = useState(false)
+  const MAX_EMPTY_ROWS = 10
 
   React.useEffect(() => {
     if (isOpen) {
-      setDraftEvents(events);
-      setEmptyRows([]);
-      setHasChanges(false);
+      setDraftEvents(events)
+      setEmptyRows([])
+      setHasChanges(false)
     }
-  }, [isOpen, events]);
+  }, [isOpen, events])
 
   const displayEvents = useMemo(() => {
     const filteredEvents = activeCategory
       ? draftEvents.filter(event => event.category === activeCategory)
-      : draftEvents;
-    return [...filteredEvents, ...emptyRows];
-  }, [draftEvents, activeCategory, emptyRows]);
+      : draftEvents
+    return [...filteredEvents, ...emptyRows]
+  }, [draftEvents, activeCategory, emptyRows])
 
   const isValidEvent = (event: DraftEvent | TimelineEvent) => {
-    return Boolean(event.title.trim() && event.startDate && event.category);
-  };
+    return Boolean(event.title.trim() && event.startDate && event.category)
+  }
 
   const canApplyChanges = useMemo(() => {
-    if (!hasChanges) return false;
-    const allEventsValid = draftEvents.every(isValidEvent);
+    if (!hasChanges) return false
+    const allEventsValid = draftEvents.every(isValidEvent)
     const allEmptyRowsValid = emptyRows.every(row => {
-      const hasAnyField = Boolean(row.title.trim() || row.startDate || row.category);
-      return hasAnyField ? isValidEvent(row) : true;
-    });
-    return allEventsValid && allEmptyRowsValid;
-  }, [draftEvents, emptyRows, hasChanges]);
+      const hasAnyField = Boolean(row.title.trim() || row.startDate || row.category)
+      return hasAnyField ? isValidEvent(row) : true
+    })
+    return allEventsValid && allEmptyRowsValid
+  }, [draftEvents, emptyRows, hasChanges])
 
   const handleDeleteEvent = (eventId: string) => {
-    setDraftEvents(draftEvents.filter(event => event.id !== eventId));
-    setHasChanges(true);
-  };
+    setDraftEvents(draftEvents.filter(event => event.id !== eventId))
+    setHasChanges(true)
+  }
 
   const handleEventChange = (id: string, changes: Partial<TimelineEvent>) => {
-    const emptyRowIndex = emptyRows.findIndex(row => row.id === id);
+    const emptyRowIndex = emptyRows.findIndex(row => row.id === id)
     if (emptyRowIndex !== -1) {
-      const updatedEmptyRows = [...emptyRows];
-      updatedEmptyRows[emptyRowIndex] = { ...updatedEmptyRows[emptyRowIndex], ...changes };
-      setEmptyRows(updatedEmptyRows);
-      const updatedRow = updatedEmptyRows[emptyRowIndex];
+      const updatedEmptyRows = [...emptyRows]
+      updatedEmptyRows[emptyRowIndex] = { ...updatedEmptyRows[emptyRowIndex], ...changes }
+      setEmptyRows(updatedEmptyRows)
+      const updatedRow = updatedEmptyRows[emptyRowIndex]
       if (isValidEvent(updatedRow)) {
         const newEvent: TimelineEvent = {
           id: crypto.randomUUID(),
@@ -92,164 +258,298 @@ export function EventTableEditor({
           startDate: updatedRow.startDate,
           endDate: updatedRow.endDate || updatedRow.startDate,
           category: updatedRow.category,
-        };
-        setDraftEvents(prev => [...prev, newEvent]);
-        setEmptyRows(rows => rows.filter(row => row.id !== id));
+        }
+        setDraftEvents(prev => [...prev, newEvent])
+        setEmptyRows(rows => rows.filter(row => row.id !== id))
       }
     } else {
-      setDraftEvents(draftEvents.map(evt => evt.id === id ? { ...evt, ...changes } : evt));
+      setDraftEvents(draftEvents.map(evt => evt.id === id ? { ...evt, ...changes } : evt))
     }
-    setHasChanges(true);
-  };
+    setHasChanges(true)
+  }
 
   const handleAddRow = () => {
     if (emptyRows.length < MAX_EMPTY_ROWS) {
       setEmptyRows(rows => [...rows, {
         id: crypto.randomUUID(), title: '', startDate: '', endDate: '', category: ''
-      }]);
+      }])
     }
-  };
+  }
 
   const handleDeleteEmptyRow = (rowId: string) => {
-    setEmptyRows(rows => rows.filter(row => row.id !== rowId));
-  };
+    setEmptyRows(rows => rows.filter(row => row.id !== rowId))
+  }
 
   const handleApplyChanges = () => {
-    if (!canApplyChanges) return;
-    onEventsChange(draftEvents);
-    onClose();
-  };
+    if (!canApplyChanges) return
+    onEventsChange(draftEvents)
+    onClose()
+  }
+
+  // Drag-to-reorder sensors
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 5 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  )
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (over && active.id !== over.id) {
+      const oldIndex = categories.findIndex(c => c.id === active.id)
+      const newIndex = categories.findIndex(c => c.id === over.id)
+      const reordered = arrayMove(categories, oldIndex, newIndex)
+      onCategoriesChange(reordered)
+    }
+  }
+
+  const isEmptyRow = (id: string) => emptyRows.some(row => row.id === id)
+
+  const isFieldFilled = (event: DraftEvent | TimelineEvent, field: string) => {
+    switch (field) {
+      case 'title': return Boolean(event.title.trim())
+      case 'startDate': return Boolean(event.startDate)
+      case 'endDate': return Boolean(event.endDate)
+      case 'category': return Boolean(event.category)
+      default: return false
+    }
+  }
 
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
-      <DialogContent className="max-w-[960px] max-h-[95vh]">
-        <DialogHeader>
-          <DialogTitle>Edit Timeline</DialogTitle>
-        </DialogHeader>
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose() }}>
+      <DialogPortal>
+        <DialogOverlay />
+        <DialogPrimitive.Content
+          className="fixed left-[50%] top-[50%] z-50 w-full max-w-[960px] translate-x-[-50%] translate-y-[-50%] bg-[#171717] border border-[rgba(210,210,210,0.2)] rounded-[20px] p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]"
+        >
+          {/* Title */}
+          <DialogPrimitive.Title className="text-center font-['Aleo',serif] font-normal text-[24px] leading-[1.4] text-[#c9ced4]">
+            Events
+          </DialogPrimitive.Title>
 
-        <div className="flex flex-col h-[calc(100vh-200px)]">
-          <Tabs
-            value={activeCategory ?? "all"}
-            onValueChange={(value) => setActiveCategory(value === "all" ? null : value)}
-            className="mb-6"
-          >
-            <TabsList>
-              <TabsTrigger value="all">All</TabsTrigger>
-              {categories.map(cat => (
-                <TabsTrigger key={cat.id} value={cat.id}>
-                  {cat.label}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-          </Tabs>
+          {/* Content Area: Sidebar + Table */}
+          <div className="flex gap-6 mt-6" style={{ height: 'min(500px, calc(100vh - 280px))' }}>
+            {/* Category Sidebar */}
+            <div className="w-[146px] shrink-0 bg-[#242526] rounded-[12px] p-2 flex flex-col gap-[2px] overflow-y-auto">
+              {/* All Categories tab (pinned, not draggable) */}
+              <button
+                onClick={() => setActiveCategory(null)}
+                className={`
+                  w-full min-w-[146px] py-[9px] pl-[11px] pr-[3px] rounded-[10px]
+                  backdrop-blur-[12px] shadow-[0px_8px_32px_rgba(0,0,0,0.4)] text-left
+                  font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-all
+                  ${activeCategory === null
+                    ? 'border border-transparent bg-[rgba(37,99,235,0.4)] text-[#dadee5] shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]'
+                    : 'border border-transparent bg-transparent text-[#c9ced4] shadow-[inset_0px_1px_0px_rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
+                  }
+                `}
+              >
+                All Categories
+              </button>
 
-          <div className="flex-1 flex flex-col min-h-0 border rounded-lg">
-            <div className="rounded-t-lg bg-card">
-              <Table>
-                <TableHeader>
-                  <TableRow className="hover:bg-transparent">
-                    <TableHead style={{ width: 'calc(100% - 540px)' }}>
-                      Title <span className="text-destructive">*</span>
-                    </TableHead>
-                    <TableHead style={{ width: '180px' }}>
-                      Start Date <span className="text-destructive">*</span>
-                    </TableHead>
-                    <TableHead style={{ width: '180px' }}>End Date</TableHead>
-                    <TableHead style={{ width: '180px' }}>
-                      Category <span className="text-destructive">*</span>
-                    </TableHead>
-                    <TableHead className="w-[48px]"></TableHead>
-                  </TableRow>
-                </TableHeader>
-              </Table>
+              {/* Draggable category tabs */}
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+                modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+              >
+                <SortableContext
+                  items={categories.map(c => c.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  {categories.map(cat => (
+                    <SortableTab
+                      key={cat.id}
+                      category={cat}
+                      isActive={activeCategory === cat.id}
+                      onClick={() => setActiveCategory(cat.id)}
+                    />
+                  ))}
+                </SortableContext>
+              </DndContext>
             </div>
 
-            <div className="flex-1 overflow-y-auto min-h-0 bg-card/50">
-              <Table>
-                <TableBody>
-                  {displayEvents.map((event) => (
-                    <TableRow key={event.id}>
-                      <TableCell className="py-2 px-3" style={{ width: 'calc(100% - 540px)' }}>
-                        <Input
+            {/* Table Area */}
+            <div className="flex-1 flex flex-col min-w-0">
+              {/* Header Row */}
+              <div
+                className="flex items-center px-4 pb-2 gap-[22px] border-b border-[rgba(210,210,210,0.2)]"
+                style={{ fontFamily: "'JetBrains Mono', monospace", fontWeight: 300, fontSize: '12px', lineHeight: '1.4', color: '#9b9ea3' }}
+              >
+                <div className="w-[246px] shrink-0">Title <span className="text-destructive">*</span></div>
+                <div className="w-[96px] shrink-0">Start Date <span className="text-destructive">*</span></div>
+                <div className="w-[96px] shrink-0">End Date</div>
+                <div className="flex-1">Category <span className="text-destructive">*</span></div>
+                <div className="w-[32px] shrink-0"></div>
+              </div>
+
+              {/* Scrollable Event Rows */}
+              <div className="flex-1 overflow-y-auto py-1 pb-4 space-y-1">
+                {displayEvents.map((event) => {
+                  const empty = isEmptyRow(event.id)
+
+                  return (
+                    <div
+                      key={event.id}
+                      className="flex items-center bg-[#242526] rounded-[4px] py-[6px] px-[10px] gap-[22px]"
+                    >
+                      {/* Title */}
+                      <div className="w-[240px] shrink-0">
+                        <input
                           type="text"
                           value={event.title}
                           onChange={(e) => handleEventChange(event.id, { title: e.target.value })}
-                          className="bg-transparent border-0 shadow-none hover:bg-accent px-2 py-1 h-auto focus-visible:ring-1 focus-visible:ring-ring"
                           placeholder="Event title"
                           autoComplete="off"
+                          className={`
+                            w-full px-[6px] py-[5px] rounded-[4px] border-none outline-none
+                            font-['Avenir',sans-serif] font-normal text-[14px] leading-[20px]
+                            placeholder:text-[#6b6e73]
+                            ${empty && !isFieldFilled(event, 'title')
+                              ? 'bg-[#151617] text-[#c9ced4]'
+                              : 'bg-transparent text-[#c9ced4] hover:bg-[#151617]'
+                            }
+                            focus:bg-[#151617] transition-colors
+                          `}
                         />
-                      </TableCell>
-                      <TableCell className="py-2 px-3" style={{ width: '180px' }}>
-                        <Input
-                          type="date"
+                      </div>
+
+                      {/* Start Date */}
+                      <div className="w-[90px] shrink-0">
+                        <DatePickerCell
                           value={event.startDate}
-                          onChange={(e) => {
-                            const newDate = e.target.value;
+                          onChange={(date) => {
                             handleEventChange(event.id, {
-                              startDate: newDate,
-                              endDate: event.endDate && event.endDate < newDate ? newDate : event.endDate
-                            });
+                              startDate: date,
+                              endDate: event.endDate && event.endDate < date ? date : event.endDate,
+                            })
                           }}
-                          className="bg-transparent border-0 shadow-none hover:bg-accent px-2 py-1 h-auto [color-scheme:dark] focus-visible:ring-1 focus-visible:ring-ring"
+                          placeholder="Pick a date"
+                          isEmpty={empty}
+                          isFilled={isFieldFilled(event, 'startDate')}
                         />
-                      </TableCell>
-                      <TableCell className="py-2 px-3" style={{ width: '180px' }}>
-                        <Input
-                          type="date"
+                      </div>
+
+                      {/* End Date */}
+                      <div className="w-[90px] shrink-0">
+                        <DatePickerCell
                           value={event.endDate}
-                          onChange={(e) => handleEventChange(event.id, { endDate: e.target.value })}
-                          min={event.startDate}
-                          className="bg-transparent border-0 shadow-none hover:bg-accent px-2 py-1 h-auto [color-scheme:dark] focus-visible:ring-1 focus-visible:ring-ring"
+                          onChange={(date) => handleEventChange(event.id, { endDate: date })}
+                          placeholder="Pick a date"
+                          disabledBefore={parseDate(event.startDate)}
+                          isEmpty={empty}
+                          isFilled={isFieldFilled(event, 'endDate')}
                         />
-                      </TableCell>
-                      <TableCell className="py-2 px-3" style={{ width: '180px' }}>
-                        <select
-                          value={event.category}
-                          onChange={(e) => handleEventChange(event.id, { category: e.target.value })}
-                          className="w-full bg-transparent hover:bg-accent px-2 py-1 rounded focus:outline-none focus:ring-1 focus:ring-ring"
+                      </div>
+
+                      {/* Category */}
+                      <div className="flex-1 min-w-0">
+                        <Select
+                          value={event.category || undefined}
+                          onValueChange={(value) => handleEventChange(event.id, { category: value })}
                         >
-                          <option value="" disabled>Select a category</option>
-                          {categories.map(cat => (
-                            <option key={cat.id} value={cat.id}>{cat.label}</option>
-                          ))}
-                        </select>
-                      </TableCell>
-                      <TableCell className="py-2 px-3 w-[48px]">
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => emptyRows.find(row => row.id === event.id)
+                          <SelectTrigger
+                            className={`
+                              w-full h-auto border-none shadow-none px-[6px] py-[5px] rounded-[4px]
+                              font-['Avenir',sans-serif] font-normal text-[14px] leading-[20px]
+                              ${empty && !isFieldFilled(event, 'category')
+                                ? 'bg-[#151617] text-[#c9ced4]'
+                                : 'bg-transparent text-[#c9ced4] hover:bg-[#151617]'
+                              }
+                              focus:bg-[#151617] focus:ring-0 transition-colors
+                              [&>span]:text-[#6b6e73] [&>span[data-placeholder]]:text-[#6b6e73]
+                            `}
+                          >
+                            <SelectValue placeholder="Select category" />
+                          </SelectTrigger>
+                          <SelectContent className="bg-[#242526] border border-[rgba(210,210,210,0.2)] rounded-lg">
+                            {categories.map(cat => (
+                              <SelectItem
+                                key={cat.id}
+                                value={cat.id}
+                                className="text-[#c9ced4] font-['Avenir',sans-serif] text-[14px] hover:bg-[#151617] focus:bg-[#151617] focus:text-[#c9ced4]"
+                              >
+                                {cat.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+
+                      {/* Delete */}
+                      <div className="w-[32px] shrink-0 flex justify-center">
+                        <button
+                          onClick={() => empty
                             ? handleDeleteEmptyRow(event.id)
                             : handleDeleteEvent(event.id)
                           }
-                          className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                          className="p-1 text-[#9b9ea3] hover:text-[#dadee5] transition-colors rounded"
                         >
                           <Trash2 size={16} />
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+                        </button>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
             </div>
           </div>
 
-          <div className="mt-4 pb-2 flex justify-between items-center">
-            <Button
+          {/* Footer */}
+          <div className="flex justify-between items-center mt-6">
+            {/* Add Event (left) */}
+            <button
               onClick={handleAddRow}
               disabled={emptyRows.length >= MAX_EMPTY_ROWS}
-              className="gap-2"
+              className="
+                min-w-[80px] px-[11px] py-[6px] rounded-[10px]
+                backdrop-blur-[12px] bg-white/10 border border-white/[0.15]
+                shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
+                font-['Avenir',sans-serif] font-medium text-[14px] text-[#c9ced4]
+                hover:bg-white/20 hover:text-[#dadee5] transition-all
+                disabled:opacity-50 disabled:pointer-events-none
+              "
             >
-              <Plus size={20} />
-              Add Row
-            </Button>
+              Add Event
+            </button>
 
-            <Button onClick={handleApplyChanges} disabled={!canApplyChanges}>
-              Apply Changes
-            </Button>
+            {/* Cancel + Save Changes (right) */}
+            <div className="flex gap-[10px]">
+              <button
+                onClick={onClose}
+                className="
+                  min-w-[80px] px-[11px] py-[6px] rounded-[10px]
+                  backdrop-blur-[12px] bg-white/10 border border-white/[0.15]
+                  shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
+                  font-['Avenir',sans-serif] font-medium text-[14px] text-[#c9ced4]
+                  hover:bg-white/20 hover:text-[#dadee5] transition-all
+                "
+              >
+                Cancel
+              </button>
+
+              <button
+                onClick={handleApplyChanges}
+                disabled={!canApplyChanges}
+                className="
+                  min-w-[80px] px-[11px] py-[6px] rounded-[10px]
+                  backdrop-blur-[12px] bg-[rgba(37,99,235,0.8)] border border-white/[0.15]
+                  shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
+                  font-['Avenir',sans-serif] font-medium text-[14px] text-[#dadee5]
+                  hover:bg-[rgba(37,99,235,0.9)] transition-all
+                  disabled:opacity-50 disabled:pointer-events-none
+                "
+              >
+                Save Changes
+              </button>
+            </div>
           </div>
-        </div>
-      </DialogContent>
+        </DialogPrimitive.Content>
+      </DialogPortal>
     </Dialog>
-  );
+  )
 }

--- a/src/components/EventTableEditor/EventTableEditor.tsx
+++ b/src/components/EventTableEditor/EventTableEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useCallback, useEffect } from 'react'
 import { TimelineEvent, CategoryConfig } from '../../types/event'
 import { Trash2, GripVertical } from 'lucide-react'
 import { format } from 'date-fns'
@@ -196,6 +196,57 @@ function DatePickerCell({
   )
 }
 
+// Color palette for categories
+const COLOR_PALETTE = [
+  { label: 'Blue', value: '#4196E4' },
+  { label: 'Purple', value: '#A770EC' },
+  { label: 'Red', value: '#E10000' },
+  { label: 'Green', value: '#259E23' },
+  { label: 'Orange', value: '#FF7D05' },
+]
+
+// Color bar component for category color picker
+function ColorBar({
+  color,
+  isSelected,
+  onClick,
+}: {
+  color: string
+  isSelected: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="relative w-[30px] h-[75px] flex items-center justify-center cursor-pointer group"
+    >
+      <div
+        className={`
+          w-[27px] rounded-[4px] transition-all duration-200
+          ${isSelected
+            ? 'h-[75px] opacity-100'
+            : 'h-[50px] opacity-60 group-hover:h-[60px] group-hover:opacity-80'
+          }
+        `}
+        style={{
+          backgroundColor: color,
+          border: `1px solid ${color}`,
+          boxShadow: 'inset 0px 4px 20px rgba(0,0,0,0.25)',
+        }}
+      />
+    </button>
+  )
+}
+
+// Glass button used in category rows
+const glassButtonClass = `
+  relative min-w-[80px] px-[11px] py-[6px] rounded-[10px]
+  backdrop-blur-[12px] bg-white/10 border border-white/[0.15]
+  shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
+  font-['Avenir',sans-serif] font-medium text-[14px] text-[#c9ced4]
+  hover:bg-white/20 hover:text-[#dadee5] transition-all
+`
+
 export function EventTableEditor({
   isOpen,
   onClose,
@@ -307,6 +358,64 @@ export function EventTableEditor({
     }
   }
 
+  // Category management state and handlers
+  const [editingLabels, setEditingLabels] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    setEditingLabels(categories.reduce((acc, cat) => ({ ...acc, [cat.id]: cat.label }), {} as Record<string, string>))
+  }, [categories])
+
+  const handleCategoryLabelChange = useCallback((catId: string, value: string) => {
+    setEditingLabels(prev => ({ ...prev, [catId]: value }))
+  }, [])
+
+  const handleCategoryLabelBlur = useCallback((catId: string) => {
+    const trimmed = (editingLabels[catId] || '').trim()
+    if (!trimmed) {
+      const cat = categories.find(c => c.id === catId)
+      if (cat) setEditingLabels(prev => ({ ...prev, [catId]: cat.label }))
+      return
+    }
+    const isDuplicate = categories.some(c => c.id !== catId && c.label.toLowerCase() === trimmed.toLowerCase())
+    if (isDuplicate) {
+      const cat = categories.find(c => c.id === catId)
+      if (cat) setEditingLabels(prev => ({ ...prev, [catId]: cat.label }))
+      return
+    }
+    onCategoriesChange(categories.map(c => c.id === catId ? { ...c, label: trimmed } : c))
+  }, [categories, editingLabels, onCategoriesChange])
+
+  const handleCategoryColorChange = useCallback((catId: string, color: string) => {
+    onCategoriesChange(categories.map(c => c.id === catId ? { ...c, color } : c))
+  }, [categories, onCategoriesChange])
+
+  const handleCategoryVisibilityToggle = useCallback((catId: string) => {
+    onCategoriesChange(categories.map(c => c.id === catId ? { ...c, visible: !c.visible } : c))
+  }, [categories, onCategoriesChange])
+
+  const handleCategoryDelete = useCallback((catId: string) => {
+    if (categories.length <= 1) return
+    onCategoriesChange(categories.filter(c => c.id !== catId))
+  }, [categories, onCategoriesChange])
+
+  const handleAddCategory = useCallback(() => {
+    if (categories.length >= 4) return
+    let uniqueName = 'New Category'
+    let counter = 1
+    while (categories.some(c => c.label.toLowerCase() === uniqueName.toLowerCase())) {
+      uniqueName = `New Category ${counter}`
+      counter++
+    }
+    const newCat: CategoryConfig = {
+      id: uniqueName.toLowerCase().replace(/\s+/g, '_') as CategoryConfig['id'],
+      label: uniqueName,
+      color: COLOR_PALETTE[categories.length % COLOR_PALETTE.length].value,
+      visible: true,
+    }
+    onCategoriesChange([...categories, newCat])
+    setEditingLabels(prev => ({ ...prev, [newCat.id]: newCat.label }))
+  }, [categories, onCategoriesChange])
+
   const isEmptyRow = (id: string) => emptyRows.some(row => row.id === id)
 
   const isFieldFilled = (event: DraftEvent | TimelineEvent, field: string) => {
@@ -363,205 +472,276 @@ export function EventTableEditor({
             </div>
           </div>
 
-          {/* Content Area: Sidebar + Table */}
-          <div className="flex gap-[16px] mt-8" style={{ height: 'min(520px, calc(100vh - 280px))' }}>
-            {/* Category Sidebar */}
-            <div className="w-[162px] shrink-0 bg-[#242526] rounded-[12px] p-2 flex flex-col gap-[2px] overflow-y-auto">
-              {/* All Categories tab (pinned, not draggable) */}
-              <button
-                onClick={() => setActiveCategory(null)}
-                className={`
-                  w-full py-[9px] pl-[11px] pr-[3px] rounded-[10px]
-                  backdrop-blur-[12px] text-left
-                  font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-all
-                  ${activeCategory === null
-                    ? 'border border-transparent bg-[rgba(37,99,235,0.4)] text-[#dadee5]'
-                    : 'border border-transparent bg-transparent text-[#c9ced4] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
-                  }
-                `}
-              >
-                All Categories
-              </button>
+          {/* Content Area */}
+          <div className="mt-8" style={{ height: 'min(520px, calc(100vh - 280px))' }}>
+            {activePageTab === 'events' ? (
+              /* Events Tab Content */
+              <div className="flex gap-[16px] h-full">
+                {/* Category Sidebar */}
+                <div className="w-[162px] shrink-0 bg-[#242526] rounded-[12px] p-2 flex flex-col gap-[2px] overflow-y-auto">
+                  {/* All Categories tab (pinned, not draggable) */}
+                  <button
+                    onClick={() => setActiveCategory(null)}
+                    className={`
+                      w-full py-[9px] pl-[11px] pr-[3px] rounded-[10px]
+                      backdrop-blur-[12px] text-left
+                      font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-all
+                      ${activeCategory === null
+                        ? 'border border-transparent bg-[rgba(37,99,235,0.4)] text-[#dadee5]'
+                        : 'border border-transparent bg-transparent text-[#c9ced4] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
+                      }
+                    `}
+                  >
+                    All Categories
+                  </button>
 
-              {/* Draggable category tabs */}
-              <DndContext
-                sensors={sensors}
-                collisionDetection={closestCenter}
-                onDragEnd={handleDragEnd}
-                modifiers={[restrictToVerticalAxis, restrictToParentElement]}
-              >
-                <SortableContext
-                  items={categories.map(c => c.id)}
-                  strategy={verticalListSortingStrategy}
-                >
-                  {categories.map(cat => (
-                    <SortableTab
-                      key={cat.id}
-                      category={cat}
-                      isActive={activeCategory === cat.id}
-                      onClick={() => setActiveCategory(cat.id)}
-                    />
-                  ))}
-                </SortableContext>
-              </DndContext>
-            </div>
-
-            {/* Table Area */}
-            <div className="flex-1 flex flex-col min-w-0">
-              {/* Header Row */}
-              <div
-                className="flex items-center pl-[16px] pr-[10px] pb-2 gap-[22px] border-b border-[rgba(210,210,210,0.2)]"
-                style={{ fontFamily: "'JetBrains Mono', monospace", fontWeight: 300, fontSize: '12px', lineHeight: '1.4', color: '#9b9ea3' }}
-              >
-                <div className="w-[240px] shrink-0">Title <span className="text-destructive">*</span></div>
-                <div className="w-[90px] shrink-0">Start Date <span className="text-destructive">*</span></div>
-                <div className="w-[90px] shrink-0">End Date</div>
-                <div className="flex-1">Category <span className="text-destructive">*</span></div>
-                <div className="w-[32px] shrink-0"></div>
-              </div>
-
-              {/* Scrollable Event Rows */}
-              <div className="flex-1 overflow-y-auto py-1 pb-4 space-y-1">
-                {displayEvents.map((event) => {
-                  const empty = isEmptyRow(event.id)
-
-                  return (
-                    <div
-                      key={event.id}
-                      className="flex items-center bg-[#242526] rounded-[4px] py-[6px] px-[10px] gap-[22px]"
+                  {/* Draggable category tabs */}
+                  <DndContext
+                    sensors={sensors}
+                    collisionDetection={closestCenter}
+                    onDragEnd={handleDragEnd}
+                    modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+                  >
+                    <SortableContext
+                      items={categories.map(c => c.id)}
+                      strategy={verticalListSortingStrategy}
                     >
-                      {/* Title */}
-                      <div className="w-[240px] shrink-0">
-                        <input
-                          type="text"
-                          value={event.title}
-                          onChange={(e) => handleEventChange(event.id, { title: e.target.value })}
-                          placeholder="Event title"
-                          autoComplete="off"
-                          className={`
-                            w-full px-[6px] py-[5px] rounded-[4px] border-none outline-none
-                            font-['Avenir',sans-serif] font-normal text-[14px] leading-[20px]
-                            placeholder:text-[#6b6e73]
-                            ${empty && !isFieldFilled(event, 'title')
-                              ? 'bg-[#151617] text-[#c9ced4]'
-                              : 'bg-transparent text-[#c9ced4] hover:bg-[#151617]'
-                            }
-                            focus:bg-[#151617] transition-colors
-                          `}
+                      {categories.map(cat => (
+                        <SortableTab
+                          key={cat.id}
+                          category={cat}
+                          isActive={activeCategory === cat.id}
+                          onClick={() => setActiveCategory(cat.id)}
                         />
-                      </div>
+                      ))}
+                    </SortableContext>
+                  </DndContext>
+                </div>
 
-                      {/* Start Date */}
-                      <div className="w-[90px] shrink-0">
-                        <DatePickerCell
-                          value={event.startDate}
-                          onChange={(date) => {
-                            handleEventChange(event.id, {
-                              startDate: date,
-                              endDate: event.endDate && event.endDate < date ? date : event.endDate,
-                            })
-                          }}
-                          placeholder="Pick a date"
-                          isEmpty={empty}
-                          isFilled={isFieldFilled(event, 'startDate')}
-                        />
-                      </div>
+                {/* Table Area */}
+                <div className="flex-1 flex flex-col min-w-0">
+                  {/* Header Row */}
+                  <div
+                    className="flex items-center pl-[16px] pr-[10px] pb-2 gap-[22px] border-b border-[rgba(210,210,210,0.2)]"
+                    style={{ fontFamily: "'JetBrains Mono', monospace", fontWeight: 300, fontSize: '12px', lineHeight: '1.4', color: '#9b9ea3' }}
+                  >
+                    <div className="w-[240px] shrink-0">Title <span className="text-destructive">*</span></div>
+                    <div className="w-[90px] shrink-0">Start Date <span className="text-destructive">*</span></div>
+                    <div className="w-[90px] shrink-0">End Date</div>
+                    <div className="flex-1">Category <span className="text-destructive">*</span></div>
+                    <div className="w-[32px] shrink-0"></div>
+                  </div>
 
-                      {/* End Date */}
-                      <div className="w-[90px] shrink-0">
-                        <DatePickerCell
-                          value={event.endDate}
-                          onChange={(date) => handleEventChange(event.id, { endDate: date })}
-                          placeholder="Pick a date"
-                          disabledBefore={parseDate(event.startDate)}
-                          isEmpty={empty}
-                          isFilled={isFieldFilled(event, 'endDate')}
-                        />
-                      </div>
+                  {/* Scrollable Event Rows */}
+                  <div className="flex-1 overflow-y-auto py-1 pb-4 space-y-1">
+                    {displayEvents.map((event) => {
+                      const empty = isEmptyRow(event.id)
 
-                      {/* Category */}
-                      <div className="flex-1 min-w-0">
-                        <Select
-                          value={event.category || undefined}
-                          onValueChange={(value) => handleEventChange(event.id, { category: value })}
+                      return (
+                        <div
+                          key={event.id}
+                          className="flex items-center bg-[#242526] rounded-[4px] py-[6px] px-[10px] gap-[22px]"
                         >
-                          <SelectTrigger
-                            className={`
-                              w-full h-auto border-none shadow-none px-[6px] py-[5px] rounded-[4px]
-                              font-['Avenir',sans-serif] font-normal text-[14px] leading-[20px]
-                              ${empty && !isFieldFilled(event, 'category')
-                                ? 'bg-[#151617] text-[#c9ced4]'
-                                : 'bg-transparent text-[#c9ced4] hover:bg-[#151617]'
-                              }
-                              focus:bg-[#151617] focus:ring-0 transition-colors
-                              [&>span]:text-[#6b6e73] [&>span[data-placeholder]]:text-[#6b6e73]
-                            `}
-                          >
-                            <SelectValue placeholder="Select category" />
-                          </SelectTrigger>
-                          <SelectContent className="bg-[#242526] border border-[rgba(210,210,210,0.2)] rounded-lg">
-                            {categories.map(cat => (
-                              <SelectItem
-                                key={cat.id}
-                                value={cat.id}
-                                className="text-[#c9ced4] font-['Avenir',sans-serif] text-[14px] hover:bg-[#151617] focus:bg-[#151617] focus:text-[#c9ced4]"
+                          {/* Title */}
+                          <div className="w-[240px] shrink-0">
+                            <input
+                              type="text"
+                              value={event.title}
+                              onChange={(e) => handleEventChange(event.id, { title: e.target.value })}
+                              placeholder="Event title"
+                              autoComplete="off"
+                              className={`
+                                w-full px-[6px] py-[5px] rounded-[4px] border-none outline-none
+                                font-['Avenir',sans-serif] font-normal text-[14px] leading-[20px]
+                                placeholder:text-[#6b6e73]
+                                ${empty && !isFieldFilled(event, 'title')
+                                  ? 'bg-[#151617] text-[#c9ced4]'
+                                  : 'bg-transparent text-[#c9ced4] hover:bg-[#151617]'
+                                }
+                                focus:bg-[#151617] transition-colors
+                              `}
+                            />
+                          </div>
+
+                          {/* Start Date */}
+                          <div className="w-[90px] shrink-0">
+                            <DatePickerCell
+                              value={event.startDate}
+                              onChange={(date) => {
+                                handleEventChange(event.id, {
+                                  startDate: date,
+                                  endDate: event.endDate && event.endDate < date ? date : event.endDate,
+                                })
+                              }}
+                              placeholder="Pick a date"
+                              isEmpty={empty}
+                              isFilled={isFieldFilled(event, 'startDate')}
+                            />
+                          </div>
+
+                          {/* End Date */}
+                          <div className="w-[90px] shrink-0">
+                            <DatePickerCell
+                              value={event.endDate}
+                              onChange={(date) => handleEventChange(event.id, { endDate: date })}
+                              placeholder="Pick a date"
+                              disabledBefore={parseDate(event.startDate)}
+                              isEmpty={empty}
+                              isFilled={isFieldFilled(event, 'endDate')}
+                            />
+                          </div>
+
+                          {/* Category */}
+                          <div className="flex-1 min-w-0">
+                            <Select
+                              value={event.category || undefined}
+                              onValueChange={(value) => handleEventChange(event.id, { category: value })}
+                            >
+                              <SelectTrigger
+                                className={`
+                                  w-full h-auto border-none shadow-none px-[6px] py-[5px] rounded-[4px]
+                                  font-['Avenir',sans-serif] font-normal text-[14px] leading-[20px]
+                                  ${empty && !isFieldFilled(event, 'category')
+                                    ? 'bg-[#151617] text-[#c9ced4]'
+                                    : 'bg-transparent text-[#c9ced4] hover:bg-[#151617]'
+                                  }
+                                  focus:bg-[#151617] focus:ring-0 transition-colors
+                                  [&>span]:text-[#6b6e73] [&>span[data-placeholder]]:text-[#6b6e73]
+                                `}
                               >
-                                {cat.label}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
+                                <SelectValue placeholder="Select category" />
+                              </SelectTrigger>
+                              <SelectContent className="bg-[#242526] border border-[rgba(210,210,210,0.2)] rounded-lg">
+                                {categories.map(cat => (
+                                  <SelectItem
+                                    key={cat.id}
+                                    value={cat.id}
+                                    className="text-[#c9ced4] font-['Avenir',sans-serif] text-[14px] hover:bg-[#151617] focus:bg-[#151617] focus:text-[#c9ced4]"
+                                  >
+                                    {cat.label}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </div>
 
-                      {/* Delete */}
-                      <div className="w-[32px] shrink-0 flex justify-center">
-                        <button
-                          onClick={() => empty
-                            ? handleDeleteEmptyRow(event.id)
-                            : handleDeleteEvent(event.id)
-                          }
-                          className="p-1 text-[#9b9ea3] hover:text-[#dadee5] transition-colors rounded"
-                        >
-                          <Trash2 size={16} />
-                        </button>
+                          {/* Delete */}
+                          <div className="w-[32px] shrink-0 flex justify-center">
+                            <button
+                              onClick={() => empty
+                                ? handleDeleteEmptyRow(event.id)
+                                : handleDeleteEvent(event.id)
+                              }
+                              className="p-1 text-[#9b9ea3] hover:text-[#dadee5] transition-colors rounded"
+                            >
+                              <Trash2 size={16} />
+                            </button>
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
+              </div>
+            ) : (
+              /* Categories Tab Content */
+              <div className="flex flex-col h-full">
+                {/* Header */}
+                <div className="flex flex-col gap-[6px]">
+                  <div
+                    className="flex items-center gap-[24px] px-[16px]"
+                    style={{ fontFamily: "'JetBrains Mono', monospace", fontWeight: 300, fontSize: '12px', lineHeight: '1.4', color: '#9b9ea3' }}
+                  >
+                    <div className="w-[243px] shrink-0">Category Title</div>
+                    <div className="flex-1 text-center">Category Color</div>
+                    <div className="w-[176px] shrink-0 opacity-0">Category Color</div>
+                  </div>
+                  <div className="h-px w-full bg-[rgba(210,210,210,0.2)]" />
+                </div>
+
+                {/* Scrollable category rows */}
+                <div className="flex-1 overflow-y-auto pt-1 pb-5 space-y-2">
+                  {categories.map(cat => (
+                    <div
+                      key={cat.id}
+                      className={`flex items-center rounded-[4px] pt-[6px] pb-[5px] ${cat.visible ? 'bg-[#242526]' : 'bg-[#151617]'}`}
+                    >
+                      <div className="flex flex-1 items-center gap-[20px] h-[76px] px-[10px]">
+                        {/* Editable title */}
+                        <div className={`w-[250px] shrink-0 bg-[#151617] rounded-[4px] px-[6px] py-[5px] ${!cat.visible ? 'opacity-40' : ''}`}>
+                          <input
+                            type="text"
+                            value={editingLabels[cat.id] || ''}
+                            onChange={(e) => handleCategoryLabelChange(cat.id, e.target.value)}
+                            onBlur={() => handleCategoryLabelBlur(cat.id)}
+                            onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
+                            className="w-full bg-transparent border-none outline-none font-['Aleo',serif] font-normal text-[24px] leading-[1.4] text-[#dadee5]"
+                          />
+                        </div>
+
+                        {/* Color picker */}
+                        <div className={`flex-1 flex items-center justify-center gap-[6px] ${!cat.visible ? 'opacity-40' : ''}`}>
+                          {COLOR_PALETTE.map(color => (
+                            <ColorBar
+                              key={color.value}
+                              color={color.value}
+                              isSelected={cat.color.toUpperCase() === color.value.toUpperCase()}
+                              onClick={() => handleCategoryColorChange(cat.id, color.value)}
+                            />
+                          ))}
+                        </div>
+
+                        {/* Action buttons */}
+                        <div className="flex items-center gap-[16px] shrink-0">
+                          <button
+                            onClick={() => handleCategoryVisibilityToggle(cat.id)}
+                            className={glassButtonClass}
+                          >
+                            {cat.visible ? 'Hide' : 'Show'}
+                          </button>
+                          <button
+                            onClick={() => handleCategoryDelete(cat.id)}
+                            disabled={categories.length <= 1}
+                            className={`${glassButtonClass} disabled:opacity-50 disabled:pointer-events-none`}
+                          >
+                            Delete
+                          </button>
+                        </div>
                       </div>
                     </div>
-                  )
-                })}
+                  ))}
+                </div>
+
+                {/* Bottom divider */}
+                <div className="h-px w-full bg-[rgba(210,210,210,0.2)]" />
               </div>
-            </div>
+            )}
           </div>
 
           {/* Footer */}
           <div className="flex justify-between items-center mt-8">
-            {/* Add Event (left) */}
-            <button
-              onClick={handleAddRow}
-              disabled={emptyRows.length >= MAX_EMPTY_ROWS}
-              className="
-                min-w-[80px] px-[11px] py-[6px] rounded-[10px]
-                backdrop-blur-[12px] bg-white/10 border border-white/[0.15]
-                shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
-                font-['Avenir',sans-serif] font-medium text-[14px] text-[#c9ced4]
-                hover:bg-white/20 hover:text-[#dadee5] transition-all
-                disabled:opacity-50 disabled:pointer-events-none
-              "
-            >
-              Add Event
-            </button>
-
-            {/* Cancel + Save Changes (right) */}
-            <div className="flex gap-[10px]">
+            {/* Add button (left) — context-dependent */}
+            {activePageTab === 'events' ? (
               <button
-                onClick={onClose}
-                className="
-                  min-w-[80px] px-[11px] py-[6px] rounded-[10px]
-                  backdrop-blur-[12px] bg-white/10 border border-white/[0.15]
-                  shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
-                  font-['Avenir',sans-serif] font-medium text-[14px] text-[#c9ced4]
-                  hover:bg-white/20 hover:text-[#dadee5] transition-all
-                "
+                onClick={handleAddRow}
+                disabled={emptyRows.length >= MAX_EMPTY_ROWS}
+                className={`${glassButtonClass} disabled:opacity-50 disabled:pointer-events-none`}
               >
+                Add Event
+              </button>
+            ) : (
+              <button
+                onClick={handleAddCategory}
+                disabled={categories.length >= 4}
+                className={`${glassButtonClass} disabled:opacity-50 disabled:pointer-events-none`}
+              >
+                Add Category
+              </button>
+            )}
+
+            {/* Cancel + Save (right) */}
+            <div className="flex gap-[10px]">
+              <button onClick={onClose} className={glassButtonClass}>
                 Cancel
               </button>
 
@@ -569,7 +749,7 @@ export function EventTableEditor({
                 onClick={handleApplyChanges}
                 disabled={!canApplyChanges}
                 className="
-                  min-w-[80px] px-[11px] py-[6px] rounded-[10px]
+                  relative min-w-[80px] px-[11px] py-[6px] rounded-[10px]
                   backdrop-blur-[12px] bg-[rgba(37,99,235,0.8)] border border-white/[0.15]
                   shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
                   font-['Avenir',sans-serif] font-medium text-[14px] text-[#dadee5]

--- a/src/components/EventTableEditor/EventTableEditor.tsx
+++ b/src/components/EventTableEditor/EventTableEditor.tsx
@@ -101,8 +101,8 @@ function SortableTab({
         backdrop-blur-[12px] shadow-[0px_8px_32px_rgba(0,0,0,0.4)] text-left
         font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-all
         ${isActive
-          ? 'border border-transparent bg-[rgba(37,99,235,0.4)] text-[#dadee5] shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]'
-          : 'border border-transparent bg-transparent text-[#c9ced4] shadow-[inset_0px_1px_0px_rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
+          ? 'border border-transparent bg-[rgba(37,99,235,0.4)] text-[#dadee5] shadow-[0px_8px_32px_rgba(0,0,0,0.4)]'
+          : 'border border-transparent bg-transparent text-[#c9ced4] shadow-[0px_8px_32px_rgba(0,0,0,0.4)] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
         }
         ${isDragging ? 'shadow-[0px_12px_40px_rgba(0,0,0,0.6)]' : ''}
       `}
@@ -342,8 +342,8 @@ export function EventTableEditor({
                   backdrop-blur-[12px] shadow-[0px_8px_32px_rgba(0,0,0,0.4)] text-left
                   font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-all
                   ${activeCategory === null
-                    ? 'border border-transparent bg-[rgba(37,99,235,0.4)] text-[#dadee5] shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]'
-                    : 'border border-transparent bg-transparent text-[#c9ced4] shadow-[inset_0px_1px_0px_rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
+                    ? 'border border-transparent bg-[rgba(37,99,235,0.4)] text-[#dadee5] shadow-[0px_8px_32px_rgba(0,0,0,0.4)]'
+                    : 'border border-transparent bg-transparent text-[#c9ced4] shadow-[0px_8px_32px_rgba(0,0,0,0.4)] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
                   }
                 `}
               >

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -142,6 +142,7 @@ export function Header({
         events={events}
         onEventsChange={onEventsChange}
         categories={categories}
+        onCategoriesChange={onCategoriesChange}
       />
     </>
   );

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -200,6 +200,7 @@ export function Header({
         events={events}
         onEventsChange={onEventsChange}
         categories={categories}
+        onCategoriesChange={onCategoriesChange}
       />
     </>
   );

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,0 +1,70 @@
+import * as React from "react"
+import { ChevronLeft, ChevronRight } from "lucide-react"
+import { DayPicker } from "react-day-picker"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+export type CalendarProps = React.ComponentProps<typeof DayPicker>
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  ...props
+}: CalendarProps) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn("p-3", className)}
+      classNames={{
+        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
+        month: "space-y-4",
+        caption: "flex justify-center pt-1 relative items-center",
+        caption_label: "text-sm font-medium",
+        nav: "space-x-1 flex items-center",
+        nav_button: cn(
+          buttonVariants({ variant: "outline" }),
+          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+        ),
+        nav_button_previous: "absolute left-1",
+        nav_button_next: "absolute right-1",
+        table: "w-full border-collapse space-y-1",
+        head_row: "flex",
+        head_cell:
+          "text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]",
+        row: "flex w-full mt-2",
+        cell: cn(
+          "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected].day-range-end)]:rounded-r-md",
+          props.mode === "range"
+            ? "[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md"
+            : "[&:has([aria-selected])]:rounded-md"
+        ),
+        day: cn(
+          buttonVariants({ variant: "ghost" }),
+          "h-8 w-8 p-0 font-normal aria-selected:opacity-100"
+        ),
+        day_range_start: "day-range-start",
+        day_range_end: "day-range-end",
+        day_selected:
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+        day_today: "bg-accent text-accent-foreground",
+        day_outside:
+          "day-outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground",
+        day_disabled: "text-muted-foreground opacity-50",
+        day_range_middle:
+          "aria-selected:bg-accent aria-selected:text-accent-foreground",
+        day_hidden: "invisible",
+        ...classNames,
+      }}
+      components={{
+        IconLeft: () => <ChevronLeft className="h-4 w-4" />,
+        IconRight: () => <ChevronRight className="h-4 w-4" />,
+      }}
+      {...props}
+    />
+  )
+}
+Calendar.displayName = "Calendar"
+
+export { Calendar }

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverAnchor = PopoverPrimitive.Anchor
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "start", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-auto rounded-lg border bg-popover p-0 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }


### PR DESCRIPTION
## Summary
Completely redesigned the EventTableEditor component with a modern UI, drag-and-drop category reordering, and a custom date picker interface. The editor now features a sidebar-based category navigation with draggable tabs and an improved table layout with better visual styling.

## Key Changes

- **UI Redesign**: Replaced the basic table-based layout with a modern sidebar + table design featuring dark theme styling with glassmorphism effects
- **Drag-to-Reorder Categories**: Implemented drag-and-drop functionality for category tabs using `@dnd-kit` library, allowing users to reorder categories by dragging
- **Custom Date Picker**: Replaced native HTML date inputs with a custom `DatePickerCell` component using Radix UI Popover and a Calendar component for better UX
- **Category Management**: Added `onCategoriesChange` callback to persist category reorder operations
- **Improved Visual Feedback**: 
  - Added visual distinction between filled and empty form fields
  - Implemented hover states and transitions for better interactivity
  - Added drag handle icons (GripVertical) that appear on hover for category tabs
- **New UI Components**: Added `Calendar` and `Popover` components to the UI library
- **Enhanced Styling**: Replaced generic Tailwind classes with custom inline styles using specific color values and design tokens (dark backgrounds, blue accents, proper spacing)
- **Better Form Validation**: Improved empty row handling with visual feedback for required fields

## Notable Implementation Details

- The `SortableTab` component wraps category tabs with `useSortable` hook for drag functionality
- Date picker uses `date-fns` for date formatting and parsing
- The sidebar uses `DndContext` with vertical axis restriction and parent element constraints
- Empty rows are visually distinguished with darker backgrounds when fields are unfilled
- The dialog now uses Radix UI primitives directly for more control over styling and behavior

https://claude.ai/code/session_01QhCZPU1BQQFk93y3XraPmv