### PR TITLE
Expand CORS allowed headers for API authentication and metadata

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -2,5 +2,5 @@ export const corsHeaders: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
   "Access-Control-Allow-Headers":
-    "authorization, x-client-info, content-type, x-session-token",
+    "authorization, apikey, x-client-info, content-type, x-session-token, x-application-name",
 };


### PR DESCRIPTION
## Summary
Updated CORS headers configuration to support additional authentication and request metadata headers required by the API.

## Key Changes
- Added `apikey` to allowed headers for API key-based authentication
- Added `x-application-name` to allowed headers for application identification in requests

## Details
The CORS headers configuration in the shared utilities now permits two additional headers:
- `apikey`: Enables API key authentication as an alternative to bearer token authorization
- `x-application-name`: Allows clients to identify themselves by application name in their requests

These headers are now included in the `Access-Control-Allow-Headers` response, enabling cross-origin requests that utilize these headers.

https://claude.ai/code/session_011SR5AGYNoHDLS1AQE2HFDK