### PR TITLE
Add view mode toggle between edit and present modes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { computeDominantCategoryColor } from './utils/dominantCategory';
 import { AuthModal } from './components/Auth/AuthModal';
 import { UnsavedChangesModal } from './components/Modal/UnsavedChangesModal';
 import { useLocalDraft } from './hooks/useLocalDraft';
+import { useViewMode } from './hooks/useViewMode';
 import { TimelineEvent, CategoryConfig } from './types/event';
 import { LimitReachedError, getCurrentLimits } from './lib/limits';
 import { supabase } from './lib/supabase';
@@ -34,6 +35,7 @@ export function App() {
     groupByCategory, handleGroupByCategoryChange,
   } = useTimelineState();
   const { user } = useAuth();
+  const { mode, setMode } = useViewMode();
   const { saveTimeline, timelineId, loadTimeline, error: timelineError, retryInitialLoad } = useTimeline();
   const location = useLocation();
   const routerNavigate = useNavigate();
@@ -46,7 +48,7 @@ export function App() {
   const [draftHydrated, setDraftHydrated] = useState(false);
   const [nudgeDismissed, setNudgeDismissed] = useState(false);
   const [activeDraftId, setActiveDraftId] = useState<string | null>(null);
-  const { loadAllDrafts, loadDraft, saveDraft, saveDraftImmediate, createDraft, clearAllDrafts, deleteDraft: deleteLocalDraft } = useLocalDraft();
+  const { loadAllDrafts, loadDraft, saveDraft, createDraft, clearAllDrafts, deleteDraft: deleteLocalDraft } = useLocalDraft();
   const handledRouteStateRef = useRef(false);
   const migrationDoneRef = useRef(false);
   const { setOnTimelineSelect, setOnDraftSelect, refreshTimelines, setActiveTimelineId, setActiveDraftId: setPanelActiveDraftId, setActiveTimelineTitle, setActiveEventCount, setActiveDominantCategoryColor } = useSidePanel();
@@ -454,21 +456,15 @@ export function App() {
     return () => setActiveDominantCategoryColor(null);
   }, [timelineAccentColor, setActiveDominantCategoryColor]);
 
-  const handlePresentMode = () => {
-    if (timelineId) {
-      window.open(`/view/${timelineId}`, '_blank');
-    } else if (activeDraftId) {
-      // Flush current state to localStorage synchronously so the new tab can read it
-      saveDraftImmediate({
-        id: activeDraftId,
-        title, description, events, categories,
-        scale: currentScale.value,
-        groupByCategory,
-        savedAt: new Date().toISOString()
-      });
-      window.open(`/view/local?draftId=${activeDraftId}`, '_blank');
+  // Switching to present mode collapses any open editor surfaces. Panel
+  // overlays catch toggle clicks so this is mostly a safety net for
+  // programmatic switches.
+  useEffect(() => {
+    if (mode === 'present') {
+      setActivePanel(null);
+      setShowAddEventModal(false);
     }
-  };
+  }, [mode]);
 
   const handleClearTimeline = () => {
     clearEvents();
@@ -537,7 +533,8 @@ export function App() {
         onEventsClick={() => setActivePanel(prev => prev === 'events' ? null : 'events')}
         onSettingsClick={() => setActivePanel(prev => prev === 'settings' ? null : 'settings')}
         activePanel={activePanel}
-        onPresentMode={handlePresentMode}
+        mode={mode}
+        onModeChange={setMode}
         saveStatus={saveStatus}
         lastSavedTime={lastSavedTime}
       />
@@ -607,6 +604,7 @@ export function App() {
             groupByCategory={groupByCategory}
             pendingScrollDate={pendingScrollDate}
             onScrollComplete={() => setPendingScrollDate(null)}
+            mode={mode}
           />
         </main>
       )}

--- a/src/components/EventDetailPanel/EventDetailPanel.tsx
+++ b/src/components/EventDetailPanel/EventDetailPanel.tsx
@@ -1,0 +1,117 @@
+import { useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { X } from 'lucide-react'
+import type { TimelineEvent } from '../../types/event'
+
+interface EventDetailPanelProps {
+  isOpen: boolean
+  event: TimelineEvent | null
+  onClose: () => void
+}
+
+export function EventDetailPanel({ isOpen, event, onClose }: EventDetailPanelProps) {
+  useEffect(() => {
+    if (!isOpen) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [isOpen, onClose])
+
+  if (typeof document === 'undefined') return null
+
+  const sources = event?.sources?.filter(s => s.url) ?? []
+  const hasDescription = !!event?.description?.trim()
+  const hasSources = sources.length > 0
+
+  return createPortal(
+    <>
+      <div
+        onClick={onClose}
+        className={`fixed inset-0 z-40 bg-black/50 transition-opacity duration-300 ease-out ${
+          isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+        aria-hidden="true"
+      />
+      <aside
+        className={`fixed inset-y-0 right-0 z-50 w-[320px] pr-[6px] py-[6px] transition-transform duration-300 ease-out ${
+          isOpen ? 'translate-x-0' : 'translate-x-full'
+        }`}
+        aria-hidden={!isOpen}
+        aria-label="Event detail panel"
+      >
+        <div className="h-full w-full bg-[#171717] rounded-[6px] border border-[#262626] flex flex-col overflow-hidden">
+          {/* Header */}
+          <div className="flex items-center justify-between gap-2 px-5 pt-4 pb-2 border-b border-[#404040] shrink-0">
+            <h2 className="header-xsmall text-[#c9ced4] m-0">Event</h2>
+            <button
+              onClick={onClose}
+              className="relative flex items-center justify-center p-1.5 rounded-lg border border-white/15 bg-white/10 backdrop-blur-[12px] text-[#c9ced4] shadow-[0px_8px_32px_0px_rgba(0,0,0,0.4),inset_0px_1px_0px_0px_rgba(255,255,255,0.1)] hover:bg-white/20 hover:text-[#dadee5] transition-colors"
+              aria-label="Close event panel"
+            >
+              <X size={16} strokeWidth={1.25} />
+            </button>
+          </div>
+
+          {/* Body */}
+          {event && (
+            <div className="flex-1 min-h-0 overflow-y-auto">
+              <div className="flex flex-col gap-6 px-5 pt-6 pb-2">
+                {/* Image (or placeholder) */}
+                {event.imageUrl ? (
+                  <img
+                    src={event.imageUrl}
+                    alt=""
+                    className="w-full aspect-[4/3] object-cover rounded-lg"
+                  />
+                ) : (
+                  <div className="w-full aspect-[4/3] rounded-lg border border-[#262626] bg-[#0F0F0F]" />
+                )}
+
+                {/* Title */}
+                <h3
+                  className="header-xsmall m-0"
+                  style={{ color: '#C9CED4', fontSize: 18 }}
+                >
+                  {event.title}
+                </h3>
+
+                {/* Description */}
+                {hasDescription && (
+                  <p className="body-m text-[#9B9EA3] whitespace-pre-wrap m-0">
+                    {event.description}
+                  </p>
+                )}
+
+                {/* Sources */}
+                {hasSources && (
+                  <div className="flex flex-col gap-2">
+                    <span className="label-m-type2 text-[#9B9EA3]">Sources</span>
+                    <div className="h-px bg-[#262626] w-full" />
+                    {sources.map((source, idx) => (
+                      <div key={`${source.url}-${idx}`} className="flex flex-col gap-2">
+                        <a
+                          href={source.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="body-m text-[#C9CED4] underline break-words hover:text-white"
+                        >
+                          {source.label.trim() || source.url}
+                        </a>
+                        {idx < sources.length - 1 && (
+                          <div className="h-px bg-[#262626] w-full" />
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </aside>
+    </>,
+    document.body
+  )
+}

--- a/src/components/EventForm/EventForm.tsx
+++ b/src/components/EventForm/EventForm.tsx
@@ -1,11 +1,11 @@
-import React, { useState, useCallback, useEffect } from 'react'
-import { TimelineEvent, CategoryConfig } from '../../types/event'
+import React, { useState, useCallback, useEffect, useRef } from 'react'
+import { TimelineEvent, CategoryConfig, EventSource } from '../../types/event'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Calendar } from '@/components/ui/calendar'
 import { DialogClose } from '@/components/ui/dialog'
-import { CalendarDays } from 'lucide-react'
+import { CalendarDays, ChevronDown, Plus, Upload, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
   parseDate,
@@ -14,8 +14,15 @@ import {
   darkCalendarClassNames,
 } from '@/utils/dateUtils'
 import { normalizeDate } from '@/utils/dateUtils'
+import { useAuth } from '@/hooks/useAuth'
+import { uploadEventImage, deleteEventImage } from '@/utils/eventImageUpload'
 
 const MAX_TITLE_LENGTH = 55
+const MAX_DESCRIPTION_LENGTH = 500
+
+function isValidUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url.trim())
+}
 
 interface EventFormProps {
   onSubmit: (event: Omit<TimelineEvent, 'id'>) => void
@@ -31,11 +38,22 @@ export function EventForm({
   initialStartDate,
   initialEvent
 }: EventFormProps) {
+  const { user } = useAuth()
   const [title, setTitle] = useState(initialEvent?.title || '')
   const [startDate, setStartDate] = useState(initialEvent?.startDate || initialStartDate || '')
   const [endDate, setEndDate] = useState(initialEvent?.endDate || '')
   const [category, setCategory] = useState(initialEvent?.category || categories[0]?.id || '')
   const [isEndDateFocused, setIsEndDateFocused] = useState(false)
+  const [description, setDescription] = useState(initialEvent?.description || '')
+  const [imageUrl, setImageUrl] = useState(initialEvent?.imageUrl || '')
+  const [sources, setSources] = useState<EventSource[]>(initialEvent?.sources ?? [])
+  const [detailsExpanded, setDetailsExpanded] = useState(
+    !!(initialEvent?.description || initialEvent?.imageUrl || (initialEvent?.sources?.length ?? 0) > 0)
+  )
+  const [imageError, setImageError] = useState<string | null>(null)
+  const [uploading, setUploading] = useState(false)
+  const [sourceUrlErrors, setSourceUrlErrors] = useState<Record<number, boolean>>({})
+  const eventIdRef = useRef<string>(initialEvent?.id || crypto.randomUUID())
 
   // Date display text states
   const [startDateText, setStartDateText] = useState(
@@ -55,6 +73,13 @@ export function EventForm({
       setCategory(initialEvent.category)
       setStartDateText(formatDateDisplay(initialEvent.startDate))
       setEndDateText(formatDateDisplay(initialEvent.endDate))
+      setDescription(initialEvent.description || '')
+      setImageUrl(initialEvent.imageUrl || '')
+      setSources(initialEvent.sources ?? [])
+      setDetailsExpanded(
+        !!(initialEvent.description || initialEvent.imageUrl || (initialEvent.sources?.length ?? 0) > 0)
+      )
+      eventIdRef.current = initialEvent.id
     }
   }, [initialEvent])
 
@@ -101,6 +126,59 @@ export function EventForm({
     }
   }, [endDateText, endDate, startDate])
 
+  const updateSource = useCallback((idx: number, field: keyof EventSource, value: string) => {
+    setSources(prev => prev.map((src, i) => i === idx ? { ...src, [field]: value } : src))
+    if (field === 'url') {
+      setSourceUrlErrors(prev => {
+        if (!prev[idx]) return prev
+        const next = { ...prev }
+        delete next[idx]
+        return next
+      })
+    }
+  }, [])
+
+  const removeSource = useCallback((idx: number) => {
+    setSources(prev => prev.filter((_, i) => i !== idx))
+    setSourceUrlErrors(prev => {
+      if (!prev[idx]) return prev
+      const next = { ...prev }
+      delete next[idx]
+      return next
+    })
+  }, [])
+
+  const handleFileChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (!file) return
+    if (!user) {
+      setImageError('Sign in to upload images.')
+      return
+    }
+    setImageError(null)
+    setUploading(true)
+    try {
+      const url = await uploadEventImage(file, user.id, eventIdRef.current)
+      setImageUrl(url)
+    } catch (err) {
+      setImageError(err instanceof Error ? err.message : 'Failed to upload image.')
+    } finally {
+      setUploading(false)
+    }
+  }, [user])
+
+  const handleRemoveImage = useCallback(() => {
+    const previousUrl = imageUrl
+    setImageUrl('')
+    setImageError(null)
+    if (previousUrl) {
+      // Best-effort: drop the storage object so cancelled uploads don't pile up.
+      // Errors are swallowed inside deleteEventImage.
+      void deleteEventImage(previousUrl)
+    }
+  }, [imageUrl])
+
   const handleSubmit = useCallback((e: React.FormEvent) => {
     e.preventDefault()
     if (!category) {
@@ -118,11 +196,32 @@ export function EventForm({
       return
     }
 
+    // Drop empty source rows; validate the rest.
+    const cleanedSources: EventSource[] = []
+    const newErrors: Record<number, boolean> = {}
+    sources.forEach((source, idx) => {
+      const url = source.url.trim()
+      if (!url) return
+      if (!isValidUrl(url)) {
+        newErrors[idx] = true
+        return
+      }
+      cleanedSources.push({ label: source.label.trim(), url })
+    })
+    if (Object.keys(newErrors).length > 0) {
+      setSourceUrlErrors(newErrors)
+      return
+    }
+    setSourceUrlErrors({})
+
     onSubmit({
       title,
       startDate,
       endDate: endDate || startDate,
-      category
+      category,
+      description: description.trim() ? description : undefined,
+      imageUrl: imageUrl || undefined,
+      sources: cleanedSources.length > 0 ? cleanedSources : undefined,
     })
 
     setTitle('')
@@ -131,7 +230,13 @@ export function EventForm({
     setStartDateText('')
     setEndDateText('')
     setCategory(categories[0]?.id || '')
-  }, [title, startDate, endDate, category, categories, onSubmit])
+    setDescription('')
+    setImageUrl('')
+    setSources([])
+    setSourceUrlErrors({})
+    setDetailsExpanded(false)
+    eventIdRef.current = crypto.randomUUID()
+  }, [title, startDate, endDate, category, categories, description, imageUrl, sources, onSubmit])
 
   return (
     <form onSubmit={handleSubmit} className="rounded-lg">
@@ -324,6 +429,139 @@ export function EventForm({
               </PopoverContent>
             </Popover>
           </div>
+        </div>
+
+        {/* Collapsible details section */}
+        <div className="flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={() => setDetailsExpanded(prev => !prev)}
+            aria-expanded={detailsExpanded}
+            className="flex items-center justify-between w-full label-m-type2 text-[#9B9EA3] hover:text-[#C9CED4] transition-colors"
+          >
+            Add more details
+            <ChevronDown
+              size={16}
+              className={`transition-transform ${detailsExpanded ? 'rotate-180' : ''}`}
+            />
+          </button>
+
+          {detailsExpanded && (
+            <div className="flex flex-col gap-4">
+              {/* Description */}
+              <div>
+                <label htmlFor="event-description" className="label-m-type2 text-[#9B9EA3] mb-1 block">
+                  Description{' '}
+                  <span className="text-muted-foreground">
+                    ({description.length}/{MAX_DESCRIPTION_LENGTH})
+                  </span>
+                </label>
+                <textarea
+                  id="event-description"
+                  value={description}
+                  onChange={(e) => {
+                    if (e.target.value.length <= MAX_DESCRIPTION_LENGTH) {
+                      setDescription(e.target.value)
+                    }
+                  }}
+                  maxLength={MAX_DESCRIPTION_LENGTH}
+                  rows={4}
+                  className="w-full bg-[#262626] border border-[#262626] rounded-[8px] p-2 body-m text-[#DADEE5] outline-none focus:border-[#404040]"
+                />
+              </div>
+
+              {/* Image */}
+              <div>
+                <label className="label-m-type2 text-[#9B9EA3] mb-1 block">Image</label>
+                {imageUrl ? (
+                  <div className="relative aspect-[4/3] rounded-lg overflow-hidden border border-[#262626]">
+                    <img src={imageUrl} alt="" className="w-full h-full object-cover" />
+                    <button
+                      type="button"
+                      onClick={handleRemoveImage}
+                      className="absolute top-2 right-2 p-1.5 rounded-md bg-black/70 hover:bg-black text-white"
+                      aria-label="Remove image"
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+                ) : (
+                  <label className="flex flex-col items-center justify-center aspect-[4/3] rounded-lg border border-dashed border-[#404040] cursor-pointer hover:border-[#525252]">
+                    <input
+                      type="file"
+                      accept="image/jpeg,image/png"
+                      onChange={handleFileChange}
+                      className="hidden"
+                      disabled={uploading}
+                    />
+                    <Upload size={20} className="text-[#9B9EA3] mb-2" />
+                    <span className="body-m text-[#9B9EA3]">
+                      {uploading ? 'Uploading…' : 'Click to upload'}
+                    </span>
+                    <span className="label-s-type2 text-[#737373] mt-1">JPG or PNG, up to 5MB</span>
+                  </label>
+                )}
+                {imageError && (
+                  <p className="label-s-type2 text-red-400 mt-1">{imageError}</p>
+                )}
+              </div>
+
+              {/* Sources */}
+              <div>
+                <label className="label-m-type2 text-[#9B9EA3] mb-1 block">Sources</label>
+                <div className="flex flex-col gap-2">
+                  {sources.map((source, idx) => {
+                    const hasUrlError = !!sourceUrlErrors[idx]
+                    return (
+                      <div key={idx} className="flex gap-2 items-start">
+                        <div className="flex-1 flex flex-col gap-1">
+                          <input
+                            type="text"
+                            placeholder="Label (optional)"
+                            value={source.label}
+                            onChange={(e) => updateSource(idx, 'label', e.target.value)}
+                            className="w-full h-8 bg-[#262626] border border-[#262626] rounded-[8px] px-2 body-m text-[#DADEE5] outline-none focus:border-[#404040]"
+                          />
+                          <input
+                            type="url"
+                            placeholder="https://…"
+                            value={source.url}
+                            onChange={(e) => updateSource(idx, 'url', e.target.value)}
+                            className={cn(
+                              'w-full h-8 bg-[#262626] rounded-[8px] px-2 body-m text-[#DADEE5] outline-none border',
+                              hasUrlError
+                                ? 'border-red-500 focus:border-red-500'
+                                : 'border-[#262626] focus:border-[#404040]'
+                            )}
+                          />
+                          {hasUrlError && (
+                            <p className="label-s-type2 text-red-400">
+                              URL must start with http:// or https://
+                            </p>
+                          )}
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => removeSource(idx)}
+                          className="p-1.5 rounded-md text-[#9B9EA3] hover:text-[#C9CED4] hover:bg-[#262626]"
+                          aria-label="Remove source"
+                        >
+                          <X size={14} />
+                        </button>
+                      </div>
+                    )
+                  })}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setSources(prev => [...prev, { label: '', url: '' }])}
+                  className="mt-2 flex items-center gap-1 label-m-type2 text-[#9B9EA3] hover:text-[#C9CED4]"
+                >
+                  <Plus size={14} /> Add source
+                </button>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Buttons */}

--- a/src/components/Navigation/GlobalNav.tsx
+++ b/src/components/Navigation/GlobalNav.tsx
@@ -3,8 +3,10 @@ import { Columns3, PanelLeft, Plus, Settings as SettingsIcon } from 'lucide-reac
 import { useSidePanel } from '@/hooks/useSidePanel'
 import { Button } from '@/components/ui/button'
 import { SaveStatusIndicator, type SaveStatus } from '@/components/SaveStatusIndicator/SaveStatusIndicator'
+import { PresentModeSelector } from '@/components/Navigation/PresentModeSelector'
 import { getTimelineYearRange } from '@/utils/timelineUtils'
 import type { TimelineEvent } from '@/types/event'
+import type { ViewMode } from '@/hooks/useViewMode'
 
 interface GlobalNavProps {
   variant?: 'default' | 'timeline'
@@ -19,7 +21,11 @@ interface GlobalNavProps {
   onEventsClick?: () => void
   onSettingsClick?: () => void
   activePanel?: 'events' | 'settings' | null
-  onPresentMode?: () => void
+  /** View mode — controls which edit affordances render */
+  mode?: ViewMode
+  onModeChange?: (mode: ViewMode) => void
+  /** When set, hides the mode toggle entirely and forces the given mode */
+  lockedMode?: ViewMode
   /** Save status — only rendered on variant="timeline" */
   saveStatus?: SaveStatus
   lastSavedTime?: Date
@@ -36,10 +42,15 @@ export function GlobalNav({
   onEventsClick,
   onSettingsClick,
   activePanel,
-  onPresentMode,
+  mode = 'edit',
+  onModeChange,
+  lockedMode,
   saveStatus,
   lastSavedTime,
 }: GlobalNavProps) {
+  const effectiveMode: ViewMode = lockedMode ?? mode
+  const showModeToggle = lockedMode === undefined && variant === 'timeline' && !!onModeChange
+  const isEditMode = effectiveMode === 'edit'
   const { isOpen: isPanelOpen, toggle: togglePanel } = useSidePanel()
 
   const handleShare = () => {
@@ -80,7 +91,7 @@ export function GlobalNav({
 
           {showTitleCluster && (
             <div className="flex flex-col gap-1 min-w-0">
-              {onTimelineTitleChange ? (
+              {onTimelineTitleChange && isEditMode ? (
                 <input
                   type="text"
                   value={timelineTitle ?? ''}
@@ -97,9 +108,9 @@ export function GlobalNav({
                   style={{ fieldSizing: 'content' } as CSSProperties}
                 />
               ) : (
-                <p className="font-['Aleo',serif] font-normal text-[18px] leading-[1.4] text-text-secondary truncate">
+                <span className="font-['Aleo',serif] font-normal text-[18px] leading-[1.4] text-text-secondary truncate">
                   {timelineTitle || 'Untitled Timeline'}
-                </p>
+                </span>
               )}
               <div className="flex items-center gap-2 shrink-0">
                 <span className="label-s-type1 text-text-tertiary whitespace-nowrap">
@@ -119,7 +130,7 @@ export function GlobalNav({
         </div>
 
         {/* Center cluster: editor action buttons */}
-        {variant === 'timeline' && (
+        {variant === 'timeline' && isEditMode && (
           <div className="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 items-center gap-2.5">
             {onAddEventClick && (
               <Button variant="glass" size="none" onClick={onAddEventClick}>
@@ -158,13 +169,9 @@ export function GlobalNav({
           )}
           {variant === 'timeline' && (
             <>
-              <Button
-                variant="glass-sm"
-                size="none"
-                onClick={onPresentMode}
-              >
-                Present
-              </Button>
+              {showModeToggle && (
+                <PresentModeSelector value={effectiveMode} onChange={onModeChange!} />
+              )}
               <Button
                 variant="glass-sm"
                 size="none"

--- a/src/components/Navigation/PresentModeSelector.tsx
+++ b/src/components/Navigation/PresentModeSelector.tsx
@@ -1,0 +1,45 @@
+import { SquarePen, SquarePlay } from 'lucide-react'
+import type { ViewMode } from '@/hooks/useViewMode'
+
+interface PresentModeSelectorProps {
+  value: ViewMode
+  onChange: (mode: ViewMode) => void
+}
+
+export function PresentModeSelector({ value, onChange }: PresentModeSelectorProps) {
+  const tabClass = (active: boolean) =>
+    `flex items-center justify-center gap-1.5 min-w-[80px] h-8 px-3 py-1.5 rounded-[6px] transition-colors body-m ${
+      active
+        ? 'bg-[#262626] text-[#C9CED4]'
+        : 'bg-transparent text-[#9B9EA3] hover:text-[#C9CED4]'
+    }`
+
+  return (
+    <div
+      className="flex flex-row items-start p-1 h-10 bg-[#171717] border border-[#262626] rounded-[10px]"
+      role="tablist"
+      aria-label="View mode"
+    >
+      <button
+        type="button"
+        role="tab"
+        aria-selected={value === 'edit'}
+        onClick={() => onChange('edit')}
+        className={tabClass(value === 'edit')}
+      >
+        <SquarePen size={16} strokeWidth={1.5} />
+        Edit
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={value === 'present'}
+        onClick={() => onChange('present')}
+        className={tabClass(value === 'present')}
+      >
+        <SquarePlay size={16} strokeWidth={1.5} />
+        Present
+      </button>
+    </div>
+  )
+}

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -6,6 +6,7 @@ import { TimelineEvent } from './TimelineEvent';
 import { TimelineScrollIndicator } from './TimelineScrollIndicator';
 import { TimelineEvent as ITimelineEvent, CategoryConfig } from '../../types/event';
 import { TimelineScale } from '../../types/timeline';
+import type { ViewMode } from '../../hooks/useViewMode';
 import { getTimelineRange, shiftEventDates } from '../../utils/dateUtils';
 import { calculateEventStacks, StackedEvent } from '../../utils/eventStacking';
 import { useTimelineScroll } from '../../hooks/useTimelineScroll';
@@ -29,6 +30,7 @@ interface TimelineProps {
   groupByCategory?: boolean;
   pendingScrollDate?: string | null;
   onScrollComplete?: () => void;
+  mode?: ViewMode;
 }
 
 interface CategoryBand {
@@ -52,8 +54,10 @@ export function Timeline({
   scale,
   groupByCategory = false,
   pendingScrollDate,
-  onScrollComplete
+  onScrollComplete,
+  mode = 'edit',
 }: TimelineProps) {
+  const isEditMode = mode === 'edit';
   // Filter visible categories and their events
   const visibleCategories = categories.filter(cat => cat.visible);
   const visibleEvents = events.filter(event =>
@@ -200,7 +204,7 @@ export function Timeline({
   }, [groupByCategory, visibleEvents, visibleCategories, months, scale.monthWidth]);
 
   const handleMonthClick = useCallback((monthIndex: number) => {
-    if (!onAddEvent || justDraggedRef.current) return;
+    if (!onAddEvent || !isEditMode || justDraggedRef.current) return;
 
     const clickedMonth = months[monthIndex];
     if (clickedMonth) {
@@ -209,14 +213,14 @@ export function Timeline({
       setEditingEvent(null);
       setShowEventModal(true);
     }
-  }, [months, onAddEvent, justDraggedRef]);
+  }, [months, onAddEvent, isEditMode, justDraggedRef]);
 
   const handleEventClick = useCallback((event: ITimelineEvent) => {
-    if (!onUpdateEvent || justDraggedRef.current) return;
+    if (!onUpdateEvent || !isEditMode || justDraggedRef.current) return;
     setEditingEvent(event);
     setSelectedDate(null);
     setShowEventModal(true);
-  }, [onUpdateEvent, justDraggedRef]);
+  }, [onUpdateEvent, isEditMode, justDraggedRef]);
 
   const handleSubmit = useCallback((eventData: Omit<ITimelineEvent, 'id'>) => {
     let newEventId: string | null = null;
@@ -284,7 +288,7 @@ export function Timeline({
             style={{
               minWidth: `${months.length * scale.monthWidth}px`,
               minHeight: '100%',
-              cursor: onAddEvent ? 'pointer' : 'default'
+              cursor: onAddEvent && isEditMode ? 'pointer' : 'default'
             }}
           >
             <TimelineHeader months={months} scale={scale} />
@@ -303,7 +307,7 @@ export function Timeline({
                 <TimelineGrid
                   months={months}
                   height={band.height}
-                  onMonthHover={setHoveredMonth}
+                  onMonthHover={isEditMode ? setHoveredMonth : undefined}
                   onMonthClick={handleMonthClick}
                   scale={scale}
                 />
@@ -314,11 +318,11 @@ export function Timeline({
                     months={months}
                     categoryOffset={band.offset}
                     categoryColor={visibleCategories.find(c => c.id === event.category)?.color}
-                    onEventClick={onUpdateEvent ? handleEventClick : undefined}
+                    onEventClick={onUpdateEvent && isEditMode ? handleEventClick : undefined}
                     scale={scale}
                     isDragging={dragState.isDragging && dragState.draggedEventId === event.id}
                     dragDeltaPixels={dragState.draggedEventId === event.id ? dragState.deltaPixels : 0}
-                    onPointerDown={onUpdateEvent ? handlePointerDown : undefined}
+                    onPointerDown={onUpdateEvent && isEditMode ? handlePointerDown : undefined}
                     rowHeight={rowHeight}
                     onMounted={handleEventMounted}
                   />
@@ -332,14 +336,14 @@ export function Timeline({
             <div className="relative border-l border-[#171717] flex-1 min-h-0">
               <TimelineGrid
                 months={months}
-                onMonthHover={setHoveredMonth}
+                onMonthHover={isEditMode ? setHoveredMonth : undefined}
                 onMonthClick={handleMonthClick}
                 scale={scale}
               />
             </div>
 
             {/* Add Event Cursor — hidden during drag */}
-            {hoveredMonth !== null && onAddEvent && !dragState.isDragging && (
+            {hoveredMonth !== null && onAddEvent && isEditMode && !dragState.isDragging && (
               <div
                 className="absolute top-[64px] bottom-0 bg-[#FBFBFB]/25 pointer-events-none transition-transform duration-75 ease-out"
                 style={{

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -13,6 +13,7 @@ import { useTimelineScroll } from '../../hooks/useTimelineScroll';
 import { useEventDrag } from '../../hooks/useEventDrag';
 import { EVENT_HEIGHT, EVENT_ROW_HEIGHT, CATEGORY_PADDING, CATEGORY_MIN_HEIGHT, SCROLL_INDICATOR_HEIGHT, HEADER_HEIGHT } from '../../constants/timeline';
 import { EventForm } from '../EventForm/EventForm';
+import { EventDetailPanel } from '../EventDetailPanel/EventDetailPanel';
 import {
   Dialog,
   DialogContent,
@@ -70,7 +71,27 @@ export function Timeline({
   const [showEventModal, setShowEventModal] = useState(false);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [editingEvent, setEditingEvent] = useState<ITimelineEvent | null>(null);
+  const [selectedEventForDetail, setSelectedEventForDetail] = useState<ITimelineEvent | null>(null);
   const [pendingScrollEventId, setPendingScrollEventId] = useState<string | null>(null);
+
+  // Reflect upstream events into the open detail panel: keeps fields in sync
+  // if the underlying event is edited (or deleted) while the panel is open.
+  useEffect(() => {
+    if (!selectedEventForDetail) return;
+    const fresh = events.find(e => e.id === selectedEventForDetail.id);
+    if (!fresh) {
+      setSelectedEventForDetail(null);
+    } else if (fresh !== selectedEventForDetail) {
+      setSelectedEventForDetail(fresh);
+    }
+  }, [events, selectedEventForDetail]);
+
+  // When toggling back to edit mode, close any open detail panel.
+  useEffect(() => {
+    if (isEditMode) {
+      setSelectedEventForDetail(null);
+    }
+  }, [isEditMode]);
 
   const { visibleRange } = useTimelineScroll(scrollContainerRef, months.length * 4);
 
@@ -216,10 +237,15 @@ export function Timeline({
   }, [months, onAddEvent, isEditMode, justDraggedRef]);
 
   const handleEventClick = useCallback((event: ITimelineEvent) => {
-    if (!onUpdateEvent || !isEditMode || justDraggedRef.current) return;
-    setEditingEvent(event);
-    setSelectedDate(null);
-    setShowEventModal(true);
+    if (justDraggedRef.current) return;
+    if (isEditMode) {
+      if (!onUpdateEvent) return;
+      setEditingEvent(event);
+      setSelectedDate(null);
+      setShowEventModal(true);
+    } else {
+      setSelectedEventForDetail(event);
+    }
   }, [onUpdateEvent, isEditMode, justDraggedRef]);
 
   const handleSubmit = useCallback((eventData: Omit<ITimelineEvent, 'id'>) => {
@@ -318,7 +344,7 @@ export function Timeline({
                     months={months}
                     categoryOffset={band.offset}
                     categoryColor={visibleCategories.find(c => c.id === event.category)?.color}
-                    onEventClick={onUpdateEvent && isEditMode ? handleEventClick : undefined}
+                    onEventClick={isEditMode && !onUpdateEvent ? undefined : handleEventClick}
                     scale={scale}
                     isDragging={dragState.isDragging && dragState.draggedEventId === event.id}
                     dragDeltaPixels={dragState.draggedEventId === event.id ? dragState.deltaPixels : 0}
@@ -355,6 +381,13 @@ export function Timeline({
           </div>
         </div>
       </div>
+
+      {/* Event detail panel (present mode) */}
+      <EventDetailPanel
+        isOpen={selectedEventForDetail !== null}
+        event={selectedEventForDetail}
+        onClose={() => setSelectedEventForDetail(null)}
+      />
 
       {/* Event Dialog */}
       <Dialog

--- a/src/components/TimelineViewer/TimelineViewer.tsx
+++ b/src/components/TimelineViewer/TimelineViewer.tsx
@@ -92,7 +92,10 @@ export function TimelineViewer() {
           title: event.title,
           startDate: event.start_date,
           endDate: event.end_date || event.start_date,
-          category: event.category
+          category: event.category,
+          description: event.description ?? undefined,
+          imageUrl: event.image_url ?? undefined,
+          sources: event.sources ?? [],
         }));
 
         // Ensure all categories have the visible property

--- a/src/components/TimelineViewer/TimelineViewer.tsx
+++ b/src/components/TimelineViewer/TimelineViewer.tsx
@@ -170,6 +170,7 @@ export function TimelineViewer() {
           categories={timeline.categories}
           scale={SCALES[timeline.scale]}
           groupByCategory={timeline.groupByCategory}
+          mode="present"
         />
       </main>
     </div>

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -155,7 +155,10 @@ export function useTimeline() {
           title: event.title,
           startDate: event.start_date,
           endDate: event.end_date,
-          category: event.category
+          category: event.category,
+          description: event.description ?? undefined,
+          imageUrl: event.image_url ?? undefined,
+          sources: event.sources ?? [],
         })),
         categories: categories || undefined,
         scale: timeline.scale || 'small',
@@ -196,7 +199,10 @@ export function useTimeline() {
                 title: event.title,
                 start_date: event.startDate,
                 end_date: event.endDate,
-                category: event.category
+                category: event.category,
+                description: event.description ?? null,
+                image_url: event.imageUrl ?? null,
+                sources: event.sources ?? [],
               }))
             );
 

--- a/src/hooks/useViewMode.ts
+++ b/src/hooks/useViewMode.ts
@@ -1,0 +1,11 @@
+import { useState, useCallback } from 'react'
+
+export type ViewMode = 'edit' | 'present'
+
+export function useViewMode(initialMode: ViewMode = 'edit') {
+  const [mode, setMode] = useState<ViewMode>(initialMode)
+  const handleModeChange = useCallback((newMode: ViewMode) => {
+    setMode(newMode)
+  }, [])
+  return { mode, setMode: handleModeChange }
+}

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,9 +1,17 @@
+export interface EventSource {
+  label: string;
+  url: string;
+}
+
 export interface TimelineEvent {
   id: string;
   title: string;
   startDate: string; // ISO date string
   endDate: string; // ISO date string
   category: TimelineCategory;
+  description?: string;
+  imageUrl?: string;
+  sources?: EventSource[];
 }
 
 export type TimelineCategory = 'category_1' | 'category_2' | 'category_3' | 'category_4';

--- a/src/utils/eventImageUpload.ts
+++ b/src/utils/eventImageUpload.ts
@@ -1,0 +1,43 @@
+import { supabase } from '../lib/supabase';
+
+const MAX_BYTES = 5 * 1024 * 1024;
+const ALLOWED_TYPES = ['image/jpeg', 'image/png'];
+
+export async function uploadEventImage(
+  file: File,
+  userId: string,
+  eventId: string
+): Promise<string> {
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    throw new Error('Only JPG and PNG images are supported.');
+  }
+  if (file.size > MAX_BYTES) {
+    throw new Error('Image must be 5MB or smaller.');
+  }
+  const ext = file.type === 'image/png' ? 'png' : 'jpg';
+  const path = `${userId}/${eventId}-${Date.now()}.${ext}`;
+
+  const { error } = await supabase.storage
+    .from('event-images')
+    .upload(path, file, { contentType: file.type });
+  if (error) throw error;
+
+  const { data } = supabase.storage
+    .from('event-images')
+    .getPublicUrl(path);
+  return data.publicUrl;
+}
+
+// Removing an image is best-effort: if the URL doesn't match the storage path
+// pattern (e.g. the user hand-edited it) we silently skip; if the storage
+// call fails we log but don't surface the error, since the row deletion
+// still succeeded.
+export async function deleteEventImage(publicUrl: string): Promise<void> {
+  const match = publicUrl.match(/event-images\/(.+)$/);
+  if (!match) return;
+  const path = match[1];
+  const { error } = await supabase.storage.from('event-images').remove([path]);
+  if (error) {
+    console.error('Failed to delete event image:', error);
+  }
+}

--- a/src/utils/saveEvents.ts
+++ b/src/utils/saveEvents.ts
@@ -1,5 +1,6 @@
 import { supabase } from '../lib/supabase';
-import type { TimelineEvent } from '../types/event';
+import type { EventSource, TimelineEvent } from '../types/event';
+import { deleteEventImage } from './eventImageUpload';
 
 interface DbEvent {
   id: string;
@@ -7,6 +8,17 @@ interface DbEvent {
   start_date: string;
   end_date: string;
   category: string;
+  description: string | null;
+  image_url: string | null;
+  sources: EventSource[] | null;
+}
+
+function sourcesEqual(a: EventSource[], b: EventSource[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].label !== b[i].label || a[i].url !== b[i].url) return false;
+  }
+  return true;
 }
 
 /**
@@ -20,7 +32,7 @@ export async function saveTimelineEvents(
   // 1. Fetch current server events for this timeline
   const { data: serverRows, error: fetchError } = await supabase
     .from('events')
-    .select('id, title, start_date, end_date, category')
+    .select('id, title, start_date, end_date, category, description, image_url, sources')
     .eq('timeline_id', timelineId);
 
   if (fetchError) throw fetchError;
@@ -35,21 +47,27 @@ export async function saveTimelineEvents(
 
   for (const event of clientEvents) {
     const existing = serverMap.get(event.id);
+    const clientDescription = event.description ?? null;
+    const clientImageUrl = event.imageUrl ?? null;
+    const clientSources = event.sources ?? [];
+
     if (!existing) {
       toInsert.push(event);
     } else if (
       existing.title !== event.title ||
       existing.start_date !== event.startDate ||
       existing.end_date !== event.endDate ||
-      existing.category !== event.category
+      existing.category !== event.category ||
+      (existing.description ?? null) !== clientDescription ||
+      (existing.image_url ?? null) !== clientImageUrl ||
+      !sourcesEqual(existing.sources ?? [], clientSources)
     ) {
       toUpdate.push(event);
     }
   }
 
-  const toDeleteIds = serverEvents
-    .filter(e => !clientIds.has(e.id))
-    .map(e => e.id);
+  const toDelete = serverEvents.filter(e => !clientIds.has(e.id));
+  const toDeleteIds = toDelete.map(e => e.id);
 
   // 3. Execute operations: UPDATE first, then DELETE, then INSERT
 
@@ -63,6 +81,9 @@ export async function saveTimelineEvents(
         start_date: event.startDate,
         end_date: event.endDate,
         category: event.category,
+        description: event.description ?? null,
+        image_url: event.imageUrl ?? null,
+        sources: event.sources ?? [],
       })
       .eq('id', event.id)
       .eq('timeline_id', timelineId);
@@ -70,8 +91,15 @@ export async function saveTimelineEvents(
     if (error) throw error;
   }
 
-  // Deletes
+  // Deletes — best-effort image cleanup before removing the row so a
+  // failed image delete doesn't strand the DB row.
   if (toDeleteIds.length > 0) {
+    await Promise.all(
+      toDelete
+        .filter(e => !!e.image_url)
+        .map(e => deleteEventImage(e.image_url as string))
+    );
+
     const { error } = await supabase
       .from('events')
       .delete()
@@ -93,6 +121,9 @@ export async function saveTimelineEvents(
           start_date: event.startDate,
           end_date: event.endDate,
           category: event.category,
+          description: event.description ?? null,
+          image_url: event.imageUrl ?? null,
+          sources: event.sources ?? [],
         }))
       );
 

--- a/supabase/migrations/20260429000000_event_detail_fields_and_image_storage.sql
+++ b/supabase/migrations/20260429000000_event_detail_fields_and_image_storage.sql
@@ -1,0 +1,46 @@
+/*
+  # Add event detail fields and storage bucket for event images
+
+  1. Schema changes
+    - Add `description` (TEXT, nullable) to `events`
+    - Add `image_url` (TEXT, nullable) to `events`
+    - Add `sources` (JSONB, defaults to '[]') to `events`
+
+  2. Storage
+    - Create public-read bucket `event-images`
+    - Public can read any image
+    - Authenticated users can INSERT/DELETE images under their own
+      `{auth.uid}/...` prefix
+*/
+
+ALTER TABLE events
+  ADD COLUMN IF NOT EXISTS description TEXT,
+  ADD COLUMN IF NOT EXISTS image_url TEXT,
+  ADD COLUMN IF NOT EXISTS sources JSONB DEFAULT '[]'::jsonb;
+
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('event-images', 'event-images', true)
+ON CONFLICT (id) DO UPDATE SET public = EXCLUDED.public;
+
+DROP POLICY IF EXISTS "Public read access for event images" ON storage.objects;
+CREATE POLICY "Public read access for event images"
+ON storage.objects FOR SELECT
+USING (bucket_id = 'event-images');
+
+DROP POLICY IF EXISTS "Authenticated users can upload event images" ON storage.objects;
+CREATE POLICY "Authenticated users can upload event images"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'event-images'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);
+
+DROP POLICY IF EXISTS "Authenticated users can delete own event images" ON storage.objects;
+CREATE POLICY "Authenticated users can delete own event images"
+ON storage.objects FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'event-images'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);


### PR DESCRIPTION
## Summary
Introduces a view mode system that allows users to toggle between "edit" and "present" modes within the timeline editor. In present mode, editing affordances (add event buttons, event click handlers, drag interactions) are hidden, providing a read-only viewing experience.

## Key Changes

- **New `useViewMode` hook** (`src/hooks/useViewMode.ts`): Manages view mode state with 'edit' and 'present' options
- **New `PresentModeSelector` component** (`src/components/Navigation/PresentModeSelector.tsx`): Tab-style UI component for toggling between edit and present modes with icons
- **Updated `GlobalNav` component**: 
  - Replaced `onPresentMode` callback with `mode` and `onModeChange` props
  - Added `lockedMode` prop to force a specific mode (used in TimelineViewer)
  - Conditionally renders the mode toggle and hides edit action buttons in present mode
  - Changed title display from `<p>` to `<span>` for semantic correctness
- **Updated `Timeline` component**: 
  - Added `mode` prop to control interaction behavior
  - Disables month/event click handlers, drag interactions, and hover states when in present mode
  - Updates cursor styling based on mode
- **Updated `App` component**:
  - Integrated `useViewMode` hook for managing global view state
  - Replaced `handlePresentMode` function with mode state management
  - Added effect to collapse UI panels when switching to present mode
  - Removed unused `saveDraftImmediate` call
- **Updated `TimelineViewer` component**: Sets `mode="present"` to enforce read-only viewing

## Implementation Details

- Mode state is managed at the App level and passed down through props
- The `lockedMode` prop allows components to force a specific mode (e.g., TimelineViewer always uses present mode)
- Edit affordances are conditionally rendered/enabled based on `isEditMode` derived from the effective mode
- The mode toggle only appears in timeline variant with an active `onModeChange` handler and no locked mode

https://claude.ai/code/session_01RYpSdg8QjfLoRMLtZ8BJpQ