### PR TITLE
Adjust GlobalNav height and title cluster layout

### DIFF
--- a/src/components/Navigation/GlobalNav.tsx
+++ b/src/components/Navigation/GlobalNav.tsx
@@ -61,7 +61,7 @@ export function GlobalNav({
     <div>
       <div className="flex h-[80px] items-start gap-5 px-6 py-[22px] relative">
         {/* Left cluster: panel toggle + optional timeline identity */}
-        <div className="flex items-center gap-5 min-w-0">
+        <div className="flex items-start gap-5 min-w-0">
           <div
             className={`shrink-0 overflow-visible transition-[max-width,opacity,margin] duration-300 ease-out ${
               isPanelOpen ? 'max-w-0 opacity-0 pointer-events-none -ml-5' : 'max-w-[48px] opacity-100'
@@ -93,16 +93,16 @@ export function GlobalNav({
                   placeholder="Untitled Timeline"
                   aria-label="Timeline name"
                   size={Math.max((timelineTitle ?? '').length, 'Untitled Timeline'.length)}
-                  className="font-['Aleo',serif] font-normal text-[18px] leading-[1.4] text-[#9b9ea3] hover:text-[#c9ced4] focus:text-[#dadee5] bg-transparent border-none outline-none caret-white min-w-0 p-0"
+                  className="font-['Aleo',serif] font-normal text-[18px] leading-[1.4] text-text-secondary hover:text-text-primary focus:text-text-primary bg-transparent border-none outline-none caret-white min-w-0 p-0"
                   style={{ fieldSizing: 'content' } as CSSProperties}
                 />
               ) : (
-                <p className="font-['Aleo',serif] font-normal text-[18px] leading-[1.4] text-[#9b9ea3] truncate">
+                <p className="font-['Aleo',serif] font-normal text-[18px] leading-[1.4] text-text-secondary truncate">
                   {timelineTitle || 'Untitled Timeline'}
                 </p>
               )}
               <div className="flex items-center gap-2 shrink-0">
-                <span className="font-['JetBrains_Mono',monospace] font-light text-[12px] leading-[1.4] text-[#c9ced4] whitespace-nowrap">
+                <span className="font-['JetBrains_Mono',monospace] font-light text-[12px] leading-[1.4] text-text-tertiary whitespace-nowrap">
                   {yearRange}
                 </span>
                 <span
@@ -110,7 +110,7 @@ export function GlobalNav({
                   style={{ backgroundColor: timelineAccentColor }}
                   aria-hidden
                 />
-                <span className="font-['JetBrains_Mono',monospace] font-light text-[12px] leading-[1.4] text-[#c9ced4] whitespace-nowrap">
+                <span className="font-['JetBrains_Mono',monospace] font-light text-[12px] leading-[1.4] text-text-tertiary whitespace-nowrap">
                   {eventCountLabel}
                 </span>
               </div>

--- a/src/components/Navigation/GlobalNav.tsx
+++ b/src/components/Navigation/GlobalNav.tsx
@@ -59,7 +59,7 @@ export function GlobalNav({
 
   return (
     <div>
-      <div className="flex h-[64px] items-center gap-5 px-6 py-4 relative">
+      <div className="flex h-[80px] items-start gap-5 px-6 py-[22px] relative">
         {/* Left cluster: panel toggle + optional timeline identity */}
         <div className="flex items-center gap-5 min-w-0">
           <div
@@ -79,7 +79,7 @@ export function GlobalNav({
           </div>
 
           {showTitleCluster && (
-            <div className="flex items-center gap-6 min-w-0">
+            <div className="flex flex-col gap-1 min-w-0">
               {onTimelineTitleChange ? (
                 <input
                   type="text"

--- a/src/components/Navigation/GlobalNav.tsx
+++ b/src/components/Navigation/GlobalNav.tsx
@@ -102,7 +102,7 @@ export function GlobalNav({
                 </p>
               )}
               <div className="flex items-center gap-2 shrink-0">
-                <span className="font-['JetBrains_Mono',monospace] font-light text-[12px] leading-[1.4] text-text-tertiary whitespace-nowrap">
+                <span className="label-s-type1 text-text-tertiary whitespace-nowrap">
                   {yearRange}
                 </span>
                 <span
@@ -110,7 +110,7 @@ export function GlobalNav({
                   style={{ backgroundColor: timelineAccentColor }}
                   aria-hidden
                 />
-                <span className="font-['JetBrains_Mono',monospace] font-light text-[12px] leading-[1.4] text-text-tertiary whitespace-nowrap">
+                <span className="label-s-type1 text-text-tertiary whitespace-nowrap">
                   {eventCountLabel}
                 </span>
               </div>


### PR DESCRIPTION
## Summary
Updated the GlobalNav component's styling to increase the header height and reorganize the title cluster layout for better visual hierarchy and spacing.

## Key Changes
- Increased header height from 64px to 80px and adjusted vertical padding from `py-4` to `py-[22px]`
- Changed header items alignment from `items-center` to `items-start` to accommodate the taller header
- Converted title cluster from horizontal flex layout (`flex items-center gap-6`) to vertical flex layout (`flex flex-col gap-1`) for improved readability and organization

## Implementation Details
These changes appear to be part of a UI refinement to give the navigation header more breathing room and reorganize how the timeline title information is displayed, moving from a side-by-side arrangement to a stacked vertical arrangement with tighter spacing.

https://claude.ai/code/session_01ThYz8iLwjP7NfDq6wuJnFC