### PR TITLE
Refactor settings panel UI and add timeline deletion feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,8 @@ import { UnsavedChangesModal } from './components/Modal/UnsavedChangesModal';
 import { useLocalDraft } from './hooks/useLocalDraft';
 import { TimelineEvent, CategoryConfig } from './types/event';
 import { LimitReachedError, getCurrentLimits } from './lib/limits';
+import { supabase } from './lib/supabase';
+import { DEFAULT_TIMELINE_TITLE } from './constants/defaults';
 
 function limitReachedMessage(kind: 'event' | 'timeline'): string {
   const { eventLimit, timelineLimit } = getCurrentLimits();
@@ -44,7 +46,7 @@ export function App() {
   const [draftHydrated, setDraftHydrated] = useState(false);
   const [nudgeDismissed, setNudgeDismissed] = useState(false);
   const [activeDraftId, setActiveDraftId] = useState<string | null>(null);
-  const { loadAllDrafts, loadDraft, saveDraft, saveDraftImmediate, createDraft, clearAllDrafts } = useLocalDraft();
+  const { loadAllDrafts, loadDraft, saveDraft, saveDraftImmediate, createDraft, clearAllDrafts, deleteDraft: deleteLocalDraft } = useLocalDraft();
   const handledRouteStateRef = useRef(false);
   const migrationDoneRef = useRef(false);
   const { setOnTimelineSelect, setOnDraftSelect, setActiveTimelineId, setActiveDraftId: setPanelActiveDraftId, setActiveTimelineTitle, setActiveEventCount, setActiveDominantCategoryColor } = useSidePanel();
@@ -463,6 +465,32 @@ export function App() {
     clearEvents();
   };
 
+  const handleDeleteTimeline = async () => {
+    try {
+      if (user && timelineId) {
+        const { error: deleteError } = await supabase
+          .from('timelines')
+          .delete()
+          .eq('id', timelineId);
+        if (deleteError) throw deleteError;
+      } else if (activeDraftId) {
+        deleteLocalDraft(activeDraftId);
+      }
+    } catch (err) {
+      console.error('Failed to delete timeline:', err);
+      alert('Failed to delete. Please try again.');
+      return;
+    }
+
+    setTitle(DEFAULT_TIMELINE_TITLE);
+    setDescription('');
+    setEvents([]);
+    resetCategories();
+    setActiveDraftId(null);
+    setActivePanel(null);
+    routerNavigate('/');
+  };
+
   const handleUpdateEvent = (updatedEvent: TimelineEvent) => {
     updateEvent(updatedEvent);
   };
@@ -519,6 +547,7 @@ export function App() {
         showAddEventModal={showAddEventModal}
         onAddEventClick={handleAddEventClick}
         onCloseAddEventModal={() => setShowAddEventModal(false)}
+        onDeleteTimeline={handleDeleteTimeline}
       />
       {!user && events.length > 0 && !nudgeDismissed && (
         <div className="mx-4 mt-2 px-4 py-3 bg-blue-900/40 border border-blue-800/50 rounded-lg flex items-center justify-between text-sm shrink-0">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,7 +49,7 @@ export function App() {
   const { loadAllDrafts, loadDraft, saveDraft, saveDraftImmediate, createDraft, clearAllDrafts, deleteDraft: deleteLocalDraft } = useLocalDraft();
   const handledRouteStateRef = useRef(false);
   const migrationDoneRef = useRef(false);
-  const { setOnTimelineSelect, setOnDraftSelect, setActiveTimelineId, setActiveDraftId: setPanelActiveDraftId, setActiveTimelineTitle, setActiveEventCount, setActiveDominantCategoryColor } = useSidePanel();
+  const { setOnTimelineSelect, setOnDraftSelect, refreshTimelines, setActiveTimelineId, setActiveDraftId: setPanelActiveDraftId, setActiveTimelineTitle, setActiveEventCount, setActiveDominantCategoryColor } = useSidePanel();
 
   const timelineData = {
     id: timelineId,
@@ -276,9 +276,18 @@ export function App() {
       handleGroupByCategoryChange(newGroupByCategory ?? false);
     } catch (error) {
       console.error('Error switching timeline:', error);
+      // `.single()` returns PGRST116 when the row doesn't exist — that's the
+      // "stale tile pointing at a deleted timeline" case. Land the user back
+      // on home quietly rather than stranding them in /editor with an alert.
+      const code = (error as { code?: string } | null)?.code;
+      if (code === 'PGRST116') {
+        setActiveTimelineId(null);
+        routerNavigate('/', { replace: true });
+        return;
+      }
       alert('Failed to load timeline. Please try again.');
     }
-  }, [loadTimeline, setTitle, setDescription, setEvents, updateCategories, resetCategories, handleScaleChange, handleGroupByCategoryChange]);
+  }, [loadTimeline, setTitle, setDescription, setEvents, updateCategories, resetCategories, handleScaleChange, handleGroupByCategoryChange, routerNavigate, setActiveTimelineId]);
 
   // Handle navigation from AI mode or the side panel with a specific timeline to load
   useEffect(() => {
@@ -481,6 +490,12 @@ export function App() {
       alert('Failed to delete. Please try again.');
       return;
     }
+
+    // Clear the side panel's active id first so the synthetic-row fallback
+    // can't keep the deleted tile visible, then force a refetch — the
+    // realtime DELETE event isn't fast enough to rely on here.
+    setActiveTimelineId(null);
+    refreshTimelines();
 
     setTitle(DEFAULT_TIMELINE_TITLE);
     setDescription('');

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -32,6 +32,7 @@ interface HeaderProps {
   showAddEventModal: boolean;
   onAddEventClick: () => void;
   onCloseAddEventModal: () => void;
+  onDeleteTimeline: () => Promise<void> | void;
 }
 
 export function Header({
@@ -55,6 +56,7 @@ export function Header({
   showAddEventModal,
   onAddEventClick,
   onCloseAddEventModal,
+  onDeleteTimeline,
 }: HeaderProps) {
   const closePanel = () => onActivePanelChange(null);
   const togglePanel = (panel: 'events' | 'settings') => {
@@ -108,6 +110,7 @@ export function Header({
         onScaleChange={onScaleChange}
         groupByCategory={groupByCategory}
         onGroupByCategoryChange={onGroupByCategoryChange}
+        onDeleteTimeline={onDeleteTimeline}
       />
 
       <EventTableEditor

--- a/src/components/Settings/ScaleSelector.tsx
+++ b/src/components/Settings/ScaleSelector.tsx
@@ -1,7 +1,3 @@
-import React from 'react';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
-
 interface ScaleSelectorProps {
   value: 'large' | 'small';
   onChange: (scale: 'large' | 'small') => void;
@@ -14,27 +10,29 @@ export function ScaleSelector({ value, onChange }: ScaleSelectorProps) {
     }
   };
 
+  const tabClass = (active: boolean) =>
+    `flex items-center justify-center w-[60px] min-w-[60px] h-8 px-3 py-1.5 rounded-[6px] transition-colors body-m ${
+      active
+        ? 'bg-[#262626] text-[#C9CED4]'
+        : 'bg-transparent text-[#9B9EA3] hover:text-[#C9CED4]'
+    }`;
+
   return (
-    <div className="space-y-2">
-      <Label>Timeline Scale</Label>
-      <div className="flex bg-secondary rounded-lg p-1">
-        <Button
-          type="button"
-          variant={value === 'large' ? 'default' : 'ghost'}
-          onClick={() => handleScaleChange('large')}
-          className="flex-1"
-        >
-          Large
-        </Button>
-        <Button
-          type="button"
-          variant={value === 'small' ? 'default' : 'ghost'}
-          onClick={() => handleScaleChange('small')}
-          className="flex-1"
-        >
-          Small
-        </Button>
-      </div>
+    <div className="flex flex-row items-start p-1 w-[128px] h-10 bg-[#171717] border border-[#262626] rounded-[10px]">
+      <button
+        type="button"
+        onClick={() => handleScaleChange('small')}
+        className={tabClass(value === 'small')}
+      >
+        Small
+      </button>
+      <button
+        type="button"
+        onClick={() => handleScaleChange('large')}
+        className={tabClass(value === 'large')}
+      >
+        Large
+      </button>
     </div>
   );
 }

--- a/src/components/Settings/TimelineSettingsPanel.tsx
+++ b/src/components/Settings/TimelineSettingsPanel.tsx
@@ -1,13 +1,14 @@
-import React, { useState, useEffect } from 'react';
-import { FileDown, FileUp, Trash2, RotateCcw, Download } from 'lucide-react';
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X, FileSpreadsheet, Download, Trash2 } from 'lucide-react';
 import { TimelineEvent, CategoryConfig } from '../../types/event';
 import type { AddEventsResult } from '../../hooks/useEvents';
 import { exportEventsToExcel } from '../../utils/excelExport';
 import { ConfirmationModal } from '../Modal/ConfirmationModal';
 import { ScaleSelector } from './ScaleSelector';
+import { SidePanelActionButton } from '../SidePanel/SidePanelActionButton';
 import { DEFAULT_TIMELINE_DESCRIPTION } from '../../constants/defaults';
-import { utils, writeFile } from 'xlsx';
-import { read } from 'xlsx';
+import { utils, read } from 'xlsx';
 
 interface ExcelRow {
   'Event Title'?: string;
@@ -15,16 +16,6 @@ interface ExcelRow {
   'End Date'?: string | number | Date;
   'Category'?: string;
 }
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription,
-} from '@/components/ui/sheet';
 
 interface TimelineSettingsPanelProps {
   isOpen: boolean;
@@ -42,6 +33,7 @@ interface TimelineSettingsPanelProps {
   onGroupByCategoryChange: (value: boolean) => void;
   categories: CategoryConfig[];
   onCategoriesChange?: (categories: CategoryConfig[]) => void;
+  onDeleteTimeline: () => Promise<void> | void;
 }
 
 export function TimelineSettingsPanel({
@@ -51,7 +43,6 @@ export function TimelineSettingsPanel({
   timelineTitle,
   timelineDescription,
   onImportEvents,
-  onClearTimeline,
   onTitleChange,
   onDescriptionChange,
   scale,
@@ -59,10 +50,10 @@ export function TimelineSettingsPanel({
   groupByCategory,
   onGroupByCategoryChange,
   categories,
+  onDeleteTimeline,
 }: TimelineSettingsPanelProps) {
-  const [showClearConfirmation, setShowClearConfirmation] = useState(false);
-  const [showResetConfirmation, setShowResetConfirmation] = useState(false);
-  const fileInputRef = React.useRef<HTMLInputElement>(null);
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const maxDescriptionLength = 260;
 
   useEffect(() => {
@@ -70,6 +61,15 @@ export function TimelineSettingsPanel({
       onDescriptionChange(DEFAULT_TIMELINE_DESCRIPTION);
     }
   }, [isOpen, timelineDescription, onDescriptionChange]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onTitleChange(e.target.value);
@@ -86,33 +86,6 @@ export function TimelineSettingsPanel({
     exportEventsToExcel(events, timelineTitle);
   };
 
-  const handleDownloadTemplate = () => {
-    const wb = utils.book_new();
-    const headers = ['Event Title', 'Start Date', 'End Date', 'Category'];
-    const instructions = [
-      '55 char limit',
-      'Format: MM/DD/YYYY',
-      'Format: MM/DD/YYYY',
-      'Must match a timeline category'
-    ];
-    const data = [
-      headers,
-      instructions,
-      ['Sample Event 1', '1/15/2024', '1/20/2024', categories[0]?.label || 'Personal Life'],
-      ['Sample Event 2', '10/14/2024', '10/16/2024', categories[1]?.label || 'Career']
-    ];
-    const ws = utils.aoa_to_sheet(data);
-    utils.book_append_sheet(wb, ws, 'Timeline Events');
-    writeFile(wb, 'timeline-template.xlsx');
-  };
-
-  const handleResetData = () => {
-    onClearTimeline();
-    onTitleChange('Timeline');
-    onDescriptionChange('');
-    setShowResetConfirmation(false);
-  };
-
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -124,7 +97,7 @@ export function TimelineSettingsPanel({
         const sheetName = workbook.SheetNames[0];
         const worksheet = workbook.Sheets[sheetName];
         const rows = utils.sheet_to_json<ExcelRow>(worksheet);
-        const events = rows.slice(2).map(row => {
+        const imported = rows.slice(2).map(row => {
           let startDate = '';
           let endDate = '';
           if (row['Start Date']) {
@@ -149,8 +122,8 @@ export function TimelineSettingsPanel({
           };
         }).filter(event => event.title && event.startDate && event.category);
 
-        if (events.length > 0) {
-          const result = onImportEvents(events);
+        if (imported.length > 0) {
+          const result = onImportEvents(imported);
           if (result.added === 0) {
             alert('All events already exist in the timeline');
           }
@@ -170,6 +143,12 @@ export function TimelineSettingsPanel({
     }
   };
 
+  const handleConfirmDelete = async () => {
+    await onDeleteTimeline();
+  };
+
+  if (typeof document === 'undefined') return null;
+
   return (
     <>
       <input
@@ -180,147 +159,135 @@ export function TimelineSettingsPanel({
         style={{ display: 'none' }}
       />
 
-      <Sheet open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
-        <SheetContent side="right" className="w-[400px] min-w-[360px] p-0">
-          <SheetDescription className="sr-only">Timeline settings panel</SheetDescription>
-          <div className="h-full flex flex-col">
-            <SheetHeader className="px-6 py-4 border-b">
-              <SheetTitle className="text-xl font-semibold">Settings</SheetTitle>
-            </SheetHeader>
-
-            <div className="flex-1 overflow-y-auto p-4 space-y-4 scrollbar-hide">
-              <div>
-                <Label htmlFor="timelineTitle">Timeline Title</Label>
-                <Input
-                  type="text"
-                  id="timelineTitle"
-                  value={timelineTitle}
-                  onChange={handleTitleChange}
-                  className="mt-1"
-                />
+      {createPortal(
+        <>
+          <div
+            onClick={onClose}
+            className={`fixed inset-0 z-40 bg-black/50 transition-opacity duration-300 ease-out ${
+              isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
+            }`}
+            aria-hidden="true"
+          />
+          <aside
+            className={`fixed inset-y-0 right-0 z-50 w-[320px] pr-[6px] py-[6px] transition-transform duration-300 ease-out ${
+              isOpen ? 'translate-x-0' : 'translate-x-full'
+            }`}
+            aria-hidden={!isOpen}
+            aria-label="Settings side panel"
+          >
+            <div className="h-full w-full bg-[#171717] rounded-[6px] border border-[#262626] flex flex-col overflow-hidden">
+              {/* Header */}
+              <div className="flex items-center justify-between gap-2 px-5 pt-4 pb-2 border-b border-[#404040] shrink-0">
+                <h2 className="header-xsmall text-[#c9ced4] m-0">Settings</h2>
+                <button
+                  onClick={onClose}
+                  className="relative flex items-center justify-center p-1.5 rounded-lg border border-white/15 bg-white/10 backdrop-blur-[12px] text-[#c9ced4] shadow-[0px_8px_32px_0px_rgba(0,0,0,0.4),inset_0px_1px_0px_0px_rgba(255,255,255,0.1)] hover:bg-white/20 hover:text-[#dadee5] transition-colors"
+                  aria-label="Close settings panel"
+                >
+                  <X size={16} strokeWidth={1.25} />
+                </button>
               </div>
 
-              <div>
-                <Label htmlFor="timelineDescription">
-                  Description <span className="text-muted-foreground">({timelineDescription.length}/{maxDescriptionLength})</span>
-                </Label>
-                <textarea
-                  id="timelineDescription"
-                  value={timelineDescription}
-                  onChange={handleDescriptionChange}
-                  rows={3}
-                  maxLength={maxDescriptionLength}
-                  className="mt-1 w-full px-3 py-2 bg-background rounded-md border border-input focus:border-ring focus:ring-1 focus:ring-ring outline-none resize-none text-foreground"
-                />
-              </div>
-
-              <div className="border-t pt-4">
-                <ScaleSelector value={scale} onChange={onScaleChange} />
-              </div>
-
-              <div className="border-t pt-4">
-                <div className="flex items-start justify-between gap-4">
-                  <div className="space-y-1">
-                    <Label htmlFor="groupByCategoryToggle">Group by category</Label>
-                    <p className="text-xs text-muted-foreground">
-                      When on, events stack within their category band. When off, all events pack to the top of the timeline.
-                    </p>
-                  </div>
-                  <button
-                    id="groupByCategoryToggle"
-                    type="button"
-                    role="switch"
-                    aria-checked={groupByCategory}
-                    onClick={() => onGroupByCategoryChange(!groupByCategory)}
-                    className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors mt-1 ${
-                      groupByCategory ? 'bg-primary' : 'bg-input'
-                    }`}
-                  >
-                    <span
-                      className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-background shadow-lg ring-0 transition-transform ${
-                        groupByCategory ? 'translate-x-5' : 'translate-x-0'
-                      }`}
+              {/* Body */}
+              <div className="flex-1 min-h-0 overflow-y-auto">
+                <div className="flex flex-col px-5 pt-6 pb-2 gap-8 min-h-full">
+                  {/* Title */}
+                  <div>
+                    <label htmlFor="timelineTitle" className="label-m-type2 text-[#9B9EA3] mb-1 block">
+                      Title
+                    </label>
+                    <input
+                      type="text"
+                      id="timelineTitle"
+                      value={timelineTitle}
+                      onChange={handleTitleChange}
+                      className="w-full h-9 bg-[#242526] border border-[#262626] rounded-[8px] px-3 py-[7.5px] body-m text-[#DADEE5] outline-none focus:border-[#404040]"
                     />
-                  </button>
-                </div>
-              </div>
+                  </div>
 
-              <div className="border-t pt-4">
-                <Label>Import / Export</Label>
-                <div className="space-y-2 mt-3">
-                  <Button
-                    variant="outline"
-                    onClick={() => fileInputRef.current?.click()}
-                    className="w-full justify-between px-4 py-3 h-auto"
-                  >
-                    <span>Import Data</span>
-                    <FileUp size={20} className="text-muted-foreground" />
-                  </Button>
+                  {/* Description */}
+                  <div>
+                    <label htmlFor="timelineDescription" className="label-m-type2 text-[#9B9EA3] mb-1 block">
+                      Description <span className="text-muted-foreground">({timelineDescription.length}/{maxDescriptionLength})</span>
+                    </label>
+                    <textarea
+                      id="timelineDescription"
+                      value={timelineDescription}
+                      onChange={handleDescriptionChange}
+                      maxLength={maxDescriptionLength}
+                      className="w-full h-[76px] bg-[#262626] border border-[#262626] rounded-[8px] p-2 body-m text-[#DADEE5] outline-none focus:border-[#404040]"
+                    />
+                  </div>
 
-                  <Button
-                    variant="outline"
-                    onClick={handleDownloadTemplate}
-                    className="w-full justify-between px-4 py-3 h-auto"
-                  >
-                    <span>Download Template to Import Data</span>
-                    <Download size={20} className="text-muted-foreground" />
-                  </Button>
+                  {/* Visual Settings */}
+                  <div className="flex flex-col gap-2.5">
+                    <span className="label-m-type2 text-[#9B9EA3]">Visual Settings</span>
+                    <div className="h-px bg-[#262626] w-full" />
 
-                  <Button
-                    variant="outline"
-                    onClick={handleExportExcel}
-                    className="w-full justify-between px-4 py-3 h-auto"
-                  >
-                    <span>Export Data</span>
-                    <FileDown size={20} className="text-muted-foreground" />
-                  </Button>
-                </div>
-              </div>
+                    {/* Timeline scale row */}
+                    <div className="flex flex-row items-center justify-between h-10">
+                      <span className="label-m-type2 text-[#9B9EA3]">Timeline scale</span>
+                      <ScaleSelector value={scale} onChange={onScaleChange} />
+                    </div>
 
-              <div className="border-t pt-4">
-                <Label>Danger Zone</Label>
-                <div className="space-y-2 mt-3">
-                  <Button
-                    variant="destructive"
-                    onClick={() => setShowClearConfirmation(true)}
-                    className="w-full justify-between px-4 py-3 h-auto"
-                  >
-                    <span>Clear Timeline</span>
-                    <Trash2 size={20} />
-                  </Button>
+                    <div className="h-px bg-[#262626] w-full" />
 
-                  <Button
-                    variant="destructive"
-                    onClick={() => setShowResetConfirmation(true)}
-                    className="w-full justify-between px-4 py-3 h-auto"
-                  >
-                    <span>Reset All Data</span>
-                    <RotateCcw size={20} />
-                  </Button>
+                    {/* Group-by-category row */}
+                    <div className="flex flex-row items-center justify-between h-6 gap-2">
+                      <span className="body-m text-[#9B9EA3]">Group events by category</span>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={groupByCategory}
+                        onClick={() => onGroupByCategoryChange(!groupByCategory)}
+                        className={`relative inline-flex shrink-0 w-11 h-6 rounded-[50px] transition-colors ${
+                          groupByCategory ? 'bg-[#259E23]' : 'bg-[rgba(37,158,35,0.3)]'
+                        }`}
+                      >
+                        <span
+                          className="absolute top-1/2 left-0 w-5 h-5 -translate-y-1/2 rounded-full bg-[#F5F5F5] transition-transform"
+                          style={{ transform: `translate(${groupByCategory ? 22 : 2}px, -50%)` }}
+                        />
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* Spacer */}
+                  <div className="flex-1" />
+
+                  {/* Bottom action group */}
+                  <div className="flex flex-col p-3 -mx-5">
+                    <SidePanelActionButton
+                      icon={FileSpreadsheet}
+                      label="Import Data"
+                      onClick={() => fileInputRef.current?.click()}
+                    />
+                    <SidePanelActionButton
+                      icon={Download}
+                      label="Download Timeline Data"
+                      onClick={handleExportExcel}
+                    />
+                    <SidePanelActionButton
+                      icon={Trash2}
+                      label="Delete Timeline"
+                      onClick={() => setShowDeleteConfirmation(true)}
+                    />
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        </SheetContent>
-      </Sheet>
+          </aside>
+        </>,
+        document.body
+      )}
 
       <ConfirmationModal
-        isOpen={showClearConfirmation}
-        onClose={() => setShowClearConfirmation(false)}
-        onConfirm={onClearTimeline}
-        title="Clear Timeline"
-        message="Are you sure you want to clear the timeline? This action cannot be undone."
-        confirmLabel="Clear Timeline"
-        cancelLabel="Cancel"
-      />
-
-      <ConfirmationModal
-        isOpen={showResetConfirmation}
-        onClose={() => setShowResetConfirmation(false)}
-        onConfirm={handleResetData}
-        title="Reset All Data"
-        message="Are you sure you want to reset all data? This will clear all events and reset the timeline title. This action cannot be undone."
-        confirmLabel="Reset All Data"
+        isOpen={showDeleteConfirmation}
+        onClose={() => setShowDeleteConfirmation(false)}
+        onConfirm={handleConfirmDelete}
+        title="Delete Timeline"
+        message="Are you sure you want to delete this timeline? This action cannot be undone."
+        confirmLabel="Delete Timeline"
         cancelLabel="Cancel"
       />
     </>

--- a/src/components/SidePanel/SidePanelBody.tsx
+++ b/src/components/SidePanel/SidePanelBody.tsx
@@ -262,6 +262,9 @@ export function SidePanelBody() {
 
   const handleDelete = async () => {
     if (!pendingDeleteId || !pendingDeleteKind) return
+    const wasActive = pendingDeleteKind === 'timeline'
+      ? pendingDeleteId === activeTimelineId
+      : pendingDeleteId === activeDraftId
     try {
       if (pendingDeleteKind === 'timeline') {
         const { error: deleteError } = await supabase
@@ -269,18 +272,16 @@ export function SidePanelBody() {
           .delete()
           .eq('id', pendingDeleteId)
         if (deleteError) throw deleteError
-        if (pendingDeleteId === activeTimelineId) {
-          const remaining = timelines.find(t => t.id !== pendingDeleteId)
-          if (remaining) {
-            onTimelineSelect(remaining.id)
-          } else {
-            onTimelineSelect('new')
-          }
-        }
         loadTimelines()
       } else {
         deleteLocalDraft(pendingDeleteId)
         setLocalDrafts(getAllDrafts())
+      }
+      // If the user just deleted the timeline/draft they were viewing in the
+      // editor, land them back on home instead of leaving the deleted content
+      // on screen.
+      if (wasActive) {
+        navigate('/')
       }
     } catch (err) {
       console.error('Failed to delete:', err)

--- a/src/components/SidePanel/SidePanelBody.tsx
+++ b/src/components/SidePanel/SidePanelBody.tsx
@@ -147,7 +147,7 @@ function TileMenuButton({
 export function SidePanelBody() {
   const navigate = useNavigate()
   const { user } = useAuth()
-  const { isOpen, close, onTimelineSelect, onDraftSelect, activeTimelineId, activeDraftId, activeTimelineTitle, activeEventCount, activeDominantCategoryColor } = useSidePanel()
+  const { isOpen, close, onTimelineSelect, onDraftSelect, setRefreshTimelines, activeTimelineId, activeDraftId, activeTimelineTitle, activeEventCount, activeDominantCategoryColor } = useSidePanel()
   const { timelines, isLoading, error, loadTimelines } = useTimelines()
   const [localDrafts, setLocalDrafts] = useState<LocalDraft[]>([])
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
@@ -174,6 +174,14 @@ export function SidePanelBody() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, user])
+
+  // Expose loadTimelines to the context so actions originating outside this
+  // component (e.g. deleting from the editor's settings panel) can force an
+  // immediate refetch instead of waiting on the realtime channel.
+  useEffect(() => {
+    setRefreshTimelines(() => loadTimelines())
+    return () => setRefreshTimelines(null)
+  }, [setRefreshTimelines, loadTimelines])
 
   const rows = useMemo<TileRow[]>(() => {
     const baseRows: TileRow[] = user

--- a/src/contexts/SidePanelContext.tsx
+++ b/src/contexts/SidePanelContext.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 
 type TimelineSelectHandler = (timelineId: string) => void
 type DraftSelectHandler = (draftId: string) => void
+type TimelinesRefreshHandler = () => void
 
 interface SidePanelContextValue {
   isOpen: boolean
@@ -13,6 +14,9 @@ interface SidePanelContextValue {
   setOnTimelineSelect: (handler: TimelineSelectHandler | null) => void
   onDraftSelect: DraftSelectHandler
   setOnDraftSelect: (handler: DraftSelectHandler | null) => void
+  /** Force the timelines list to refetch (e.g. after deleting from the editor). No-op if nothing is registered. */
+  refreshTimelines: () => void
+  setRefreshTimelines: (handler: TimelinesRefreshHandler | null) => void
   activeTimelineId: string | null
   setActiveTimelineId: (id: string | null) => void
   activeDraftId: string | null
@@ -52,6 +56,7 @@ export function SidePanelProvider({ children }: { children: ReactNode }) {
   const navigate = useNavigate()
   const customHandlerRef = useRef<TimelineSelectHandler | null>(null)
   const customDraftHandlerRef = useRef<DraftSelectHandler | null>(null)
+  const customRefreshRef = useRef<TimelinesRefreshHandler | null>(null)
 
   useEffect(() => {
     try {
@@ -89,6 +94,14 @@ export function SidePanelProvider({ children }: { children: ReactNode }) {
     customDraftHandlerRef.current = handler
   }, [])
 
+  const refreshTimelines = useCallback(() => {
+    customRefreshRef.current?.()
+  }, [])
+
+  const setRefreshTimelines = useCallback((handler: TimelinesRefreshHandler | null) => {
+    customRefreshRef.current = handler
+  }, [])
+
   const value = useMemo<SidePanelContextValue>(() => ({
     isOpen,
     open,
@@ -98,6 +111,8 @@ export function SidePanelProvider({ children }: { children: ReactNode }) {
     setOnTimelineSelect,
     onDraftSelect,
     setOnDraftSelect,
+    refreshTimelines,
+    setRefreshTimelines,
     activeTimelineId,
     setActiveTimelineId,
     activeDraftId,
@@ -108,7 +123,7 @@ export function SidePanelProvider({ children }: { children: ReactNode }) {
     setActiveEventCount,
     activeDominantCategoryColor,
     setActiveDominantCategoryColor,
-  }), [isOpen, open, close, toggle, onTimelineSelect, setOnTimelineSelect, onDraftSelect, setOnDraftSelect, activeTimelineId, activeDraftId, activeTimelineTitle, activeEventCount, activeDominantCategoryColor])
+  }), [isOpen, open, close, toggle, onTimelineSelect, setOnTimelineSelect, onDraftSelect, setOnDraftSelect, refreshTimelines, setRefreshTimelines, activeTimelineId, activeDraftId, activeTimelineTitle, activeEventCount, activeDominantCategoryColor])
 
   return (
     <SidePanelContext.Provider value={value}>


### PR DESCRIPTION
## Summary
This PR refactors the TimelineSettingsPanel component to use a custom side panel implementation instead of the shadcn Sheet component, adds a timeline deletion feature, and updates related UI components to match a new design system.

## Key Changes

- **Settings Panel UI Refactor**: Replaced shadcn `Sheet` component with a custom side panel using `createPortal`, featuring:
  - Custom styling with dark theme colors (#171717, #262626, etc.)
  - Smooth slide-in/out animations with backdrop overlay
  - Keyboard support (Escape key to close)
  - Improved accessibility with proper ARIA labels

- **Timeline Deletion**: 
  - Added `onDeleteTimeline` prop and handler to TimelineSettingsPanel
  - Implemented `handleDeleteTimeline` in App.tsx that deletes timelines from Supabase or local drafts
  - Replaced "Clear Timeline" and "Reset All Data" buttons with single "Delete Timeline" action
  - Removed `onClearTimeline` prop in favor of new deletion flow

- **ScaleSelector Component**: 
  - Removed dependency on shadcn Button and Label components
  - Implemented custom button styling with dark theme
  - Simplified to use plain HTML buttons with inline styling

- **Action Buttons**: 
  - Integrated new `SidePanelActionButton` component for consistent action styling
  - Reorganized import/export and delete actions into bottom action group

- **Code Cleanup**:
  - Removed unused imports (FileDown, FileUp, RotateCcw, writeFile)
  - Removed `handleDownloadTemplate` and `handleResetData` functions
  - Simplified variable naming (events → imported)
  - Removed unused UI component imports (Button, Input, Label, Sheet components)

## Implementation Details

- The settings panel now uses React portals to render outside the component tree, improving z-index management
- Escape key handler properly cleans up event listeners on unmount
- Delete operation handles both Supabase timelines and local drafts
- After deletion, user is redirected to home page with cleared state
- All visual styling updated to match new dark theme design system

https://claude.ai/code/session_01E15mrymTjwtuw7JQpHxv1c