### PR TITLE
Add group-by-category layout mode and improve event stacking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -481,7 +481,7 @@ export function App() {
   };
 
   return (
-    <div className="app-container min-h-screen bg-black text-white overflow-auto">
+    <div className="app-container h-screen bg-black text-white overflow-hidden flex flex-col">
       <GlobalNav
         variant="timeline"
         timelineId={timelineId}
@@ -520,7 +520,7 @@ export function App() {
         onCloseAddEventModal={() => setShowAddEventModal(false)}
       />
       {!user && events.length > 0 && !nudgeDismissed && (
-        <div className="mx-4 mt-2 px-4 py-3 bg-blue-900/40 border border-blue-800/50 rounded-lg flex items-center justify-between text-sm">
+        <div className="mx-4 mt-2 px-4 py-3 bg-blue-900/40 border border-blue-800/50 rounded-lg flex items-center justify-between text-sm shrink-0">
           <span className="text-blue-200">
             Your work isn't saved to the cloud yet.{' '}
             <button
@@ -540,7 +540,7 @@ export function App() {
         </div>
       )}
       {timelineError ? (
-        <div className="flex items-center justify-center py-20">
+        <div className="flex-1 flex items-center justify-center py-20">
           <div className="bg-gray-800 p-6 rounded-lg shadow-xl max-w-md w-full text-center">
             <p className="text-red-400 mb-4">{timelineError}</p>
             <button
@@ -552,7 +552,7 @@ export function App() {
           </div>
         </div>
       ) : (
-        <main className="timeline-container relative mt-[140px]">
+        <main className="timeline-container relative flex-1 min-h-0 flex flex-col pt-[140px]">
           <Timeline
             events={events}
             categories={categories}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ export function App() {
     title, description, setTitle, setDescription,
     categories, updateCategories, resetCategories,
     scale, currentScale, handleScaleChange,
+    groupByCategory, handleGroupByCategoryChange,
   } = useTimelineState();
   const { user } = useAuth();
   const { saveTimeline, timelineId, loadTimeline, error: timelineError, retryInitialLoad } = useTimeline();
@@ -53,7 +54,8 @@ export function App() {
     description,
     events,
     categories,
-    scale: currentScale.value
+    scale: currentScale.value,
+    groupByCategory,
   };
 
   const { saveStatus, lastSavedTime, handleChange } = useAutosave(timelineData);
@@ -91,10 +93,11 @@ export function App() {
         description,
         events,
         categories,
-        scale: currentScale.value
+        scale: currentScale.value,
+        groupByCategory,
       });
     }
-  }, [timelineId, title, description, events, categories, currentScale.value, handleChange]);
+  }, [timelineId, title, description, events, categories, currentScale.value, groupByCategory, handleChange]);
 
   // Hydrate from localStorage draft if logged out
   useEffect(() => {
@@ -178,6 +181,7 @@ export function App() {
           setEvents(draft.events);
           updateCategories(draft.categories);
           handleScaleChange(draft.scale);
+          handleGroupByCategoryChange(draft.groupByCategory ?? false);
         } else {
           routerNavigate('/ai', { replace: true });
           setDraftHydrated(true);
@@ -194,6 +198,7 @@ export function App() {
           setEvents(mostRecent.events);
           updateCategories(mostRecent.categories);
           handleScaleChange(mostRecent.scale);
+          handleGroupByCategoryChange(mostRecent.groupByCategory ?? false);
         } else {
           routerNavigate('/ai', { replace: true });
           setDraftHydrated(true);
@@ -205,7 +210,7 @@ export function App() {
       // Clear the route state so refreshing doesn't re-trigger
       routerNavigate('/editor', { replace: true, state: {} });
     }
-  }, [user, draftHydrated, createDraft, handleScaleChange, loadAllDrafts, loadDraft, location.state, routerNavigate, setDescription, setEvents, setTitle, updateCategories]);
+  }, [user, draftHydrated, createDraft, handleScaleChange, handleGroupByCategoryChange, loadAllDrafts, loadDraft, location.state, routerNavigate, setDescription, setEvents, setTitle, updateCategories]);
 
   // Save to localStorage when logged out
   useEffect(() => {
@@ -217,10 +222,11 @@ export function App() {
         events,
         categories,
         scale: currentScale.value,
+        groupByCategory,
         savedAt: new Date().toISOString()
       });
     }
-  }, [user, draftHydrated, activeDraftId, title, description, events, categories, currentScale.value, saveDraft]);
+  }, [user, draftHydrated, activeDraftId, title, description, events, categories, currentScale.value, groupByCategory, saveDraft]);
 
   // Migrate localStorage drafts to Supabase on login
   useEffect(() => {
@@ -258,7 +264,14 @@ export function App() {
   const switchTimeline = useCallback(async (newTimelineId: string) => {
     try {
       // Load new data first — don't clear state until we have the replacement
-      const { title: newTitle, description: newDescription, events: newEvents, categories: newCategories, scale: newScale } = await loadTimeline(newTimelineId);
+      const {
+        title: newTitle,
+        description: newDescription,
+        events: newEvents,
+        categories: newCategories,
+        scale: newScale,
+        groupByCategory: newGroupByCategory,
+      } = await loadTimeline(newTimelineId);
 
       // Only update state after successful load
       setTitle(newTitle);
@@ -270,11 +283,12 @@ export function App() {
         resetCategories();
       }
       handleScaleChange(newScale || 'large');
+      handleGroupByCategoryChange(newGroupByCategory ?? false);
     } catch (error) {
       console.error('Error switching timeline:', error);
       alert('Failed to load timeline. Please try again.');
     }
-  }, [loadTimeline, setTitle, setDescription, setEvents, updateCategories, resetCategories, handleScaleChange]);
+  }, [loadTimeline, setTitle, setDescription, setEvents, updateCategories, resetCategories, handleScaleChange, handleGroupByCategoryChange]);
 
   // Handle navigation from Homepage (or /ai) with a specific timeline to load
   useEffect(() => {
@@ -368,6 +382,7 @@ export function App() {
     setEvents(draft.events);
     updateCategories(draft.categories);
     handleScaleChange(draft.scale);
+    handleGroupByCategoryChange(draft.groupByCategory ?? false);
   };
 
   const handleDiscardAndSwitch = async () => {
@@ -436,6 +451,7 @@ export function App() {
         id: activeDraftId,
         title, description, events, categories,
         scale: currentScale.value,
+        groupByCategory,
         savedAt: new Date().toISOString()
       });
       window.open(`/view/local?draftId=${activeDraftId}`, '_blank');
@@ -495,6 +511,8 @@ export function App() {
         onEventsChange={handleBulkEventsChange}
         scale={scale}
         onScaleChange={handleScaleChange}
+        groupByCategory={groupByCategory}
+        onGroupByCategoryChange={handleGroupByCategoryChange}
         activePanel={activePanel}
         onActivePanelChange={setActivePanel}
         showAddEventModal={showAddEventModal}
@@ -541,6 +559,7 @@ export function App() {
             onAddEvent={addEvent}
             onUpdateEvent={handleUpdateEvent}
             scale={currentScale}
+            groupByCategory={groupByCategory}
             pendingScrollDate={pendingScrollDate}
             onScrollComplete={() => setPendingScrollDate(null)}
           />

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -25,6 +25,8 @@ interface HeaderProps {
   onEventsChange: (events: TimelineEvent[]) => void;
   scale: 'large' | 'small';
   onScaleChange: (scale: 'large' | 'small') => void;
+  groupByCategory: boolean;
+  onGroupByCategoryChange: (value: boolean) => void;
   activePanel: 'events' | 'settings' | null;
   onActivePanelChange: (panel: 'events' | 'settings' | null) => void;
   showAddEventModal: boolean;
@@ -46,6 +48,8 @@ export function Header({
   onEventsChange,
   scale,
   onScaleChange,
+  groupByCategory,
+  onGroupByCategoryChange,
   activePanel,
   onActivePanelChange,
   showAddEventModal,
@@ -102,6 +106,8 @@ export function Header({
         onCategoriesChange={onCategoriesChange}
         scale={scale}
         onScaleChange={onScaleChange}
+        groupByCategory={groupByCategory}
+        onGroupByCategoryChange={onGroupByCategoryChange}
       />
 
       <EventTableEditor

--- a/src/components/Settings/TimelineSettingsPanel.tsx
+++ b/src/components/Settings/TimelineSettingsPanel.tsx
@@ -38,7 +38,10 @@ interface TimelineSettingsPanelProps {
   onDescriptionChange: (description: string) => void;
   scale: 'large' | 'small';
   onScaleChange: (scale: 'large' | 'small') => void;
+  groupByCategory: boolean;
+  onGroupByCategoryChange: (value: boolean) => void;
   categories: CategoryConfig[];
+  onCategoriesChange?: (categories: CategoryConfig[]) => void;
 }
 
 export function TimelineSettingsPanel({
@@ -53,6 +56,8 @@ export function TimelineSettingsPanel({
   onDescriptionChange,
   scale,
   onScaleChange,
+  groupByCategory,
+  onGroupByCategoryChange,
   categories,
 }: TimelineSettingsPanelProps) {
   const [showClearConfirmation, setShowClearConfirmation] = useState(false);
@@ -211,6 +216,33 @@ export function TimelineSettingsPanel({
 
               <div className="border-t pt-4">
                 <ScaleSelector value={scale} onChange={onScaleChange} />
+              </div>
+
+              <div className="border-t pt-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="space-y-1">
+                    <Label htmlFor="groupByCategoryToggle">Group by category</Label>
+                    <p className="text-xs text-muted-foreground">
+                      When on, events stack within their category band. When off, all events pack to the top of the timeline.
+                    </p>
+                  </div>
+                  <button
+                    id="groupByCategoryToggle"
+                    type="button"
+                    role="switch"
+                    aria-checked={groupByCategory}
+                    onClick={() => onGroupByCategoryChange(!groupByCategory)}
+                    className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors mt-1 ${
+                      groupByCategory ? 'bg-primary' : 'bg-input'
+                    }`}
+                  >
+                    <span
+                      className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-background shadow-lg ring-0 transition-transform ${
+                        groupByCategory ? 'translate-x-5' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
               </div>
 
               <div className="border-t pt-4">

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -8,10 +8,10 @@ import { TimelineOverview } from './TimelineOverview';
 import { TimelineEvent as ITimelineEvent, CategoryConfig } from '../../types/event';
 import { TimelineScale } from '../../types/timeline';
 import { getTimelineRange, shiftEventDates } from '../../utils/dateUtils';
-import { calculateEventStacks } from '../../utils/eventStacking';
+import { calculateEventStacks, StackedEvent } from '../../utils/eventStacking';
 import { useTimelineScroll } from '../../hooks/useTimelineScroll';
 import { useEventDrag } from '../../hooks/useEventDrag';
-import { EVENT_HEIGHT, CATEGORY_PADDING, CATEGORY_MIN_HEIGHT, SCROLL_INDICATOR_HEIGHT, HEADER_HEIGHT } from '../../constants/timeline';
+import { EVENT_HEIGHT, EVENT_ROW_HEIGHT, CATEGORY_PADDING, CATEGORY_MIN_HEIGHT, SCROLL_INDICATOR_HEIGHT, HEADER_HEIGHT } from '../../constants/timeline';
 import { EventForm } from '../EventForm/EventForm';
 import {
   Dialog,
@@ -24,11 +24,24 @@ interface TimelineProps {
   events: ITimelineEvent[];
   categories: CategoryConfig[];
   isFullScreen?: boolean;
-  onAddEvent?: (event: Omit<ITimelineEvent, 'id'>) => void;
+  onAddEvent?: (event: Omit<ITimelineEvent, 'id'>) => ITimelineEvent | void;
   onUpdateEvent?: (event: ITimelineEvent) => void;
   scale: TimelineScale;
+  groupByCategory?: boolean;
   pendingScrollDate?: string | null;
   onScrollComplete?: () => void;
+}
+
+interface CategoryBand {
+  id: string;
+  height: number;
+  offset: number;
+  events: StackedEvent[];
+}
+
+interface LayoutData {
+  bands: CategoryBand[];
+  totalHeight: number;
 }
 
 export function Timeline({
@@ -38,12 +51,13 @@ export function Timeline({
   onAddEvent,
   onUpdateEvent,
   scale,
+  groupByCategory = false,
   pendingScrollDate,
   onScrollComplete
 }: TimelineProps) {
   // Filter visible categories and their events
   const visibleCategories = categories.filter(cat => cat.visible);
-  const visibleEvents = events.filter(event => 
+  const visibleEvents = events.filter(event =>
     visibleCategories.some(cat => cat.id === event.category)
   );
 
@@ -53,7 +67,8 @@ export function Timeline({
   const [showEventModal, setShowEventModal] = useState(false);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [editingEvent, setEditingEvent] = useState<ITimelineEvent | null>(null);
-  
+  const [pendingScrollEventId, setPendingScrollEventId] = useState<string | null>(null);
+
   const { visibleRange } = useTimelineScroll(scrollContainerRef, months.length * 4);
 
   const scrollToDate = useCallback((dateStr: string) => {
@@ -93,32 +108,47 @@ export function Timeline({
     }
   }, [pendingScrollDate, scrollToDate, onScrollComplete]);
 
-  // Calculate stacks and heights for each category
-  const categoryData = React.useMemo(() => {
-    let currentOffset = 0;
-    const data = visibleCategories.map(category => {
-      const categoryEvents = visibleEvents.filter(event => event.category === category.id);
-      const stackedEvents = calculateEventStacks(categoryEvents, months, scale.monthWidth);
-      const maxStack = Math.max(...stackedEvents.map(event => event.stackIndex), 0);
-      
-      const height = (maxStack + 1) * EVENT_HEIGHT + CATEGORY_PADDING;
+  // Compute layout: either one band per visible category (grouped mode)
+  // or a single band containing all visible events (default).
+  const layout = React.useMemo<LayoutData>(() => {
+    if (groupByCategory) {
+      let currentOffset = 0;
+      const bands: CategoryBand[] = visibleCategories.map(category => {
+        const categoryEvents = visibleEvents.filter(event => event.category === category.id);
+        const stackedEvents = calculateEventStacks(categoryEvents, months, scale.monthWidth);
+        const maxStack = Math.max(...stackedEvents.map(event => event.stackIndex), 0);
 
-      const result = {
-        id: category.id,
-        height: Math.max(height, CATEGORY_MIN_HEIGHT),
-        offset: currentOffset,
-        events: stackedEvents,
+        const height = (maxStack + 1) * EVENT_HEIGHT + CATEGORY_PADDING;
+
+        const band: CategoryBand = {
+          id: category.id,
+          height: Math.max(height, CATEGORY_MIN_HEIGHT),
+          offset: currentOffset,
+          events: stackedEvents,
+        };
+
+        currentOffset += band.height;
+        return band;
+      });
+
+      return {
+        bands,
+        totalHeight: currentOffset || CATEGORY_MIN_HEIGHT,
       };
+    }
 
-      currentOffset += result.height;
-      return result;
-    });
+    // Default: single global stacking pass.
+    const stackedEvents = calculateEventStacks(visibleEvents, months, scale.monthWidth);
+    const maxStack = Math.max(...stackedEvents.map(event => event.stackIndex), 0);
+    const height = stackedEvents.length === 0
+      ? EVENT_ROW_HEIGHT
+      : (maxStack + 1) * EVENT_ROW_HEIGHT + CATEGORY_PADDING;
 
     return {
-      categories: data,
-      totalHeight: currentOffset || CATEGORY_MIN_HEIGHT,
+      bands: [{ id: 'all', height, offset: 0, events: stackedEvents }],
+      totalHeight: height,
     };
-  }, [visibleEvents, visibleCategories, months, scale.monthWidth]);
+  }, [groupByCategory, visibleEvents, visibleCategories, months, scale.monthWidth]);
 
   const handleMonthClick = useCallback((monthIndex: number) => {
     if (!onAddEvent || justDraggedRef.current) return;
@@ -140,10 +170,14 @@ export function Timeline({
   }, [onUpdateEvent, justDraggedRef]);
 
   const handleSubmit = useCallback((eventData: Omit<ITimelineEvent, 'id'>) => {
+    let newEventId: string | null = null;
     if (editingEvent) {
       onUpdateEvent?.({ ...eventData, id: editingEvent.id });
     } else {
-      onAddEvent?.(eventData);
+      const newEvent = onAddEvent?.(eventData);
+      if (newEvent && typeof newEvent === 'object' && 'id' in newEvent) {
+        newEventId = newEvent.id;
+      }
     }
     setShowEventModal(false);
     setEditingEvent(null);
@@ -152,19 +186,40 @@ export function Timeline({
     requestAnimationFrame(() => {
       scrollToDate(eventData.startDate);
     });
+
+    if (newEventId) {
+      // Defer until after the next layout pass so the event has a stackIndex
+      // and rendered DOM node we can scroll to.
+      setPendingScrollEventId(newEventId);
+    }
   }, [editingEvent, onAddEvent, onUpdateEvent, scrollToDate]);
+
+  const handleEventMounted = useCallback((eventId: string, node: HTMLDivElement | null) => {
+    if (!node) return;
+    if (eventId === pendingScrollEventId) {
+      // scrollIntoView handles vertical scroll on the page; horizontal scroll
+      // is handled separately by scrollToDate.
+      node.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+      setPendingScrollEventId(null);
+    }
+  }, [pendingScrollEventId]);
+
+  const showCategoryLabels = groupByCategory;
+  const rowHeight = groupByCategory ? EVENT_HEIGHT : EVENT_ROW_HEIGHT;
 
   return (
     <div className={isFullScreen ? 'h-[calc(100vh-6rem)]' : 'relative'}>
-      <div
-        className="absolute left-0 z-10 pointer-events-none"
-        style={{ top: SCROLL_INDICATOR_HEIGHT + HEADER_HEIGHT, height: categoryData.totalHeight }}
-      >
-        <TimelineCategoryLabels
-          categories={categoryData.categories}
-          customCategories={visibleCategories}
-        />
-      </div>
+      {showCategoryLabels && (
+        <div
+          className="absolute left-0 z-10 pointer-events-none"
+          style={{ top: SCROLL_INDICATOR_HEIGHT + HEADER_HEIGHT, height: layout.totalHeight }}
+        >
+          <TimelineCategoryLabels
+            categories={layout.bands.map(b => ({ id: b.id, height: b.height }))}
+            customCategories={visibleCategories}
+          />
+        </div>
+      )}
 
       <div className="relative">
         <TimelineScrollIndicator
@@ -176,9 +231,9 @@ export function Timeline({
             ref={scrollContainerRef}
             className="overflow-x-auto scrollbar-hide"
           >
-            <div 
+            <div
               className="relative timeline-grid transition-all duration-200 ease-in-out"
-              style={{ 
+              style={{
                 display: 'grid',
                 gridTemplateColumns: `repeat(${months.length * 4}, ${scale.quarterWidth}px)`,
                 minWidth: `${months.length * scale.monthWidth}px`,
@@ -186,38 +241,40 @@ export function Timeline({
               }}
             >
               <TimelineHeader months={months} scale={scale} />
-              {categoryData.categories.map((category) => (
-                <div 
-                  key={`category-${category.id}`}
+              {layout.bands.map((band) => (
+                <div
+                  key={`band-${band.id}`}
                   className="relative border-l border-[#171717]"
-                  style={{ 
-                    height: category.height,
+                  style={{
+                    height: band.height,
                     gridColumn: `1 / span ${months.length * 4}`,
                     display: 'grid',
                     gridTemplateColumns: `repeat(${months.length * 4}, ${scale.quarterWidth}px)`,
-                    gridAutoRows: `${EVENT_HEIGHT}px`,
+                    gridAutoRows: `${rowHeight}px`,
                     gap: 0,
                   }}
                 >
-                  <TimelineGrid 
-                    months={months} 
-                    height={category.height}
+                  <TimelineGrid
+                    months={months}
+                    height={band.height}
                     onMonthHover={setHoveredMonth}
                     onMonthClick={handleMonthClick}
                     scale={scale}
                   />
-                  {category.events.map((event) => (
+                  {band.events.map((event) => (
                     <TimelineEvent
                       key={event.id}
                       event={event}
                       months={months}
-                      categoryOffset={category.offset}
-                      categoryColor={visibleCategories.find(c => c.id === category.id)?.color}
+                      categoryOffset={band.offset}
+                      categoryColor={visibleCategories.find(c => c.id === event.category)?.color}
                       onEventClick={onUpdateEvent ? handleEventClick : undefined}
                       scale={scale}
                       isDragging={dragState.isDragging && dragState.draggedEventId === event.id}
                       dragDeltaPixels={dragState.draggedEventId === event.id ? dragState.deltaPixels : 0}
                       onPointerDown={onUpdateEvent ? handlePointerDown : undefined}
+                      rowHeight={rowHeight}
+                      onMounted={handleEventMounted}
                     />
                   ))}
                 </div>
@@ -228,7 +285,7 @@ export function Timeline({
                 className="relative border-l border-[#171717]"
                 style={{
                   gridColumn: `1 / span ${months.length * 4}`,
-                  minHeight: `calc(100vh - ${categoryData.totalHeight + HEADER_HEIGHT + SCROLL_INDICATOR_HEIGHT}px - 6rem)`,
+                  minHeight: `calc(100vh - ${layout.totalHeight + HEADER_HEIGHT + SCROLL_INDICATOR_HEIGHT}px - 6rem)`,
                 }}
               >
                 <TimelineGrid

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -208,7 +208,7 @@ export function Timeline({
   const rowHeight = groupByCategory ? EVENT_HEIGHT : EVENT_ROW_HEIGHT;
 
   return (
-    <div className={isFullScreen ? 'h-[calc(100vh-6rem)]' : 'relative'}>
+    <div className={isFullScreen ? 'h-[calc(100vh-6rem)] relative' : 'flex-1 min-h-0 flex flex-col relative'}>
       {showCategoryLabels && (
         <div
           className="absolute left-0 z-10 pointer-events-none"
@@ -221,92 +221,84 @@ export function Timeline({
         </div>
       )}
 
-      <div className="relative">
+      <div className="relative flex-1 min-h-0 flex flex-col">
         <TimelineScrollIndicator
           months={months}
           visibleRange={visibleRange}
         />
-        <div className="overflow-hidden">
+        <div
+          ref={scrollContainerRef}
+          className="flex-1 min-h-0 overflow-auto scrollbar-hide"
+        >
           <div
-            ref={scrollContainerRef}
-            className="overflow-x-auto scrollbar-hide"
+            className="relative timeline-grid transition-[min-width] duration-200 ease-in-out flex flex-col"
+            style={{
+              minWidth: `${months.length * scale.monthWidth}px`,
+              minHeight: '100%',
+              cursor: onAddEvent ? 'pointer' : 'default'
+            }}
           >
-            <div
-              className="relative timeline-grid transition-all duration-200 ease-in-out"
-              style={{
-                display: 'grid',
-                gridTemplateColumns: `repeat(${months.length * 4}, ${scale.quarterWidth}px)`,
-                minWidth: `${months.length * scale.monthWidth}px`,
-                cursor: onAddEvent ? 'pointer' : 'default'
-              }}
-            >
-              <TimelineHeader months={months} scale={scale} />
-              {layout.bands.map((band) => (
-                <div
-                  key={`band-${band.id}`}
-                  className="relative border-l border-[#171717]"
-                  style={{
-                    height: band.height,
-                    gridColumn: `1 / span ${months.length * 4}`,
-                    display: 'grid',
-                    gridTemplateColumns: `repeat(${months.length * 4}, ${scale.quarterWidth}px)`,
-                    gridAutoRows: `${rowHeight}px`,
-                    gap: 0,
-                  }}
-                >
-                  <TimelineGrid
-                    months={months}
-                    height={band.height}
-                    onMonthHover={setHoveredMonth}
-                    onMonthClick={handleMonthClick}
-                    scale={scale}
-                  />
-                  {band.events.map((event) => (
-                    <TimelineEvent
-                      key={event.id}
-                      event={event}
-                      months={months}
-                      categoryOffset={band.offset}
-                      categoryColor={visibleCategories.find(c => c.id === event.category)?.color}
-                      onEventClick={onUpdateEvent ? handleEventClick : undefined}
-                      scale={scale}
-                      isDragging={dragState.isDragging && dragState.draggedEventId === event.id}
-                      dragDeltaPixels={dragState.draggedEventId === event.id ? dragState.deltaPixels : 0}
-                      onPointerDown={onUpdateEvent ? handlePointerDown : undefined}
-                      rowHeight={rowHeight}
-                      onMounted={handleEventMounted}
-                    />
-                  ))}
-                </div>
-              ))}
-
-              {/* Filler row: extends vertical grid lines to bottom of viewport */}
+            <TimelineHeader months={months} scale={scale} />
+            {layout.bands.map((band) => (
               <div
-                className="relative border-l border-[#171717]"
+                key={`band-${band.id}`}
+                className="relative border-l border-[#171717] shrink-0"
                 style={{
-                  gridColumn: `1 / span ${months.length * 4}`,
-                  minHeight: `calc(100vh - ${layout.totalHeight + HEADER_HEIGHT + SCROLL_INDICATOR_HEIGHT}px - 6rem)`,
+                  height: band.height,
+                  display: 'grid',
+                  gridTemplateColumns: `repeat(${months.length * 4}, ${scale.quarterWidth}px)`,
+                  gridAutoRows: `${rowHeight}px`,
+                  gap: 0,
                 }}
               >
                 <TimelineGrid
                   months={months}
+                  height={band.height}
                   onMonthHover={setHoveredMonth}
                   onMonthClick={handleMonthClick}
                   scale={scale}
                 />
+                {band.events.map((event) => (
+                  <TimelineEvent
+                    key={event.id}
+                    event={event}
+                    months={months}
+                    categoryOffset={band.offset}
+                    categoryColor={visibleCategories.find(c => c.id === event.category)?.color}
+                    onEventClick={onUpdateEvent ? handleEventClick : undefined}
+                    scale={scale}
+                    isDragging={dragState.isDragging && dragState.draggedEventId === event.id}
+                    dragDeltaPixels={dragState.draggedEventId === event.id ? dragState.deltaPixels : 0}
+                    onPointerDown={onUpdateEvent ? handlePointerDown : undefined}
+                    rowHeight={rowHeight}
+                    onMounted={handleEventMounted}
+                  />
+                ))}
               </div>
+            ))}
 
-              {/* Add Event Cursor — hidden during drag */}
-              {hoveredMonth !== null && onAddEvent && !dragState.isDragging && (
-                <div
-                  className="absolute top-[64px] bottom-0 bg-[#FBFBFB]/25 pointer-events-none transition-transform duration-75 ease-out"
-                  style={{
-                    transform: `translateX(${hoveredMonth * scale.monthWidth}px)`,
-                    width: `${scale.monthWidth}px`,
-                  }}
-                />
-              )}
+            {/* Filler: extends vertical grid lines through remaining space.
+                flex-1 lets it fill the scroll container when events are short,
+                and the whole grid scrolls vertically when they aren't. */}
+            <div className="relative border-l border-[#171717] flex-1 min-h-0">
+              <TimelineGrid
+                months={months}
+                onMonthHover={setHoveredMonth}
+                onMonthClick={handleMonthClick}
+                scale={scale}
+              />
             </div>
+
+            {/* Add Event Cursor — hidden during drag */}
+            {hoveredMonth !== null && onAddEvent && !dragState.isDragging && (
+              <div
+                className="absolute top-[64px] bottom-0 bg-[#FBFBFB]/25 pointer-events-none transition-transform duration-75 ease-out"
+                style={{
+                  transform: `translateX(${hoveredMonth * scale.monthWidth}px)`,
+                  width: `${scale.monthWidth}px`,
+                }}
+              />
+            )}
           </div>
         </div>
 

--- a/src/components/Timeline/TimelineEvent.tsx
+++ b/src/components/Timeline/TimelineEvent.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useRef, useEffect } from 'react';
+import React, { memo, useRef, useEffect, useState, useLayoutEffect } from 'react';
 import { TimelineEvent as ITimelineEvent } from '../../types/event';
 import { Month, TimelineScale } from '../../types/timeline';
 import { EVENT_ROW_HEIGHT, EVENT_MIN_WIDTH } from '../../constants/timeline';
@@ -13,7 +13,11 @@ interface TimelineEventProps {
   isDragging?: boolean;
   dragDeltaPixels?: number;
   onPointerDown?: (eventId: string, e: React.PointerEvent) => void;
+  rowHeight?: number;
+  onMounted?: (eventId: string, node: HTMLDivElement | null) => void;
 }
+
+const STACK_TRANSITION_MS = 220;
 
 export const TimelineEvent = memo(function TimelineEvent({
   event,
@@ -23,8 +27,50 @@ export const TimelineEvent = memo(function TimelineEvent({
   isDragging = false,
   dragDeltaPixels = 0,
   onPointerDown,
+  rowHeight = EVENT_ROW_HEIGHT,
+  onMounted,
 }: TimelineEventProps) {
   const wasDraggingRef = useRef(false);
+  const elementRef = useRef<HTMLDivElement | null>(null);
+
+  // FLIP-style transition when stackIndex changes between renders.
+  // Phase progression: 'idle' -> 'jumping' (transform = oldDelta, no transition)
+  // -> 'animating' (transform = 0, with transition) -> 'idle'.
+  const [animPhase, setAnimPhase] = useState<'idle' | 'jumping' | 'animating'>('idle');
+  const [animOffset, setAnimOffset] = useState(0);
+  const lastSeenStackRef = useRef(event.stackIndex);
+
+  useLayoutEffect(() => {
+    const prev = lastSeenStackRef.current;
+    if (prev !== event.stackIndex && !isDragging) {
+      const delta = (prev - event.stackIndex) * rowHeight;
+      if (delta !== 0) {
+        setAnimOffset(delta);
+        setAnimPhase('jumping');
+      }
+    }
+    lastSeenStackRef.current = event.stackIndex;
+  }, [event.stackIndex, rowHeight, isDragging]);
+
+  useLayoutEffect(() => {
+    if (animPhase !== 'jumping') return;
+    // Two RAFs: first lets the browser commit the "jumped" frame with no
+    // transition, second flips into the animating frame with transition on.
+    const id1 = requestAnimationFrame(() => {
+      const id2 = requestAnimationFrame(() => {
+        setAnimPhase('animating');
+        setAnimOffset(0);
+      });
+      // Stash so cleanup can cancel either pending frame.
+      cleanupRef.current = id2;
+    });
+    cleanupRef.current = id1;
+    return () => {
+      if (cleanupRef.current !== null) cancelAnimationFrame(cleanupRef.current);
+    };
+  }, [animPhase]);
+
+  const cleanupRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (isDragging) {
@@ -75,6 +121,18 @@ export const TimelineEvent = memo(function TimelineEvent({
     }
   };
 
+  const setRef = (node: HTMLDivElement | null) => {
+    elementRef.current = node;
+    if (onMounted) onMounted(event.id, node);
+  };
+
+  const handleTransitionEnd = (e: React.TransitionEvent<HTMLDivElement>) => {
+    if (e.propertyName === 'transform' && animPhase === 'animating') {
+      setAnimPhase('idle');
+      setAnimOffset(0);
+    }
+  };
+
   const eventContent = (
     <div
       className="flex items-center h-full w-full rounded"
@@ -92,6 +150,21 @@ export const TimelineEvent = memo(function TimelineEvent({
       </div>
     </div>
   );
+
+  // Build the transform/transition for the main element. Drag takes priority
+  // over the stack-reflow transition (the dragged event animates separately).
+  let transform: string | undefined;
+  let transition: string | undefined;
+  if (isDragging) {
+    transform = `translateX(${dragDeltaPixels}px) scale(1.04)`;
+    transition = 'box-shadow 150ms ease, opacity 150ms ease';
+  } else if (animPhase === 'jumping') {
+    transform = `translateY(${animOffset}px)`;
+    transition = 'none';
+  } else if (animPhase === 'animating') {
+    transform = 'translateY(0px)';
+    transition = `transform ${STACK_TRANSITION_MS}ms ease`;
+  }
 
   return (
     <>
@@ -115,6 +188,7 @@ export const TimelineEvent = memo(function TimelineEvent({
 
       {/* Main event element */}
       <div
+        ref={setRef}
         className={`flex items-center text-text-secondary hover:text-text-primary group rounded p-0.5 ${
           isDragging ? 'select-none' : 'transition-colors hover:brightness-110'
         } ${isDraggable ? (isDragging ? 'cursor-grabbing' : 'cursor-grab') : 'cursor-pointer'}`}
@@ -125,20 +199,17 @@ export const TimelineEvent = memo(function TimelineEvent({
           minWidth: `${EVENT_MIN_WIDTH}px`,
           height: `${EVENT_ROW_HEIGHT}px`,
           zIndex: isDragging ? 1000 : event.stackIndex + 1,
-          transform: isDragging
-            ? `translateX(${dragDeltaPixels}px) scale(1.04)`
-            : undefined,
+          transform,
           boxShadow: isDragging
             ? '0 8px 24px rgba(0, 0, 0, 0.45)'
             : undefined,
           opacity: isDragging ? 0.92 : 1,
-          transition: isDragging
-            ? 'box-shadow 150ms ease, opacity 150ms ease'
-            : undefined,
+          transition,
         }}
         onClick={handleClick}
         onPointerDown={handlePointerDown}
         onDragStart={(e) => e.preventDefault()}
+        onTransitionEnd={handleTransitionEnd}
         title={`${event.title} (${event.startDate}${event.endDate !== event.startDate ? ` to ${event.endDate}` : ''})`}
       >
         {eventContent}

--- a/src/components/TimelineViewer/TimelineViewer.tsx
+++ b/src/components/TimelineViewer/TimelineViewer.tsx
@@ -14,6 +14,7 @@ interface TimelineData {
   events: TimelineEvent[];
   categories: CategoryConfig[];
   scale: 'large' | 'small';
+  groupByCategory: boolean;
 }
 
 export function TimelineViewer() {
@@ -50,7 +51,8 @@ export function TimelineViewer() {
             description: draft.description || '',
             events: draft.events || [],
             categories,
-            scale: draft.scale || 'large'
+            scale: draft.scale || 'large',
+            groupByCategory: draft.groupByCategory ?? false
           });
         } catch {
           setError('Failed to load local draft');
@@ -104,7 +106,8 @@ export function TimelineViewer() {
           description: timelineData.description || '',
           events: formattedEvents,
           categories: categories,
-          scale: timelineData.scale || 'large'
+          scale: timelineData.scale || 'large',
+          groupByCategory: timelineData.group_by_category ?? false
         });
       } catch (err) {
         console.error('Error loading timeline:', err);
@@ -162,10 +165,11 @@ export function TimelineViewer() {
       </div>
 
       <main className="timeline-container relative mt-4">
-        <Timeline 
+        <Timeline
           events={timeline.events}
           categories={timeline.categories}
           scale={SCALES[timeline.scale]}
+          groupByCategory={timeline.groupByCategory}
         />
       </main>
     </div>

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -12,6 +12,7 @@ interface TimelineData {
   events: TimelineEvent[];
   categories: CategoryConfig[];
   scale: 'large' | 'small';
+  groupByCategory: boolean;
 }
 
 export function useAutosave(timelineData: TimelineData) {
@@ -32,6 +33,7 @@ export function useAutosave(timelineData: TimelineData) {
           title: data.title,
           description: data.description,
           scale: data.scale,
+          group_by_category: data.groupByCategory,
           updated_at: new Date().toISOString()
         })
         .eq('id', data.id);

--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -9,12 +9,13 @@ export interface AddEventsResult {
 export function useEvents() {
   const [events, setEvents] = useState<TimelineEvent[]>([]);
 
-  const addEvent = useCallback((event: Omit<TimelineEvent, 'id'>) => {
+  const addEvent = useCallback((event: Omit<TimelineEvent, 'id'>): TimelineEvent => {
     const newEvent: TimelineEvent = {
       ...event,
       id: crypto.randomUUID(),
     };
     setEvents(prev => [...prev, newEvent]);
+    return newEvent;
   }, []);
 
   const updateEvent = useCallback((updatedEvent: TimelineEvent) => {

--- a/src/hooks/useGroupByCategory.ts
+++ b/src/hooks/useGroupByCategory.ts
@@ -1,0 +1,14 @@
+import { useState, useCallback } from 'react'
+
+export function useGroupByCategory(initial = false) {
+  const [groupByCategory, setGroupByCategory] = useState<boolean>(initial)
+
+  const handleGroupByCategoryChange = useCallback((value: boolean) => {
+    setGroupByCategory(value)
+  }, [])
+
+  return {
+    groupByCategory,
+    handleGroupByCategoryChange,
+  }
+}

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -40,6 +40,8 @@ interface TimelineData {
   description?: string;
   events: TimelineEvent[];
   categories?: CategoryConfig[];
+  scale?: 'large' | 'small';
+  groupByCategory?: boolean;
 }
 
 export function useTimeline() {
@@ -114,7 +116,9 @@ export function useTimeline() {
           title: DEFAULT_TIMELINE_TITLE,
           description: '',
           events: [],
-          categories: undefined // Will use default categories
+          categories: undefined, // Will use default categories
+          scale: 'large',
+          groupByCategory: false
         };
       }
 
@@ -153,7 +157,9 @@ export function useTimeline() {
           endDate: event.end_date,
           category: event.category
         })),
-        categories: categories || undefined
+        categories: categories || undefined,
+        scale: timeline.scale || 'large',
+        groupByCategory: timeline.group_by_category ?? false
       };
     } catch (error) {
       // Reset timelineId if there was an error

--- a/src/hooks/useTimelineState.ts
+++ b/src/hooks/useTimelineState.ts
@@ -2,16 +2,18 @@ import { useEvents } from './useEvents'
 import { useTimelineTitle } from './useTimelineTitle'
 import { useCategories } from './useCategories'
 import { useTimelineScale } from './useTimelineScale'
+import { useGroupByCategory } from './useGroupByCategory'
 
 export function useTimelineState() {
   const { events, addEvent, addEvents, clearEvents, setEvents, updateEvent } = useEvents()
   const { title, description, setTitle, setDescription, resetTitle } = useTimelineTitle()
   const { categories, updateCategories, resetCategories } = useCategories()
   const { scale, currentScale, handleScaleChange } = useTimelineScale()
+  const { groupByCategory, handleGroupByCategoryChange } = useGroupByCategory()
 
   return {
     // State
-    events, title, description, categories, scale, currentScale,
+    events, title, description, categories, scale, currentScale, groupByCategory,
     // Event actions
     addEvent, addEvents, clearEvents, setEvents, updateEvent,
     // Title actions
@@ -20,5 +22,7 @@ export function useTimelineState() {
     updateCategories, resetCategories,
     // Scale actions
     handleScaleChange,
+    // Layout actions
+    handleGroupByCategoryChange,
   }
 }

--- a/src/utils/draftStorage.ts
+++ b/src/utils/draftStorage.ts
@@ -10,6 +10,7 @@ export interface LocalDraft {
   events: TimelineEvent[]
   categories: CategoryConfig[]
   scale: 'large' | 'small'
+  groupByCategory?: boolean
   savedAt: string
 }
 
@@ -81,6 +82,7 @@ export function createDraft(): LocalDraft | null {
     events: [],
     categories: [...DEFAULT_CATEGORIES],
     scale: 'large',
+    groupByCategory: false,
     savedAt: new Date().toISOString(),
   }
 

--- a/src/utils/eventStacking.ts
+++ b/src/utils/eventStacking.ts
@@ -10,38 +10,66 @@ interface EventPlacement {
   event: TimelineEvent;
   startColumn: number;
   endColumn: number;
-  visualEndColumn: number; // Includes space needed for title
+  visualEndColumn: number; // Includes space needed for title + trailing buffer
   stackIndex: number;
+}
+
+// Pixel chrome inside the event row preceding/following the title text:
+// outer p-0.5 (2px) + inner 2px + color bar 8px + pl-1 (4px) before the text,
+// plus inner 2px + outer 2px after.
+const TITLE_CHROME_WIDTH = 20;
+// Empty horizontal space reserved after each event so adjacent same-row
+// events don't visually touch.
+const TRAILING_BUFFER_PX = 24;
+// Font matches the .body-lg class applied to the event title in TimelineEvent.tsx.
+const TITLE_FONT = '400 16px Avenir, sans-serif';
+
+let measureCanvas: HTMLCanvasElement | null = null;
+let measureCtx: CanvasRenderingContext2D | null = null;
+
+function measureTextWidth(text: string): number {
+  if (typeof document === 'undefined') {
+    // SSR / non-browser fallback: approximate at ~8px per character.
+    return text.length * 8;
+  }
+  if (!measureCtx) {
+    measureCanvas = document.createElement('canvas');
+    measureCtx = measureCanvas.getContext('2d');
+    if (measureCtx) measureCtx.font = TITLE_FONT;
+  }
+  if (!measureCtx) return text.length * 8;
+  return measureCtx.measureText(text).width;
 }
 
 function getEventColumns(event: TimelineEvent, months: Month[]): { start: number; end: number } {
   if (!months?.length) return { start: 0, end: 0 };
-  
+
   const startDate = new Date(event.startDate);
   const endDate = new Date(event.endDate);
-  
+
   const startIndex = months.findIndex(
     m => m.year === startDate.getFullYear() && m.month === startDate.getMonth()
   );
-  
+
   const endIndex = months.findIndex(
     m => m.year === endDate.getFullYear() && m.month === endDate.getMonth()
   );
-  
+
   return {
     start: Math.max(0, startIndex),
     end: Math.min(months.length - 1, endIndex)
   };
 }
 
-function calculateTitleWidth(title: string, monthWidth: number): number {
-  // Calculate columns needed for title
-  const titleWidth = Math.max(EVENT_MIN_WIDTH, title.length * 8); // 8px per character approximation
-  return Math.ceil(titleWidth / monthWidth);
+function calculateRequiredColumns(title: string, monthWidth: number): number {
+  const textPx = measureTextWidth(title);
+  const displayPx = Math.max(EVENT_MIN_WIDTH, textPx + TITLE_CHROME_WIDTH);
+  const requiredPx = displayPx + TRAILING_BUFFER_PX;
+  return Math.ceil(requiredPx / monthWidth);
 }
 
 function hasCollision(placement: EventPlacement, existingPlacements: EventPlacement[]): boolean {
-  return existingPlacements.some(existing => 
+  return existingPlacements.some(existing =>
     existing.stackIndex === placement.stackIndex && // Same row
     placement.startColumn <= existing.visualEndColumn && // New event starts before existing ends
     existing.startColumn <= placement.visualEndColumn // Existing event starts before new ends
@@ -51,16 +79,12 @@ function hasCollision(placement: EventPlacement, existingPlacements: EventPlacem
 export function calculateEventStacks(events: TimelineEvent[], months: Month[] = [], monthWidth: number = 28): StackedEvent[] {
   if (!events?.length) return [];
 
-  // Sort events by start date, then by duration (shorter events first)
+  // Sort events by start date only — earlier events get the top rows.
+  // Stable sort preserves array order for equal start dates.
   const sortedEvents = [...events].sort((a, b) => {
     const aStart = new Date(a.startDate).getTime();
     const bStart = new Date(b.startDate).getTime();
-    
-    if (aStart !== bStart) return aStart - bStart;
-    
-    const aDuration = new Date(a.endDate).getTime() - aStart;
-    const bDuration = new Date(b.endDate).getTime() - bStart;
-    return aDuration - bDuration;
+    return aStart - bStart;
   });
 
   const placements: EventPlacement[] = [];
@@ -69,14 +93,14 @@ export function calculateEventStacks(events: TimelineEvent[], months: Month[] = 
   for (const event of sortedEvents) {
     // Calculate columns for date span
     const { start: startColumn, end: endColumn } = getEventColumns(event, months);
-    
-    // Calculate columns needed for title
-    const titleColumns = calculateTitleWidth(event.title, monthWidth);
-    
-    // Calculate total visual space needed (max of date span and title width)
+
+    // Total visual span the event occupies (title + chrome + trailing buffer).
+    const requiredColumns = calculateRequiredColumns(event.title, monthWidth);
+
+    // Use the larger of the date span or the title-driven span.
     const visualEndColumn = Math.max(
       endColumn,
-      startColumn + titleColumns - 1
+      startColumn + requiredColumns - 1
     );
 
     // Find first available row from top

--- a/supabase/migrations/20260418000000_add_group_by_category.sql
+++ b/supabase/migrations/20260418000000_add_group_by_category.sql
@@ -1,0 +1,19 @@
+/*
+  # Add group_by_category column to timelines table
+
+  1. Changes
+    - Add `group_by_category` boolean column to `timelines` table with default false
+    - Idempotent: only adds the column if it does not already exist
+*/
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'timelines'
+    AND column_name = 'group_by_category'
+  ) THEN
+    ALTER TABLE timelines
+    ADD COLUMN group_by_category boolean NOT NULL DEFAULT false;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
This PR introduces a new "group by category" layout mode for the timeline and significantly improves event stacking calculations with better text measurement and collision detection.

## Key Changes

### Layout & Display
- **New `groupByCategory` prop**: Added toggle to switch between two layout modes:
  - `true`: Events stack within their category band (preserves category separation)
  - `false` (default): All events pack into a single global stack at the top
- **Dynamic row height**: Uses `EVENT_HEIGHT` when grouped, `EVENT_ROW_HEIGHT` when global
- **Conditional category labels**: Only shown when `groupByCategory` is enabled
- **Refactored layout computation**: Replaced `categoryData` with `LayoutData` interface containing `bands` array for unified handling of both modes

### Event Stacking Algorithm
- **Improved text measurement**: Added canvas-based text width measurement using actual font metrics (`TITLE_FONT = '400 16px Avenir, sans-serif'`) instead of character approximation
- **Better collision detection**: Now accounts for:
  - Title chrome width (padding, color bar, etc.) = 20px
  - Trailing buffer between events = 24px
  - Actual rendered text width via canvas measurement
- **Simplified sorting**: Events now sort by start date only (removed duration-based secondary sort) for more predictable stacking
- **Accurate column calculation**: `calculateRequiredColumns()` now properly computes visual space needed for title + chrome + buffer

### Event Animation & Interaction
- **FLIP-style stack transitions**: When `stackIndex` changes, events smoothly animate to new positions using:
  - `jumping` phase: Apply transform without transition
  - `animating` phase: Animate transform to 0 with 220ms ease
  - `idle` phase: Complete
- **Event mounting callback**: New `onMounted` prop allows parent to scroll newly-created events into view
- **Improved drag handling**: Drag state takes priority over stack animations; separate visual feedback for dragging

### State Management
- **New `useGroupByCategory` hook**: Manages toggle state
- **Updated `useTimelineState`**: Integrated group-by-category state
- **Persistence**: Added `groupByCategory` to:
  - Timeline data model
  - Local draft storage
  - Autosave
  - Supabase schema (new migration)

### UI Updates
- **Settings panel**: Added toggle control with description explaining the two modes
- **Header integration**: Wired up group-by-category state throughout the app
- **Type updates**: Enhanced `TimelineProps`, `TimelineEventProps`, and data interfaces

### Database
- **Migration**: Added `group_by_category` boolean column to `timelines` table with default `false`

## Notable Implementation Details
- Text measurement gracefully falls back to character approximation (8px/char) in SSR/non-browser environments
- Canvas context is cached to avoid repeated creation
- Event `onAddEvent` callback now returns `ITimelineEvent | void` to support scroll-to-new-event workflow
- Transition cleanup properly cancels pending animation frames to prevent memory leaks

https://claude.ai/code/session_01YPzBTrVQGk74HSjPQf9ukM