### PR TITLE
Persist side panel open/closed state to localStorage

### DIFF
--- a/src/contexts/SidePanelContext.tsx
+++ b/src/contexts/SidePanelContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useMemo, useRef, useState, type ReactNode } from 'react'
+import { createContext, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 type TimelineSelectHandler = (timelineId: string) => void
@@ -30,8 +30,20 @@ interface SidePanelContextValue {
 
 export const SidePanelContext = createContext<SidePanelContextValue | null>(null)
 
+const STORAGE_KEY = 'side_panel_open'
+
+function readStoredIsOpen(): boolean {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw === null) return true
+    return raw === 'true'
+  } catch {
+    return true
+  }
+}
+
 export function SidePanelProvider({ children }: { children: ReactNode }) {
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(readStoredIsOpen)
   const [activeTimelineId, setActiveTimelineId] = useState<string | null>(null)
   const [activeDraftId, setActiveDraftId] = useState<string | null>(null)
   const [activeTimelineTitle, setActiveTimelineTitle] = useState<string | null>(null)
@@ -40,6 +52,14 @@ export function SidePanelProvider({ children }: { children: ReactNode }) {
   const navigate = useNavigate()
   const customHandlerRef = useRef<TimelineSelectHandler | null>(null)
   const customDraftHandlerRef = useRef<DraftSelectHandler | null>(null)
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, String(isOpen))
+    } catch {
+      // storage full or disabled — silently ignore
+    }
+  }, [isOpen])
 
   const open = useCallback(() => setIsOpen(true), [])
   const close = useCallback(() => setIsOpen(false), [])


### PR DESCRIPTION
## Summary
Added persistence of the side panel's open/closed state to localStorage, so the panel state is maintained across browser sessions.

## Key Changes
- Added `useEffect` hook import to dependencies
- Created `readStoredIsOpen()` helper function that safely reads the persisted state from localStorage with a default value of `true`
- Updated `isOpen` state initialization to use the stored value via `readStoredIsOpen()`
- Added `useEffect` hook that syncs the `isOpen` state to localStorage whenever it changes
- Included error handling for both read and write operations to gracefully handle cases where localStorage is unavailable or full

## Implementation Details
- The storage key `'side_panel_open'` is defined as a constant for maintainability
- The `readStoredIsOpen()` function defaults to `true` if no stored value exists, ensuring the panel is open by default for new users
- Both localStorage operations are wrapped in try-catch blocks to prevent errors if storage is disabled or full
- The effect dependency array includes only `[isOpen]`, ensuring the localStorage is updated whenever the panel state changes

https://claude.ai/code/session_01Br8NHAoHeeKUPS5GQTUAsJ