### PR TITLE
Refactor AI timeline creation into dedicated /ai route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,9 +12,7 @@ import { useSidePanel } from './contexts/SidePanelContext';
 import { AuthModal } from './components/Auth/AuthModal';
 import { UnsavedChangesModal } from './components/Modal/UnsavedChangesModal';
 import { useLocalDraft } from './hooks/useLocalDraft';
-import { NewTimelineScreen } from './components/NewTimeline/NewTimelineScreen';
-import { useAIMode } from './hooks/useAIMode';
-import { TimelineEvent } from './types/event';
+import { TimelineEvent, CategoryConfig } from './types/event';
 
 export function App() {
   const {
@@ -36,9 +34,7 @@ export function App() {
   const [pendingScrollDate, setPendingScrollDate] = useState<string | null>(null);
   const [draftHydrated, setDraftHydrated] = useState(false);
   const [nudgeDismissed, setNudgeDismissed] = useState(false);
-  const [showCreationScreen, setShowCreationScreen] = useState(false);
   const [activeDraftId, setActiveDraftId] = useState<string | null>(null);
-  const { isGenerating, isClassifying, classifiedType, categoryLabels, error: aiError, classifyAndGenerate, abort: abortAI, resetClassification } = useAIMode();
   const { loadAllDrafts, loadDraft, saveDraft, saveDraftImmediate, createDraft, clearAllDrafts } = useLocalDraft();
   const handledRouteStateRef = useRef(false);
   const { setOnTimelineSelect, setOnDraftSelect, setActiveTimelineId, setActiveDraftId: setPanelActiveDraftId, setActiveTimelineTitle } = useSidePanel();
@@ -93,28 +89,50 @@ export function App() {
         skipCreationScreen?: boolean;
         draftId?: string;
         timelineId?: string;
+        aiGenerated?: {
+          title: string;
+          description: string;
+          events: TimelineEvent[];
+          categories: CategoryConfig[];
+        };
       } | null;
 
-      if (routeState?.newTimeline) {
-        if (routeState.skipCreationScreen) {
-          // "Build from Scratch" — create draft immediately
-          const newDraft = createDraft();
-          if (!newDraft) {
-            alert('You\'ve reached the 3-timeline limit. Delete an existing timeline to create a new one.');
-            routerNavigate('/', { replace: true });
-            setDraftHydrated(true);
-            return;
-          }
-          setActiveDraftId(newDraft.id);
-          setTitle(newDraft.title);
-          setDescription(newDraft.description);
-          setEvents(newDraft.events);
-          updateCategories(newDraft.categories);
-          handleScaleChange(newDraft.scale);
-        } else {
-          // "Build with AI" — defer draft creation until generation completes
-          setShowCreationScreen(true);
+      if (routeState?.aiGenerated) {
+        // Arriving from /ai with a freshly generated timeline — create a draft
+        // and seed it with the generated data.
+        const newDraft = createDraft();
+        if (!newDraft) {
+          alert('You\'ve reached the 3-timeline limit. Delete an existing timeline to create a new one.');
+          routerNavigate('/', { replace: true });
+          setDraftHydrated(true);
+          return;
         }
+        const { title: aiTitle, description: aiDesc, events: aiEvents, categories: aiCategories } = routeState.aiGenerated;
+        setActiveDraftId(newDraft.id);
+        setTitle(aiTitle);
+        setDescription(aiDesc);
+        setEvents(aiEvents);
+        updateCategories(aiCategories);
+        handleScaleChange(newDraft.scale);
+        if (aiEvents.length > 0) {
+          const earliest = aiEvents.reduce((a, b) => a.startDate < b.startDate ? a : b);
+          setPendingScrollDate(earliest.startDate);
+        }
+      } else if (routeState?.newTimeline && routeState.skipCreationScreen) {
+        // "Build from Scratch" — create draft immediately
+        const newDraft = createDraft();
+        if (!newDraft) {
+          alert('You\'ve reached the 3-timeline limit. Delete an existing timeline to create a new one.');
+          routerNavigate('/', { replace: true });
+          setDraftHydrated(true);
+          return;
+        }
+        setActiveDraftId(newDraft.id);
+        setTitle(newDraft.title);
+        setDescription(newDraft.description);
+        setEvents(newDraft.events);
+        updateCategories(newDraft.categories);
+        handleScaleChange(newDraft.scale);
       } else if (routeState?.draftId) {
         // Clicking a local draft tile on Homepage
         const draft = loadDraft(routeState.draftId);
@@ -126,10 +144,12 @@ export function App() {
           updateCategories(draft.categories);
           handleScaleChange(draft.scale);
         } else {
-          setShowCreationScreen(true);
+          routerNavigate('/ai', { replace: true });
+          setDraftHydrated(true);
+          return;
         }
       } else {
-        // No route state — load most recent draft or show creation screen
+        // No route state — load most recent draft or send user to AI entry
         const allDrafts = loadAllDrafts();
         if (allDrafts.length > 0) {
           const mostRecent = allDrafts[0];
@@ -140,7 +160,9 @@ export function App() {
           updateCategories(mostRecent.categories);
           handleScaleChange(mostRecent.scale);
         } else {
-          setShowCreationScreen(true);
+          routerNavigate('/ai', { replace: true });
+          setDraftHydrated(true);
+          return;
         }
       }
 
@@ -195,26 +217,55 @@ export function App() {
     }
   }, [user, draftHydrated]);
 
-  // Handle navigation from Homepage with a specific timeline to load
+  // Handle navigation from Homepage (or /ai) with a specific timeline to load
   useEffect(() => {
-    const state = location.state as { timelineId?: string; skipCreationScreen?: boolean } | null;
-    if (state?.timelineId && user && !handledRouteStateRef.current) {
+    const state = location.state as {
+      timelineId?: string;
+      skipCreationScreen?: boolean;
+      aiGenerated?: {
+        title: string;
+        description: string;
+        events: TimelineEvent[];
+        categories: CategoryConfig[];
+      };
+    } | null;
+    if (!user || handledRouteStateRef.current) return;
+
+    if (state?.aiGenerated) {
+      handledRouteStateRef.current = true;
+      const aiData = state.aiGenerated;
+      (async () => {
+        // Creates the timeline row in Supabase and sets timelineId so autosave
+        // will persist subsequent state updates to the new row.
+        await switchTimeline('new');
+        setTitle(aiData.title);
+        setDescription(aiData.description);
+        setEvents(aiData.events);
+        updateCategories(aiData.categories);
+        if (aiData.events.length > 0) {
+          const earliest = aiData.events.reduce((a, b) => a.startDate < b.startDate ? a : b);
+          setPendingScrollDate(earliest.startDate);
+        }
+      })();
+      routerNavigate('/editor', { replace: true, state: {} });
+    } else if (state?.timelineId) {
       handledRouteStateRef.current = true;
       if (state.timelineId === 'new' && state.skipCreationScreen) {
         switchTimeline('new');
       } else if (state.timelineId === 'new') {
-        setShowCreationScreen(true);
+        // "new" without skipCreationScreen now means "go to AI mode"
+        routerNavigate('/ai', { replace: true });
+        return;
       } else {
         switchTimeline(state.timelineId);
       }
-      // Clear the state so refreshing doesn't re-trigger
       routerNavigate('/editor', { replace: true, state: {} });
     }
   }, [location.state, user]);
 
   const handleTimelineSwitch = async (newTimelineId: string) => {
     if (newTimelineId === 'new') {
-      setShowCreationScreen(true);
+      routerNavigate('/ai');
       return;
     }
 
@@ -348,63 +399,6 @@ export function App() {
     updateEvent(updatedEvent);
   };
 
-  const handleManualCreate = async () => {
-    setShowCreationScreen(false);
-    resetClassification();
-    if (user) {
-      await switchTimeline('new');
-    } else if (!activeDraftId) {
-      // Create a draft now for logged-out users choosing manual mode
-      const newDraft = createDraft();
-      if (newDraft) {
-        setActiveDraftId(newDraft.id);
-        setTitle(newDraft.title);
-        setDescription(newDraft.description);
-        setEvents(newDraft.events);
-        updateCategories(newDraft.categories);
-        handleScaleChange(newDraft.scale);
-      } else {
-        alert('You\'ve reached the 3-timeline limit. Delete an existing timeline to create a new one.');
-        routerNavigate('/', { replace: true });
-      }
-    }
-  };
-
-  const handleAIGenerate = async (subject: string) => {
-    try {
-      const { title: genTitle, description: genDesc, events: genEvents, categories: genCategories } = await classifyAndGenerate(subject);
-
-      // Create draft for logged-out users now that generation succeeded
-      if (!user && !activeDraftId) {
-        const newDraft = createDraft();
-        if (newDraft) {
-          setActiveDraftId(newDraft.id);
-        } else {
-          alert('You\'ve reached the 3-timeline limit. Delete an existing timeline to create a new one.');
-          routerNavigate('/', { replace: true });
-          return;
-        }
-      }
-
-      setTitle(genTitle);
-      setDescription(genDesc);
-      setEvents(genEvents);
-      updateCategories(genCategories);
-      setShowCreationScreen(false);
-      resetClassification();
-      if (genEvents.length > 0) {
-        const earliest = genEvents.reduce((a, b) => a.startDate < b.startDate ? a : b);
-        setPendingScrollDate(earliest.startDate);
-      }
-    } catch {
-      // Error is already set in useAIMode — stays on creation screen showing error
-    }
-  };
-
-  const handleCancelAI = () => {
-    abortAI();
-  };
-
   const handleBulkEventsChange = (newEvents: TimelineEvent[]) => {
     const currentIds = new Set(events.map(e => e.id));
     const addedEvents = newEvents.filter(e => !currentIds.has(e.id));
@@ -509,18 +503,6 @@ export function App() {
         isOpen={showAuthModal}
         onClose={() => setShowAuthModal(false)}
       />
-      {showCreationScreen && (
-        <NewTimelineScreen
-          onAIGenerate={handleAIGenerate}
-          onCancel={handleCancelAI}
-          onManualCreate={handleManualCreate}
-          isGenerating={isGenerating}
-          isClassifying={isClassifying}
-          classifiedType={classifiedType}
-          categoryLabels={categoryLabels}
-          error={aiError}
-        />
-      )}
       <UnsavedChangesModal
         isOpen={showUnsavedChangesModal}
         onClose={() => {

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, RouterProvider, Navigate, Outlet } from 'react-router-dom';
 import { App } from './App';
 import { Homepage } from './components/Homepage/Homepage';
+import { AIModePage } from './components/AIMode/AIModePage';
 import { TimelineViewer } from './components/TimelineViewer/TimelineViewer';
 import { SidePanelProvider } from './contexts/SidePanelContext';
 import { GlobalLayout } from './components/Layout/GlobalLayout';
@@ -21,6 +22,7 @@ const router = createBrowserRouter([
     children: [
       { path: '/', element: <Homepage /> },
       { path: '/editor', element: <App /> },
+      { path: '/ai', element: <AIModePage /> },
       { path: '/timelines', element: <Navigate to="/" replace /> },
     ],
   },

--- a/src/components/AIMode/AIModePage.tsx
+++ b/src/components/AIMode/AIModePage.tsx
@@ -1,0 +1,51 @@
+import { useNavigate } from 'react-router-dom'
+import { GlobalNav } from '@/components/Navigation/GlobalNav'
+import { NewTimelineScreen } from '@/components/NewTimeline/NewTimelineScreen'
+import { useAIMode } from '@/hooks/useAIMode'
+
+export function AIModePage() {
+  const navigate = useNavigate()
+  const {
+    isGenerating,
+    isClassifying,
+    classifiedType,
+    categoryLabels,
+    error,
+    classifyAndGenerate,
+    abort,
+  } = useAIMode()
+
+  const handleAIGenerate = async (subject: string) => {
+    try {
+      const { title, description, events, categories } = await classifyAndGenerate(subject)
+      navigate('/editor', {
+        state: {
+          aiGenerated: { title, description, events, categories },
+        },
+      })
+    } catch {
+      // Error is surfaced via the `error` state in useAIMode and rendered below.
+    }
+  }
+
+  const handleCancel = () => {
+    abort()
+  }
+
+  return (
+    <div className="relative min-h-screen bg-surface-primary">
+      <div className="absolute top-0 left-0 right-0 z-20">
+        <GlobalNav />
+      </div>
+      <NewTimelineScreen
+        onAIGenerate={handleAIGenerate}
+        onCancel={handleCancel}
+        isGenerating={isGenerating}
+        isClassifying={isClassifying}
+        classifiedType={classifiedType}
+        categoryLabels={categoryLabels}
+        error={error}
+      />
+    </div>
+  )
+}

--- a/src/components/Homepage/Homepage.tsx
+++ b/src/components/Homepage/Homepage.tsx
@@ -70,11 +70,7 @@ export function Homepage() {
   };
 
   const handleBuildWithAI = () => {
-    if (user) {
-      navigate('/editor', { state: { timelineId: 'new' } });
-    } else {
-      navigate('/editor', { state: { newTimeline: true } });
-    }
+    navigate('/ai');
   };
 
   const handleAuthClick = () => {

--- a/src/components/NewTimeline/NewTimelineScreen.tsx
+++ b/src/components/NewTimeline/NewTimelineScreen.tsx
@@ -1,12 +1,10 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { GlobalNav } from '@/components/Navigation/GlobalNav'
 import { SUBJECT_TYPE_SUFFIX } from '@/constants/pillDefinitions'
 import type { SubjectType } from '@/constants/pillDefinitions'
 
 interface NewTimelineScreenProps {
   onAIGenerate: (subject: string) => void
   onCancel: () => void
-  onManualCreate: () => void
   isGenerating: boolean
   isClassifying: boolean
   classifiedType: SubjectType | null
@@ -108,7 +106,6 @@ function BackgroundPattern() {
 export function NewTimelineScreen({
   onAIGenerate,
   onCancel,
-  onManualCreate,
   isGenerating,
   isClassifying,
   classifiedType,
@@ -181,10 +178,9 @@ export function NewTimelineScreen({
   const hasText = name.trim().length > 0
 
   return (
-    <div className="fixed inset-0 bg-surface-primary z-50 overflow-auto">
+    <div className="relative min-h-screen bg-surface-primary overflow-auto">
       <BackgroundPattern />
       <div className="relative z-10">
-        <GlobalNav />
         <div
           className="pl-[120px] pr-[80px] pt-[260px] pb-[200px]"
         >
@@ -313,15 +309,6 @@ export function NewTimelineScreen({
               </div>
             )}
 
-            {/* Manual create escape hatch */}
-            {!isWorking && (
-              <button
-                onClick={onManualCreate}
-                className="text-sm text-text-tertiary hover:text-white underline underline-offset-2 transition-colors font-avenir"
-              >
-                Create my own timeline
-              </button>
-            )}
           </div>
         </div>
       </div>

--- a/src/components/SidePanel/GlobalSidePanel.tsx
+++ b/src/components/SidePanel/GlobalSidePanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { MoreVertical, PanelLeft, Trash2, LogOut, Video } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useSidePanel } from '@/contexts/SidePanelContext'
@@ -68,6 +69,7 @@ function TileMenuButton({ onDelete }: { onDelete: () => void }) {
 }
 
 export function GlobalSidePanel() {
+  const navigate = useNavigate()
   const { user } = useAuth()
   const { isOpen, close, onTimelineSelect, onDraftSelect, activeTimelineId, activeDraftId, activeTimelineTitle } = useSidePanel()
   const { timelines, isLoading, error, loadTimelines } = useTimelines()
@@ -181,9 +183,12 @@ export function GlobalSidePanel() {
       >
         {/* Header */}
         <div className="flex items-center justify-between gap-2 px-5 pt-4 pb-2 border-b border-[#404040] shrink-0">
-          <p className="font-['Aleo',serif] font-normal text-[18px] leading-[1.4] text-[#c9ced4]">
+          <button
+            onClick={() => navigate('/')}
+            className="font-['Aleo',serif] font-normal text-[18px] leading-[1.4] text-[#c9ced4] hover:text-[#dadee5] transition-colors bg-transparent border-none p-0 cursor-pointer"
+          >
             Timelines
-          </p>
+          </button>
           <button
             onClick={close}
             className="relative flex items-center justify-center p-1.5 rounded-md border border-white/15 bg-white/10 backdrop-blur-[12px] text-[#c9ced4] shadow-[0px_8px_32px_0px_rgba(0,0,0,0.4),inset_0px_1px_0px_0px_rgba(255,255,255,0.1)] hover:bg-white/20 hover:text-[#dadee5] transition-colors"


### PR DESCRIPTION
## Summary
Extracted the AI-powered timeline creation flow into a dedicated `/ai` route page, removing the modal-based `NewTimelineScreen` from the main App component. This improves separation of concerns and provides a cleaner user experience for the AI generation workflow.

## Key Changes

- **New `/ai` route**: Created `AIModePage` component that wraps `NewTimelineScreen` with `GlobalNav`, serving as the dedicated entry point for AI-powered timeline creation
- **Removed modal state from App**: Eliminated `showCreationScreen` state and related handlers (`handleManualCreate`, `handleAIGenerate`, `handleCancelAI`) from the main App component
- **Updated navigation flow**: 
  - "Build with AI" button now navigates to `/ai` instead of showing a modal
  - When AI generation completes, the generated timeline data is passed via route state to `/editor`
  - Removed the "Create my own timeline" escape hatch from `NewTimelineScreen`
- **Simplified `NewTimelineScreen`**: Removed `onManualCreate` prop and `GlobalNav` rendering since it's now handled by the parent `AIModePage`
- **Updated route state handling**: Added support for `aiGenerated` property in route state to seed the editor with AI-generated content (title, description, events, categories)
- **Consistent redirect behavior**: When users without drafts or with missing drafts navigate to the app, they're redirected to `/ai` instead of showing a modal

## Implementation Details

- The `aiGenerated` route state object contains the complete timeline data structure needed to populate the editor
- When AI generation completes, the earliest event date is automatically scrolled into view via `setPendingScrollDate`
- The refactor maintains backward compatibility with existing draft loading and timeline switching logic
- Both logged-in and logged-out users follow the same `/ai` → `/editor` flow for AI-generated timelines

https://claude.ai/code/session_01F79hUS7mscdXkokdk4Za1D