### PR TITLE
Adjust spacing and remove unnecessary margin from timeline layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -483,7 +483,7 @@ export function App() {
           </div>
         </div>
       ) : (
-        <main className="timeline-container relative mt-16">
+        <main className="timeline-container relative mt-[140px]">
           <Timeline
             events={events}
             categories={categories}

--- a/src/components/SidePanel/GlobalSidePanel.tsx
+++ b/src/components/SidePanel/GlobalSidePanel.tsx
@@ -232,7 +232,7 @@ export function GlobalSidePanel() {
                 return (
                   <div
                     key={`${row.kind}:${row.id}`}
-                    className={`group flex items-center gap-4 px-2 py-2.5 rounded-[10px] transition-colors ${
+                    className={`group flex items-center gap-4 px-2 py-2.5 rounded-[6px] transition-colors ${
                       isActive ? 'bg-surface-primary' : ''
                     }`}
                   >
@@ -266,14 +266,14 @@ export function GlobalSidePanel() {
           <button
             type="button"
             onClick={() => setIsVideoTutorialOpen(true)}
-            className="w-full flex items-center px-[7px] py-[9px] rounded-[10px] border border-transparent backdrop-blur-[12px] font-['Avenir',sans-serif] font-medium text-[14px] leading-[1.5] text-[#9b9ea3] hover:bg-[#262626] hover:text-[#dadee5] transition-colors"
+            className="w-full flex items-center px-[7px] py-[9px] rounded-[6px] border border-transparent backdrop-blur-[12px] font-['Avenir',sans-serif] font-medium text-[14px] leading-[1.5] text-[#9b9ea3] hover:bg-[#262626] hover:text-[#dadee5] transition-colors"
           >
             How it Works
           </button>
           <button
             type="button"
             onClick={() => setIsFeedbackOpen(true)}
-            className="w-full flex items-center px-[7px] py-[9px] rounded-[10px] border border-transparent backdrop-blur-[12px] font-['Avenir',sans-serif] font-medium text-[14px] leading-[1.5] text-[#9b9ea3] hover:bg-[#262626] hover:text-[#dadee5] transition-colors"
+            className="w-full flex items-center px-[7px] py-[9px] rounded-[6px] border border-transparent backdrop-blur-[12px] font-['Avenir',sans-serif] font-medium text-[14px] leading-[1.5] text-[#9b9ea3] hover:bg-[#262626] hover:text-[#dadee5] transition-colors"
           >
             Feedback
           </button>

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -155,7 +155,7 @@ export function Timeline({
   }, [editingEvent, onAddEvent, onUpdateEvent, scrollToDate]);
 
   return (
-    <div className={isFullScreen ? 'h-[calc(100vh-6rem)]' : 'relative mb-16'}>
+    <div className={isFullScreen ? 'h-[calc(100vh-6rem)]' : 'relative'}>
       <div
         className="absolute left-0 z-10 pointer-events-none"
         style={{ top: SCROLL_INDICATOR_HEIGHT + HEADER_HEIGHT, height: categoryData.totalHeight }}


### PR DESCRIPTION
## Summary
This PR refines the spacing and layout of the timeline component by adjusting margin/padding values and removing unnecessary bottom margin.

## Key Changes
- Updated the main timeline container's top margin from `mt-16` to `mt-[140px]` in App.tsx for more precise spacing control
- Removed the `mb-16` (bottom margin) class from the Timeline component's root div when not in fullscreen mode, keeping only the `relative` positioning class

## Implementation Details
These changes appear to be layout refinements that:
1. Provide more explicit control over the top spacing of the timeline container (140px instead of the default 16 unit margin)
2. Eliminate unnecessary bottom margin from the timeline wrapper in normal (non-fullscreen) mode, likely to prevent excess whitespace at the bottom of the timeline

The modifications maintain the existing functionality while improving the visual spacing and layout consistency of the timeline interface.

https://claude.ai/code/session_01QMXd5KHntBgvQvn3xX31Tk