### PR TITLE
Change default timeline scale from 'large' to 'small'

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -272,7 +272,7 @@ export function App() {
       } else {
         resetCategories();
       }
-      handleScaleChange(newScale || 'large');
+      handleScaleChange(newScale || 'small');
       handleGroupByCategoryChange(newGroupByCategory ?? false);
     } catch (error) {
       console.error('Error switching timeline:', error);

--- a/src/components/TimelineViewer/TimelineViewer.tsx
+++ b/src/components/TimelineViewer/TimelineViewer.tsx
@@ -51,7 +51,7 @@ export function TimelineViewer() {
             description: draft.description || '',
             events: draft.events || [],
             categories,
-            scale: draft.scale || 'large',
+            scale: draft.scale || 'small',
             groupByCategory: draft.groupByCategory ?? false
           });
         } catch {
@@ -106,7 +106,7 @@ export function TimelineViewer() {
           description: timelineData.description || '',
           events: formattedEvents,
           categories: categories,
-          scale: timelineData.scale || 'large',
+          scale: timelineData.scale || 'small',
           groupByCategory: timelineData.group_by_category ?? false
         });
       } catch (err) {

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -117,7 +117,7 @@ export function useTimeline() {
           description: '',
           events: [],
           categories: undefined, // Will use default categories
-          scale: 'large',
+          scale: 'small',
           groupByCategory: false
         };
       }
@@ -158,7 +158,7 @@ export function useTimeline() {
           category: event.category
         })),
         categories: categories || undefined,
-        scale: timeline.scale || 'large',
+        scale: timeline.scale || 'small',
         groupByCategory: timeline.group_by_category ?? false
       };
     } catch (error) {
@@ -168,7 +168,7 @@ export function useTimeline() {
     }
   }, [user, timelineId]);
 
-  const saveTimeline = useCallback(async (title: string, events: TimelineEvent[], scale: 'large' | 'small' = 'large') => {
+  const saveTimeline = useCallback(async (title: string, events: TimelineEvent[], scale: 'large' | 'small' = 'small') => {
     if (!user) throw new Error('Must be signed in to save');
 
     try {

--- a/src/hooks/useTimelineScale.ts
+++ b/src/hooks/useTimelineScale.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { SCALES } from '../constants/scales';
 import { TimelineScale } from '../types/timeline';
 
-export function useTimelineScale(initialScale: 'large' | 'small' = 'large') {
+export function useTimelineScale(initialScale: 'large' | 'small' = 'small') {
   const [scale, setScale] = useState<'large' | 'small'>(initialScale);
 
   const handleScaleChange = useCallback((newScale: 'large' | 'small') => {

--- a/src/utils/draftStorage.ts
+++ b/src/utils/draftStorage.ts
@@ -81,7 +81,7 @@ export function createDraft(): LocalDraft | null {
     description: '',
     events: [],
     categories: [...DEFAULT_CATEGORIES],
-    scale: 'large',
+    scale: 'small',
     groupByCategory: false,
     savedAt: new Date().toISOString(),
   }

--- a/supabase/migrations/20260420000000_default_timeline_scale_small.sql
+++ b/supabase/migrations/20260420000000_default_timeline_scale_small.sql
@@ -1,0 +1,9 @@
+/*
+  # Change default timeline scale to 'small'
+
+  1. Changes
+    - Update the default value of the `scale` column on `timelines` from 'large' to 'small'
+    - Existing rows are not modified; only new inserts without an explicit `scale` are affected
+*/
+
+ALTER TABLE timelines ALTER COLUMN scale SET DEFAULT 'small';


### PR DESCRIPTION
## Summary
Updates the default timeline scale across the application from 'large' to 'small'. This change affects both new timeline creation and fallback values throughout the codebase, ensuring a consistent default experience for users.

## Key Changes
- **Database Migration**: Added migration to update the default value of the `scale` column in the `timelines` table from 'large' to 'small'
- **Hook Defaults**: Updated default parameters in `useTimeline()` and `useTimelineScale()` hooks to use 'small' scale
- **Fallback Values**: Changed all fallback scale values from 'large' to 'small' in:
  - `useTimeline.ts` (new timeline creation and data loading)
  - `TimelineViewer.tsx` (draft and timeline data initialization)
  - `App.tsx` (timeline switching)
  - `draftStorage.ts` (new draft creation)

## Implementation Details
- The database migration only affects new inserts without an explicit `scale` value; existing rows remain unchanged
- All frontend components now consistently default to 'small' scale, providing a unified user experience
- The change is backward compatible as it only affects default values when scale is not explicitly provided

https://claude.ai/code/session_015tQsaFSe8n1oWgvFHFVtxZ