### PR TITLE
Add AI-powered event enrichment with detail panel and view mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { useSidePanel } from './hooks/useSidePanel';
 import { computeDominantCategoryColor } from './utils/dominantCategory';
 import { AuthModal } from './components/Auth/AuthModal';
 import { UnsavedChangesModal } from './components/Modal/UnsavedChangesModal';
+import { ApiKeyModal } from './components/Modal/ApiKeyModal';
 import { EventDetailPanel } from './components/EventDetailPanel/EventDetailPanel';
 import { useLocalDraft } from './hooks/useLocalDraft';
 import { TimelineEvent, CategoryConfig } from './types/event';
@@ -45,6 +46,11 @@ export function App() {
   const [showAddEventModal, setShowAddEventModal] = useState(false);
   const [mode, setMode] = useState<'edit' | 'view'>('edit');
   const [detailPanelEvent, setDetailPanelEvent] = useState<TimelineEvent | null>(null);
+  const [showApiKeyModal, setShowApiKeyModal] = useState(false);
+  // Once a key is saved or sign-in completes, we want to re-open the panel for
+  // the same event so generation kicks off automatically. This holds the
+  // event we were trying to enrich when the user landed on setup-required.
+  const pendingDetailEventRef = useRef<TimelineEvent | null>(null);
   const [pendingScrollDate, setPendingScrollDate] = useState<string | null>(null);
   const [draftHydrated, setDraftHydrated] = useState(false);
   const [nudgeDismissed, setNudgeDismissed] = useState(false);
@@ -76,6 +82,15 @@ export function App() {
     () => computeDominantCategoryColor(events, categories),
     [events, categories],
   );
+
+  // After sign-in completes, re-open the detail panel for the event that
+  // landed on setup-required, so the now-available server path can run.
+  useEffect(() => {
+    if (user && pendingDetailEventRef.current) {
+      setDetailPanelEvent(pendingDetailEventRef.current);
+      pendingDetailEventRef.current = null;
+    }
+  }, [user]);
 
   // Trigger autosave when timeline data changes
   useEffect(() => {
@@ -650,8 +665,25 @@ export function App() {
           handleUpdateEvent(updated);
           setDetailPanelEvent(updated);
         }}
-        onRequestSignIn={() => {
+        onRequestSetup={() => {
+          pendingDetailEventRef.current = detailPanelEvent;
           setDetailPanelEvent(null);
+          setShowApiKeyModal(true);
+        }}
+      />
+      <ApiKeyModal
+        isOpen={showApiKeyModal}
+        onClose={() => setShowApiKeyModal(false)}
+        onKeySaved={() => {
+          setShowApiKeyModal(false);
+          // Resume the panel; the new key flips us straight into generating.
+          if (pendingDetailEventRef.current) {
+            setDetailPanelEvent(pendingDetailEventRef.current);
+            pendingDetailEventRef.current = null;
+          }
+        }}
+        onRequestSignIn={() => {
+          setShowApiKeyModal(false);
           setShowAuthModal(true);
         }}
       />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -650,6 +650,10 @@ export function App() {
           handleUpdateEvent(updated);
           setDetailPanelEvent(updated);
         }}
+        onRequestSignIn={() => {
+          setDetailPanelEvent(null);
+          setShowAuthModal(true);
+        }}
       />
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { useSidePanel } from './hooks/useSidePanel';
 import { computeDominantCategoryColor } from './utils/dominantCategory';
 import { AuthModal } from './components/Auth/AuthModal';
 import { UnsavedChangesModal } from './components/Modal/UnsavedChangesModal';
+import { EventDetailPanel } from './components/EventDetailPanel/EventDetailPanel';
 import { useLocalDraft } from './hooks/useLocalDraft';
 import { TimelineEvent, CategoryConfig } from './types/event';
 import { LimitReachedError, getCurrentLimits } from './lib/limits';
@@ -42,6 +43,8 @@ export function App() {
   const [showUnsavedChangesModal, setShowUnsavedChangesModal] = useState(false);
   const [activePanel, setActivePanel] = useState<'events' | 'settings' | null>(null);
   const [showAddEventModal, setShowAddEventModal] = useState(false);
+  const [mode, setMode] = useState<'edit' | 'view'>('edit');
+  const [detailPanelEvent, setDetailPanelEvent] = useState<TimelineEvent | null>(null);
   const [pendingScrollDate, setPendingScrollDate] = useState<string | null>(null);
   const [draftHydrated, setDraftHydrated] = useState(false);
   const [nudgeDismissed, setNudgeDismissed] = useState(false);
@@ -510,6 +513,10 @@ export function App() {
     updateEvent(updatedEvent);
   };
 
+  const handleDeleteEvent = (eventId: string) => {
+    setEvents(events.filter(e => e.id !== eventId));
+  };
+
   const handleBulkEventsChange = (newEvents: TimelineEvent[]) => {
     const currentIds = new Set(events.map(e => e.id));
     const addedEvents = newEvents.filter(e => !currentIds.has(e.id));
@@ -540,6 +547,12 @@ export function App() {
         onPresentMode={handlePresentMode}
         saveStatus={saveStatus}
         lastSavedTime={lastSavedTime}
+        mode={mode}
+        onModeChange={(newMode) => {
+          setMode(newMode);
+          // Force any open editing panel closed when switching to view mode.
+          if (newMode === 'view') setActivePanel(null);
+        }}
       />
       <Header
         title={title}
@@ -563,6 +576,7 @@ export function App() {
         onAddEventClick={handleAddEventClick}
         onCloseAddEventModal={() => setShowAddEventModal(false)}
         onDeleteTimeline={handleDeleteTimeline}
+        mode={mode}
       />
       {!user && events.length > 0 && !nudgeDismissed && (
         <div className="mx-4 mt-2 px-4 py-3 bg-blue-900/40 border border-blue-800/50 rounded-lg flex items-center justify-between text-sm shrink-0">
@@ -601,12 +615,15 @@ export function App() {
           <Timeline
             events={events}
             categories={categories}
-            onAddEvent={addEvent}
-            onUpdateEvent={handleUpdateEvent}
+            onAddEvent={mode === 'edit' ? addEvent : undefined}
+            onUpdateEvent={mode === 'edit' ? handleUpdateEvent : undefined}
+            onDeleteEvent={mode === 'edit' ? handleDeleteEvent : undefined}
+            onOpenDetails={(event) => setDetailPanelEvent(event)}
             scale={currentScale}
             groupByCategory={groupByCategory}
             pendingScrollDate={pendingScrollDate}
             onScrollComplete={() => setPendingScrollDate(null)}
+            mode={mode}
           />
         </main>
       )}
@@ -622,6 +639,17 @@ export function App() {
         }}
         onDiscard={handleDiscardAndSwitch}
         onSave={handleSaveAndSwitch}
+      />
+      <EventDetailPanel
+        open={detailPanelEvent !== null}
+        event={detailPanelEvent}
+        timelineTitle={title}
+        mode={mode}
+        onClose={() => setDetailPanelEvent(null)}
+        onEventChange={(updated) => {
+          handleUpdateEvent(updated);
+          setDetailPanelEvent(updated);
+        }}
       />
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,7 +55,7 @@ export function App() {
   const [draftHydrated, setDraftHydrated] = useState(false);
   const [nudgeDismissed, setNudgeDismissed] = useState(false);
   const [activeDraftId, setActiveDraftId] = useState<string | null>(null);
-  const { loadAllDrafts, loadDraft, saveDraft, saveDraftImmediate, createDraft, clearAllDrafts, deleteDraft: deleteLocalDraft } = useLocalDraft();
+  const { loadAllDrafts, loadDraft, saveDraft, createDraft, clearAllDrafts, deleteDraft: deleteLocalDraft } = useLocalDraft();
   const handledRouteStateRef = useRef(false);
   const migrationDoneRef = useRef(false);
   const { setOnTimelineSelect, setOnDraftSelect, refreshTimelines, setActiveTimelineId, setActiveDraftId: setPanelActiveDraftId, setActiveTimelineTitle, setActiveEventCount, setActiveDominantCategoryColor } = useSidePanel();
@@ -472,22 +472,6 @@ export function App() {
     return () => setActiveDominantCategoryColor(null);
   }, [timelineAccentColor, setActiveDominantCategoryColor]);
 
-  const handlePresentMode = () => {
-    if (timelineId) {
-      window.open(`/view/${timelineId}`, '_blank');
-    } else if (activeDraftId) {
-      // Flush current state to localStorage synchronously so the new tab can read it
-      saveDraftImmediate({
-        id: activeDraftId,
-        title, description, events, categories,
-        scale: currentScale.value,
-        groupByCategory,
-        savedAt: new Date().toISOString()
-      });
-      window.open(`/view/local?draftId=${activeDraftId}`, '_blank');
-    }
-  };
-
   const handleClearTimeline = () => {
     clearEvents();
   };
@@ -559,7 +543,6 @@ export function App() {
         onEventsClick={() => setActivePanel(prev => prev === 'events' ? null : 'events')}
         onSettingsClick={() => setActivePanel(prev => prev === 'settings' ? null : 'settings')}
         activePanel={activePanel}
-        onPresentMode={handlePresentMode}
         saveStatus={saveStatus}
         lastSavedTime={lastSavedTime}
         mode={mode}

--- a/src/components/AIMode/AIModePage.tsx
+++ b/src/components/AIMode/AIModePage.tsx
@@ -1,7 +1,12 @@
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { GlobalNav } from '@/components/Navigation/GlobalNav'
 import { NewTimelineScreen } from '@/components/NewTimeline/NewTimelineScreen'
 import { useAIMode } from '@/hooks/useAIMode'
+import { useAuth } from '@/hooks/useAuth'
+import { useAnthropicKey } from '@/services/userApiKey'
+import { AuthModal } from '@/components/Auth/AuthModal'
+import { ApiKeyModal } from '@/components/Modal/ApiKeyModal'
 
 export function AIModePage() {
   const navigate = useNavigate()
@@ -13,8 +18,15 @@ export function AIModePage() {
     classifyAndGenerate,
     abort,
   } = useAIMode()
+  const { user } = useAuth()
+  const apiKey = useAnthropicKey()
+  const [showApiKeyModal, setShowApiKeyModal] = useState(false)
+  const [showAuthModal, setShowAuthModal] = useState(false)
+  // Subject the user was trying to generate when they hit the setup gate.
+  // Resumed automatically once they save a key or sign in.
+  const pendingSubjectRef = useRef<string | null>(null)
 
-  const handleAIGenerate = async (subject: string) => {
+  const runGenerate = async (subject: string) => {
     try {
       const { title, description, events, categories } = await classifyAndGenerate(subject)
       navigate('/editor', {
@@ -26,6 +38,29 @@ export function AIModePage() {
       // Error is surfaced via the `error` state in useAIMode and rendered below.
     }
   }
+
+  const handleAIGenerate = async (subject: string) => {
+    // BYOK or signed-in user → run directly. Otherwise prompt.
+    if (apiKey || user) {
+      await runGenerate(subject)
+      return
+    }
+    pendingSubjectRef.current = subject
+    setShowApiKeyModal(true)
+  }
+
+  // Resume the pending generation once the user has signed in (the AuthModal
+  // path closes the modal before auth state propagates, so `onClose` may run
+  // with a stale `user`).
+  useEffect(() => {
+    if (user && pendingSubjectRef.current) {
+      const subject = pendingSubjectRef.current
+      pendingSubjectRef.current = null
+      runGenerate(subject)
+    }
+    // runGenerate is stable enough — its only deps are setters / hook returns.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user])
 
   const handleCancel = () => {
     abort()
@@ -43,6 +78,26 @@ export function AIModePage() {
         isClassifying={isClassifying}
         classifiedType={classifiedType}
         error={error}
+      />
+      <ApiKeyModal
+        isOpen={showApiKeyModal}
+        onClose={() => setShowApiKeyModal(false)}
+        onKeySaved={() => {
+          setShowApiKeyModal(false)
+          if (pendingSubjectRef.current) {
+            const subject = pendingSubjectRef.current
+            pendingSubjectRef.current = null
+            runGenerate(subject)
+          }
+        }}
+        onRequestSignIn={() => {
+          setShowApiKeyModal(false)
+          setShowAuthModal(true)
+        }}
+      />
+      <AuthModal
+        isOpen={showAuthModal}
+        onClose={() => setShowAuthModal(false)}
       />
     </div>
   )

--- a/src/components/EventActionsMenu/EventActionsMenu.tsx
+++ b/src/components/EventActionsMenu/EventActionsMenu.tsx
@@ -45,70 +45,80 @@ export function EventActionsMenu({
     setAdjusted({ left, top })
   }, [position.x, position.y])
 
-  // Close on outside click + Escape.
+  // Close on Escape. (Outside-click closes via the invisible overlay below
+  // — that way the click is also absorbed and doesn't fall through to the
+  // timeline grid, which would otherwise fire its month-click handler and
+  // create a new event at the click position.)
   useEffect(() => {
-    const handleDocClick = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        onClose()
-      }
-    }
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
     }
-    // Defer to next tick so the click that opened the menu doesn't close it.
-    const tid = window.setTimeout(() => {
-      document.addEventListener('mousedown', handleDocClick)
-    }, 0)
     document.addEventListener('keydown', handleKey)
-    return () => {
-      window.clearTimeout(tid)
-      document.removeEventListener('mousedown', handleDocClick)
-      document.removeEventListener('keydown', handleKey)
-    }
+    return () => document.removeEventListener('keydown', handleKey)
   }, [onClose])
 
   if (typeof document === 'undefined') return null
 
   return createPortal(
-    <div
-      ref={menuRef}
-      role="menu"
-      style={{
-        position: 'fixed',
-        left: adjusted.left,
-        top: adjusted.top,
-        width: MENU_WIDTH,
-        minHeight: MENU_HEIGHT,
-        zIndex: 1000,
-      }}
-      className="bg-[#171717] border border-[#404040] rounded-[6px] shadow-[0_4px_12px_rgba(0,0,0,0.4)] py-1"
-    >
-      <MenuItem
-        onClick={() => {
-          onEdit()
+    <>
+      {/* Invisible click-catcher. Sits above the timeline, below the menu.
+          mousedown closes (and stops propagation), so the underlying grid
+          never sees the click. Same trick for click + contextmenu so a
+          right-click anywhere outside also dismisses cleanly. */}
+      <div
+        onMouseDown={(e) => {
+          e.stopPropagation()
           onClose()
         }}
-      >
-        Edit event
-      </MenuItem>
-      <MenuItem
-        onClick={() => {
-          onOpenDetails()
+        onClick={(e) => e.stopPropagation()}
+        onContextMenu={(e) => {
+          e.preventDefault()
           onClose()
         }}
-      >
-        Open details
-      </MenuItem>
-      <MenuItem
-        destructive
-        onClick={() => {
-          onDelete()
-          onClose()
+        className="fixed inset-0"
+        style={{ zIndex: 999 }}
+        aria-hidden="true"
+      />
+      <div
+        ref={menuRef}
+        role="menu"
+        style={{
+          position: 'fixed',
+          left: adjusted.left,
+          top: adjusted.top,
+          width: MENU_WIDTH,
+          minHeight: MENU_HEIGHT,
+          zIndex: 1000,
         }}
+        className="bg-[#171717] border border-[#404040] rounded-[6px] shadow-[0_4px_12px_rgba(0,0,0,0.4)] py-1"
       >
-        Delete
-      </MenuItem>
-    </div>,
+        <MenuItem
+          onClick={() => {
+            onEdit()
+            onClose()
+          }}
+        >
+          Edit event
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            onOpenDetails()
+            onClose()
+          }}
+        >
+          Open details
+        </MenuItem>
+        <MenuItem
+          destructive
+          onClick={() => {
+            onDelete()
+            onClose()
+          }}
+        >
+          Delete
+        </MenuItem>
+      </div>
+    </>,
     document.body,
   )
 }

--- a/src/components/EventActionsMenu/EventActionsMenu.tsx
+++ b/src/components/EventActionsMenu/EventActionsMenu.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import type { TimelineEvent } from '@/types/event'
+
+interface EventActionsMenuProps {
+  event: TimelineEvent
+  position: { x: number; y: number }
+  onClose: () => void
+  onEdit: () => void
+  onOpenDetails: () => void
+  onDelete: () => void
+}
+
+const MENU_WIDTH = 144
+const MENU_HEIGHT = 116 // 3 items × ~36px + 4px padding
+
+export function EventActionsMenu({
+  position,
+  onClose,
+  onEdit,
+  onOpenDetails,
+  onDelete,
+}: EventActionsMenuProps) {
+  const menuRef = useRef<HTMLDivElement | null>(null)
+  const [adjusted, setAdjusted] = useState<{ left: number; top: number }>({
+    left: position.x,
+    top: position.y,
+  })
+
+  // Flip horizontally / vertically if the menu would overflow the viewport.
+  useLayoutEffect(() => {
+    const node = menuRef.current
+    if (!node) return
+    const rect = node.getBoundingClientRect()
+    const vw = window.innerWidth
+    const vh = window.innerHeight
+    let left = position.x
+    let top = position.y
+    if (left + rect.width > vw - 8) {
+      left = Math.max(8, position.x - rect.width)
+    }
+    if (top + rect.height > vh - 8) {
+      top = Math.max(8, position.y - rect.height)
+    }
+    setAdjusted({ left, top })
+  }, [position.x, position.y])
+
+  // Close on outside click + Escape.
+  useEffect(() => {
+    const handleDocClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    // Defer to next tick so the click that opened the menu doesn't close it.
+    const tid = window.setTimeout(() => {
+      document.addEventListener('mousedown', handleDocClick)
+    }, 0)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      window.clearTimeout(tid)
+      document.removeEventListener('mousedown', handleDocClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [onClose])
+
+  if (typeof document === 'undefined') return null
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      role="menu"
+      style={{
+        position: 'fixed',
+        left: adjusted.left,
+        top: adjusted.top,
+        width: MENU_WIDTH,
+        minHeight: MENU_HEIGHT,
+        zIndex: 1000,
+      }}
+      className="bg-[#171717] border border-[#404040] rounded-[6px] shadow-[0_4px_12px_rgba(0,0,0,0.4)] py-1"
+    >
+      <MenuItem
+        onClick={() => {
+          onEdit()
+          onClose()
+        }}
+      >
+        Edit event
+      </MenuItem>
+      <MenuItem
+        onClick={() => {
+          onOpenDetails()
+          onClose()
+        }}
+      >
+        Open details
+      </MenuItem>
+      <MenuItem
+        destructive
+        onClick={() => {
+          onDelete()
+          onClose()
+        }}
+      >
+        Delete
+      </MenuItem>
+    </div>,
+    document.body,
+  )
+}
+
+function MenuItem({
+  children,
+  onClick,
+  destructive,
+}: {
+  children: React.ReactNode
+  onClick: () => void
+  destructive?: boolean
+}) {
+  return (
+    <button
+      role="menuitem"
+      onClick={onClick}
+      className={`w-full text-left px-3 py-2 font-['Avenir',sans-serif] text-[14px] leading-[20px] transition-colors hover:bg-white/5 ${
+        destructive
+          ? 'text-destructive hover:text-destructive'
+          : 'text-[#c9ced4] hover:text-[#dadee5]'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/components/EventDetailPanel/EventDetailPanel.tsx
+++ b/src/components/EventDetailPanel/EventDetailPanel.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { X } from 'lucide-react'
 import { ConfirmationModal } from '../Modal/ConfirmationModal'
 import { formatDateLong } from '@/utils/dateUtils'
+import { useAuth } from '@/hooks/useAuth'
 import {
   enrichEvent,
   fetchEventImage,
@@ -16,9 +17,11 @@ interface EventDetailPanelProps {
   mode: 'edit' | 'view'
   onClose: () => void
   onEventChange: (updated: TimelineEvent) => void
+  /** Optional: trigger the sign-in modal from the panel's logged-out state. */
+  onRequestSignIn?: () => void
 }
 
-type PanelState = 'idle' | 'generating' | 'loaded' | 'error'
+type PanelState = 'idle' | 'generating' | 'loaded' | 'error' | 'signin-required'
 
 function formatDateRange(event: TimelineEvent): string {
   if (event.startDate === event.endDate) return formatDateLong(event.startDate)
@@ -36,7 +39,9 @@ export function EventDetailPanel({
   mode,
   onClose,
   onEventChange,
+  onRequestSignIn,
 }: EventDetailPanelProps) {
+  const { user } = useAuth()
   const [state, setState] = useState<PanelState>('idle')
   const [streamedDescription, setStreamedDescription] = useState('')
   const [imageUrl, setImageUrl] = useState<string | null>(null)
@@ -45,6 +50,7 @@ export function EventDetailPanel({
   const [errorMessage, setErrorMessage] = useState('')
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false)
   const abortRef = useRef<AbortController | null>(null)
+  const panelRef = useRef<HTMLElement | null>(null)
 
   // Reset state when the panel closes or the event changes.
   useEffect(() => {
@@ -74,6 +80,19 @@ export function EventDetailPanel({
       return
     }
 
+    // Generation requires a signed-in user (the edge function rejects
+    // anonymous calls). Surface a friendly sign-in prompt instead of running
+    // the request just to show an auth error.
+    if (!user) {
+      setState('signin-required')
+      setStreamedDescription('')
+      setImageUrl(null)
+      setImageAttribution(null)
+      setSources([])
+      setErrorMessage('')
+      return
+    }
+
     setState('generating')
     setStreamedDescription('')
     setImageUrl(null)
@@ -83,7 +102,7 @@ export function EventDetailPanel({
 
     runGeneration(event, false)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, event?.id])
+  }, [open, event?.id, user])
 
   // Cleanup on unmount
   useEffect(() => {
@@ -92,15 +111,34 @@ export function EventDetailPanel({
     }
   }, [])
 
-  // Escape closes the panel (desktop). Mobile uses the X button.
+  // Escape closes the panel. Click outside the panel also closes it (desktop
+  // has no visible backdrop so the timeline behind stays visible, but a click
+  // anywhere off-panel should still dismiss the way Cancel would). Suppress
+  // outside-click while the destructive Remove confirmation modal is open so
+  // clicking the modal's overlay doesn't also dismiss the panel.
   useEffect(() => {
     if (!open) return
-    const handler = (e: KeyboardEvent) => {
+    const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
     }
-    document.addEventListener('keydown', handler)
-    return () => document.removeEventListener('keydown', handler)
-  }, [open, onClose])
+    const handleMouseDown = (e: MouseEvent) => {
+      if (showRemoveConfirm) return
+      const node = panelRef.current
+      if (!node) return
+      const target = e.target as Node | null
+      if (target && !node.contains(target)) {
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', handleKey)
+    // mousedown (not click) so we close before any background element starts
+    // its own interaction (e.g. dragging an event).
+    document.addEventListener('mousedown', handleMouseDown)
+    return () => {
+      document.removeEventListener('keydown', handleKey)
+      document.removeEventListener('mousedown', handleMouseDown)
+    }
+  }, [open, onClose, showRemoveConfirm])
 
   function runGeneration(currentEvent: TimelineEvent, preserveImage: boolean) {
     // Abort any prior in-flight generation
@@ -213,6 +251,7 @@ export function EventDetailPanel({
       />
 
       <aside
+        ref={panelRef}
         className={`fixed inset-0 md:inset-y-0 md:right-0 md:left-auto md:w-[326px] md:pr-[6px] md:py-[6px] z-50 transition-transform duration-300 ease-out ${
           open ? 'translate-x-0' : 'translate-x-full'
         }`}
@@ -272,7 +311,21 @@ export function EventDetailPanel({
                 <h2 className="header-xsmall text-[#DADEE5] m-0">{event.title}</h2>
 
                 {/* Description / state */}
-                {state === 'error' ? (
+                {state === 'signin-required' ? (
+                  <div className="flex flex-col gap-2">
+                    <p className="body-m text-[#9B9EA3] m-0">
+                      Sign in to generate AI-powered details for this event.
+                    </p>
+                    {onRequestSignIn && (
+                      <button
+                        onClick={onRequestSignIn}
+                        className="self-start font-['Avenir',sans-serif] text-[14px] leading-[20px] text-[#DADEE5] underline hover:text-white"
+                      >
+                        Sign in
+                      </button>
+                    )}
+                  </div>
+                ) : state === 'error' ? (
                   <div className="flex flex-col gap-2">
                     <p className="body-m text-[#9B9EA3] m-0">
                       Couldn't generate details. {errorMessage ? `(${errorMessage})` : ''}

--- a/src/components/EventDetailPanel/EventDetailPanel.tsx
+++ b/src/components/EventDetailPanel/EventDetailPanel.tsx
@@ -243,10 +243,11 @@ export function EventDetailPanel({
 
   return createPortal(
     <>
-      {/* Mobile-only backdrop */}
+      {/* Backdrop — same bg-black/50 overlay used by FeedbackPanel and
+          TimelineSettingsPanel. Clicking dismisses the panel. */}
       <div
         onClick={onClose}
-        className={`md:hidden fixed inset-0 z-40 bg-black/50 transition-opacity duration-300 ease-out ${
+        className={`fixed inset-0 z-40 bg-black/50 transition-opacity duration-300 ease-out ${
           open ? 'opacity-100' : 'opacity-0 pointer-events-none'
         }`}
         aria-hidden="true"

--- a/src/components/EventDetailPanel/EventDetailPanel.tsx
+++ b/src/components/EventDetailPanel/EventDetailPanel.tsx
@@ -75,13 +75,10 @@ export function EventDetailPanel({
       return
     }
 
-    // Fresh event — only auto-generate in edit mode (view-mode click on an
-    // empty event is supposed to be a no-op upstream, but guard anyway).
-    if (mode !== 'edit') {
-      setState('idle')
-      return
-    }
-
+    // Fresh event — auto-generation runs in either edit or view/present mode
+    // as long as a path is available. Public viewers' generations get
+    // persisted client-side by their TimelineViewer's onEventChange handler.
+    //
     // Generation needs at least one of: a BYOK Anthropic key (browser-direct)
     // or a signed-in user (server path). Without either, prompt the user to
     // pick a path instead of running a request that's destined to fail.

--- a/src/components/EventDetailPanel/EventDetailPanel.tsx
+++ b/src/components/EventDetailPanel/EventDetailPanel.tsx
@@ -4,6 +4,7 @@ import { X } from 'lucide-react'
 import { ConfirmationModal } from '../Modal/ConfirmationModal'
 import { formatDateLong } from '@/utils/dateUtils'
 import { useAuth } from '@/hooks/useAuth'
+import { useAnthropicKey } from '@/services/userApiKey'
 import {
   enrichEvent,
   fetchEventImage,
@@ -17,11 +18,11 @@ interface EventDetailPanelProps {
   mode: 'edit' | 'view'
   onClose: () => void
   onEventChange: (updated: TimelineEvent) => void
-  /** Optional: trigger the sign-in modal from the panel's logged-out state. */
-  onRequestSignIn?: () => void
+  /** Trigger the BYOK / sign-in setup modal when neither path is available. */
+  onRequestSetup?: () => void
 }
 
-type PanelState = 'idle' | 'generating' | 'loaded' | 'error' | 'signin-required'
+type PanelState = 'idle' | 'generating' | 'loaded' | 'error' | 'setup-required'
 
 function formatDateRange(event: TimelineEvent): string {
   if (event.startDate === event.endDate) return formatDateLong(event.startDate)
@@ -39,9 +40,10 @@ export function EventDetailPanel({
   mode,
   onClose,
   onEventChange,
-  onRequestSignIn,
+  onRequestSetup,
 }: EventDetailPanelProps) {
   const { user } = useAuth()
+  const apiKey = useAnthropicKey()
   const [state, setState] = useState<PanelState>('idle')
   const [streamedDescription, setStreamedDescription] = useState('')
   const [imageUrl, setImageUrl] = useState<string | null>(null)
@@ -80,11 +82,11 @@ export function EventDetailPanel({
       return
     }
 
-    // Generation requires a signed-in user (the edge function rejects
-    // anonymous calls). Surface a friendly sign-in prompt instead of running
-    // the request just to show an auth error.
-    if (!user) {
-      setState('signin-required')
+    // Generation needs at least one of: a BYOK Anthropic key (browser-direct)
+    // or a signed-in user (server path). Without either, prompt the user to
+    // pick a path instead of running a request that's destined to fail.
+    if (!apiKey && !user) {
+      setState('setup-required')
       setStreamedDescription('')
       setImageUrl(null)
       setImageAttribution(null)
@@ -102,7 +104,7 @@ export function EventDetailPanel({
 
     runGeneration(event, false)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, event?.id, user])
+  }, [open, event?.id, user, apiKey])
 
   // Cleanup on unmount
   useEffect(() => {
@@ -311,17 +313,17 @@ export function EventDetailPanel({
                 <h2 className="header-xsmall text-[#DADEE5] m-0">{event.title}</h2>
 
                 {/* Description / state */}
-                {state === 'signin-required' ? (
+                {state === 'setup-required' ? (
                   <div className="flex flex-col gap-2">
                     <p className="body-m text-[#9B9EA3] m-0">
-                      Sign in to generate AI-powered details for this event.
+                      Generate with AI — paste your Anthropic key or sign in.
                     </p>
-                    {onRequestSignIn && (
+                    {onRequestSetup && (
                       <button
-                        onClick={onRequestSignIn}
+                        onClick={onRequestSetup}
                         className="self-start font-['Avenir',sans-serif] text-[14px] leading-[20px] text-[#DADEE5] underline hover:text-white"
                       >
-                        Sign in
+                        Set up AI
                       </button>
                     )}
                   </div>

--- a/src/components/EventDetailPanel/EventDetailPanel.tsx
+++ b/src/components/EventDetailPanel/EventDetailPanel.tsx
@@ -1,0 +1,365 @@
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { X } from 'lucide-react'
+import { ConfirmationModal } from '../Modal/ConfirmationModal'
+import { formatDateLong } from '@/utils/dateUtils'
+import {
+  enrichEvent,
+  fetchEventImage,
+} from '@/services/eventEnrichment'
+import type { EventSource, TimelineEvent } from '@/types/event'
+
+interface EventDetailPanelProps {
+  open: boolean
+  event: TimelineEvent | null
+  timelineTitle: string
+  mode: 'edit' | 'view'
+  onClose: () => void
+  onEventChange: (updated: TimelineEvent) => void
+}
+
+type PanelState = 'idle' | 'generating' | 'loaded' | 'error'
+
+function formatDateRange(event: TimelineEvent): string {
+  if (event.startDate === event.endDate) return formatDateLong(event.startDate)
+  return `${formatDateLong(event.startDate)} → ${formatDateLong(event.endDate)}`
+}
+
+function hasGeneratedContent(event: TimelineEvent | null): boolean {
+  return Boolean(event?.description)
+}
+
+export function EventDetailPanel({
+  open,
+  event,
+  timelineTitle,
+  mode,
+  onClose,
+  onEventChange,
+}: EventDetailPanelProps) {
+  const [state, setState] = useState<PanelState>('idle')
+  const [streamedDescription, setStreamedDescription] = useState('')
+  const [imageUrl, setImageUrl] = useState<string | null>(null)
+  const [imageAttribution, setImageAttribution] = useState<string | null>(null)
+  const [sources, setSources] = useState<EventSource[]>([])
+  const [errorMessage, setErrorMessage] = useState('')
+  const [showRemoveConfirm, setShowRemoveConfirm] = useState(false)
+  const abortRef = useRef<AbortController | null>(null)
+
+  // Reset state when the panel closes or the event changes.
+  useEffect(() => {
+    if (!open || !event) {
+      // Cleanup any in-flight stream when panel closes.
+      if (abortRef.current) {
+        abortRef.current.abort()
+        abortRef.current = null
+      }
+      return
+    }
+
+    if (hasGeneratedContent(event)) {
+      // Cached content — render straight from the event.
+      setState('loaded')
+      setStreamedDescription(event.description ?? '')
+      setImageUrl(event.imageUrl ?? null)
+      setImageAttribution(event.imageAttribution ?? null)
+      setSources(event.sources ?? [])
+      return
+    }
+
+    // Fresh event — only auto-generate in edit mode (view-mode click on an
+    // empty event is supposed to be a no-op upstream, but guard anyway).
+    if (mode !== 'edit') {
+      setState('idle')
+      return
+    }
+
+    setState('generating')
+    setStreamedDescription('')
+    setImageUrl(null)
+    setImageAttribution(null)
+    setSources([])
+    setErrorMessage('')
+
+    runGeneration(event, false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, event?.id])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (abortRef.current) abortRef.current.abort()
+    }
+  }, [])
+
+  // Escape closes the panel (desktop). Mobile uses the X button.
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open, onClose])
+
+  function runGeneration(currentEvent: TimelineEvent, preserveImage: boolean) {
+    // Abort any prior in-flight generation
+    if (abortRef.current) abortRef.current.abort()
+    const ctrl = new AbortController()
+    abortRef.current = ctrl
+
+    setState('generating')
+    setStreamedDescription('')
+    if (!preserveImage) {
+      setImageUrl(null)
+      setImageAttribution(null)
+    }
+    setSources([])
+    setErrorMessage('')
+
+    let descBuffer = ''
+    let collectedSources: EventSource[] = []
+    let nextImageUrl: string | null = preserveImage ? currentEvent.imageUrl ?? null : null
+    let nextImageAttribution: string | null = preserveImage
+      ? currentEvent.imageAttribution ?? null
+      : null
+
+    // Image fetch in parallel with text streaming. Only re-fetch if not preserving.
+    if (!preserveImage) {
+      fetchEventImage(currentEvent.title)
+        .then((res) => {
+          if (ctrl.signal.aborted) return
+          nextImageUrl = res.imageUrl
+          nextImageAttribution = res.attribution
+          setImageUrl(res.imageUrl)
+          setImageAttribution(res.attribution)
+        })
+        .catch(() => {
+          // Already returns null/null on errors — nothing to do.
+        })
+    }
+
+    enrichEvent(
+      currentEvent,
+      timelineTitle,
+      {
+        onDelta: (text) => {
+          if (ctrl.signal.aborted) return
+          descBuffer += text
+          setStreamedDescription(descBuffer)
+        },
+        onSources: (s) => {
+          if (ctrl.signal.aborted) return
+          collectedSources = s
+          setSources(s)
+        },
+        onDone: () => {
+          if (ctrl.signal.aborted) return
+          // Persist the full set of fields atomically.
+          onEventChange({
+            ...currentEvent,
+            description: descBuffer || null,
+            imageUrl: nextImageUrl,
+            imageAttribution: nextImageAttribution,
+            sources: collectedSources.length > 0 ? collectedSources : null,
+          })
+          setState('loaded')
+        },
+        onError: (message) => {
+          if (ctrl.signal.aborted) return
+          setErrorMessage(message)
+          setState('error')
+        },
+      },
+      ctrl.signal,
+    )
+  }
+
+  function handleRegenerate() {
+    if (!event) return
+    // Preserve image only if we already have one.
+    runGeneration(event, !!imageUrl)
+  }
+
+  function handleRemove() {
+    if (!event) return
+    onEventChange({
+      ...event,
+      description: null,
+      imageUrl: null,
+      imageAttribution: null,
+      sources: null,
+    })
+    onClose()
+  }
+
+  if (typeof document === 'undefined') return null
+
+  const showFooter = mode === 'edit' && open && !!event
+  const description = state === 'loaded' ? event?.description ?? streamedDescription : streamedDescription
+  const displayImageUrl = state === 'loaded' ? event?.imageUrl ?? imageUrl : imageUrl
+  const displayAttribution = state === 'loaded' ? event?.imageAttribution ?? imageAttribution : imageAttribution
+  const displaySources = state === 'loaded' ? event?.sources ?? sources : sources
+
+  return createPortal(
+    <>
+      {/* Mobile-only backdrop */}
+      <div
+        onClick={onClose}
+        className={`md:hidden fixed inset-0 z-40 bg-black/50 transition-opacity duration-300 ease-out ${
+          open ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+        aria-hidden="true"
+      />
+
+      <aside
+        className={`fixed inset-0 md:inset-y-0 md:right-0 md:left-auto md:w-[326px] md:pr-[6px] md:py-[6px] z-50 transition-transform duration-300 ease-out ${
+          open ? 'translate-x-0' : 'translate-x-full'
+        }`}
+        aria-hidden={!open}
+        aria-label="Event details"
+      >
+        <div className="h-full w-full bg-[#171717] flex flex-col overflow-hidden border-0 md:border md:border-[#262626] rounded-none md:rounded-[6px]">
+          <div className="flex flex-col items-stretch p-[24px_20px] gap-[16px] overflow-y-auto flex-1 min-h-0">
+            {event && (
+              <>
+                {/* Date row + mobile close */}
+                <div className="flex items-center justify-between">
+                  <p className="label-s-type1 text-[#9B9EA3] m-0">
+                    {formatDateRange(event)}
+                  </p>
+                  <button
+                    onClick={onClose}
+                    className="md:hidden flex items-center justify-center p-1.5 rounded-lg border border-white/15 bg-white/10 backdrop-blur-[12px] text-[#c9ced4] shadow-[0px_8px_32px_0px_rgba(0,0,0,0.4),inset_0px_1px_0px_0px_rgba(255,255,255,0.1)] hover:bg-white/20 hover:text-[#dadee5] transition-colors"
+                    aria-label="Close panel"
+                  >
+                    <X size={16} strokeWidth={1.25} />
+                  </button>
+                </div>
+
+                {/* Photo frame */}
+                <div
+                  className={`w-full md:w-[274px] aspect-[274/205] bg-[#0A0A0A] border border-[#525252] rounded-[8px] overflow-hidden ${
+                    state === 'generating' && !displayImageUrl ? 'animate-pulse' : ''
+                  }`}
+                >
+                  {displayImageUrl && (
+                    <img
+                      src={displayImageUrl}
+                      alt={event.title}
+                      className="w-full h-full object-cover rounded-[8px]"
+                    />
+                  )}
+                </div>
+
+                {/* Photo attribution */}
+                {displayAttribution && (
+                  <p
+                    className="m-0"
+                    style={{
+                      fontFamily: "'Avenir', sans-serif",
+                      fontWeight: 400,
+                      fontSize: '8px',
+                      lineHeight: '140%',
+                      color: '#9B9EA3',
+                    }}
+                  >
+                    {displayAttribution}
+                  </p>
+                )}
+
+                {/* Title */}
+                <h2 className="header-xsmall text-[#DADEE5] m-0">{event.title}</h2>
+
+                {/* Description / state */}
+                {state === 'error' ? (
+                  <div className="flex flex-col gap-2">
+                    <p className="body-m text-[#9B9EA3] m-0">
+                      Couldn't generate details. {errorMessage ? `(${errorMessage})` : ''}
+                    </p>
+                    <button
+                      onClick={handleRegenerate}
+                      className="self-start font-['Avenir',sans-serif] text-[14px] leading-[20px] text-[#DADEE5] underline hover:text-white"
+                    >
+                      Try again
+                    </button>
+                  </div>
+                ) : (
+                  description &&
+                  description
+                    .split(/\n\n+/)
+                    .filter((p) => p.trim().length > 0)
+                    .map((para, i) => (
+                      <p key={i} className="body-m text-[#9B9EA3] m-0 whitespace-pre-wrap">
+                        {para}
+                      </p>
+                    ))
+                )}
+
+                {/* Sources */}
+                {displaySources && displaySources.length > 0 && (
+                  <div className="flex flex-col gap-0">
+                    <h3 className="label-m-type2 text-[#9B9EA3] m-0 mb-2">Sources</h3>
+                    {displaySources.map((source, i) => (
+                      <a
+                        key={`${source.url}-${i}`}
+                        href={source.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="body-m text-[#9B9EA3] underline hover:text-[#DADEE5] py-2 border-b border-[#262626] last:border-b-0 break-words"
+                      >
+                        {source.title || source.url}
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+
+          {showFooter && (
+            <div className="flex gap-[10px] px-[20px] pb-[20px] pt-[12px] shrink-0">
+              <FooterButton onClick={handleRegenerate} disabled={state === 'generating'}>
+                Regenerate
+              </FooterButton>
+              <FooterButton onClick={() => setShowRemoveConfirm(true)} disabled={state === 'generating'}>
+                Remove
+              </FooterButton>
+            </div>
+          )}
+        </div>
+      </aside>
+
+      <ConfirmationModal
+        isOpen={showRemoveConfirm}
+        onClose={() => setShowRemoveConfirm(false)}
+        onConfirm={handleRemove}
+        title="Remove event details"
+        message="This will clear the description, image, and sources for this event. The event itself will not be deleted."
+        confirmLabel="Remove"
+        cancelLabel="Cancel"
+      />
+    </>,
+    document.body,
+  )
+}
+
+function FooterButton({
+  children,
+  onClick,
+  disabled,
+}: {
+  children: React.ReactNode
+  onClick: () => void
+  disabled?: boolean
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="flex-1 flex items-center justify-center h-[33px] px-[10px] py-[5px] rounded-[10px] border border-white/[0.15] bg-white/10 backdrop-blur-[12px] shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_1px_rgba(255,255,255,0.1)] font-['Avenir',sans-serif] font-medium text-[14px] leading-[150%] text-[#C9CED4] hover:bg-white/20 hover:text-[#dadee5] transition-colors disabled:opacity-50 disabled:pointer-events-none"
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -33,6 +33,7 @@ interface HeaderProps {
   onAddEventClick: () => void;
   onCloseAddEventModal: () => void;
   onDeleteTimeline: () => Promise<void> | void;
+  mode?: 'edit' | 'view';
 }
 
 export function Header({
@@ -57,6 +58,7 @@ export function Header({
   onAddEventClick,
   onCloseAddEventModal,
   onDeleteTimeline,
+  mode = 'edit',
 }: HeaderProps) {
   const closePanel = () => onActivePanelChange(null);
   const togglePanel = (panel: 'events' | 'settings') => {
@@ -70,15 +72,18 @@ export function Header({
 
   return (
     <>
-      {/* Mobile toolbar — desktop toolbar lives in GlobalNav */}
-      <div className="md:hidden">
-        <FloatingToolbar
-          onAddEventClick={onAddEventClick}
-          onEventsClick={() => togglePanel('events')}
-          onSettingsClick={() => togglePanel('settings')}
-          activePanel={activePanel}
-        />
-      </div>
+      {/* Mobile toolbar — desktop toolbar lives in GlobalNav.
+          Hidden in view mode (no editing affordances). */}
+      {mode === 'edit' && (
+        <div className="md:hidden">
+          <FloatingToolbar
+            onAddEventClick={onAddEventClick}
+            onEventsClick={() => togglePanel('events')}
+            onSettingsClick={() => togglePanel('settings')}
+            activePanel={activePanel}
+          />
+        </div>
+      )}
 
       <Dialog open={showAddEventModal} onOpenChange={(open) => { if (!open) onCloseAddEventModal(); }}>
         <DialogContent className="bg-surface-secondary border-[rgba(210,210,210,0.15)] max-w-[360px] rounded-[20px] px-5 py-6">

--- a/src/components/Modal/ApiKeyModal.tsx
+++ b/src/components/Modal/ApiKeyModal.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from 'react'
+import { Modal } from './Modal'
+import { setAnthropicKey } from '@/services/userApiKey'
+
+interface ApiKeyModalProps {
+  isOpen: boolean
+  onClose: () => void
+  /** Called after the user successfully saves a key. The caller can then
+   *  resume whatever AI generation triggered the modal. */
+  onKeySaved: () => void
+  /** Called when the user picks "Sign in instead". The parent should close
+   *  this modal and open AuthModal. */
+  onRequestSignIn: () => void
+}
+
+export function ApiKeyModal({
+  isOpen,
+  onClose,
+  onKeySaved,
+  onRequestSignIn,
+}: ApiKeyModalProps) {
+  const [draft, setDraft] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [showInput, setShowInput] = useState(false)
+
+  // Reset state every time the modal opens.
+  useEffect(() => {
+    if (isOpen) {
+      setDraft('')
+      setError(null)
+      setShowInput(false)
+    }
+  }, [isOpen])
+
+  const save = () => {
+    const trimmed = draft.trim()
+    if (!trimmed) {
+      setError('Paste a key first.')
+      return
+    }
+    if (!trimmed.startsWith('sk-ant-')) {
+      setError('Anthropic keys start with sk-ant-. Double-check and try again.')
+      return
+    }
+    setAnthropicKey(trimmed)
+    onKeySaved()
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Generate with AI">
+      <div className="space-y-4">
+        <p className="body-m text-[#c9ced4] m-0">
+          Timeline Academy uses Claude to generate event details and timelines.
+          You can use your own Anthropic API key (free, no rate limits) or sign
+          in to use ours.
+        </p>
+
+        {!showInput ? (
+          <div className="flex flex-col gap-2">
+            <button
+              onClick={() => setShowInput(true)}
+              className={glassPrimary}
+            >
+              Add Anthropic key
+            </button>
+            <button
+              onClick={onRequestSignIn}
+              className={glassSecondary}
+            >
+              Sign in instead
+            </button>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <input
+              type="password"
+              placeholder="sk-ant-..."
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') save()
+              }}
+              autoFocus
+              spellCheck={false}
+              autoComplete="off"
+              className="w-full h-9 bg-[#242526] border border-[#262626] rounded-[8px] px-3 py-[7.5px] outline-none focus:border-[#404040] font-['JetBrains_Mono',monospace] text-[12px] text-[#DADEE5]"
+            />
+            {error && (
+              <p className="body-m text-destructive m-0">{error}</p>
+            )}
+            <p className="font-['Avenir',sans-serif] text-[12px] leading-[16px] text-[#6b6e73] m-0">
+              Get a key at{' '}
+              <a
+                href="https://console.anthropic.com/settings/keys"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-[#9B9EA3]"
+              >
+                console.anthropic.com
+              </a>
+              . Stored only in this browser.
+            </p>
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={() => setShowInput(false)}
+                className={glassSecondary}
+              >
+                Back
+              </button>
+              <button onClick={save} className={glassPrimary}>
+                Save & continue
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </Modal>
+  )
+}
+
+const glassPrimary = `
+  relative px-[16px] py-[8px] rounded-[10px]
+  backdrop-blur-[12px] bg-[rgba(37,99,235,0.8)] border border-white/[0.15]
+  shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
+  font-['Avenir',sans-serif] font-medium text-[14px] text-[#dadee5]
+  hover:bg-[rgba(37,99,235,0.9)] transition-all
+`
+
+const glassSecondary = `
+  relative px-[16px] py-[8px] rounded-[10px]
+  backdrop-blur-[12px] bg-white/10 border border-white/[0.15]
+  shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
+  font-['Avenir',sans-serif] font-medium text-[14px] text-[#c9ced4]
+  hover:bg-white/20 hover:text-[#dadee5] transition-all
+`

--- a/src/components/Navigation/GlobalNav.tsx
+++ b/src/components/Navigation/GlobalNav.tsx
@@ -1,5 +1,12 @@
 import { type CSSProperties } from 'react'
-import { Columns3, PanelLeft, Plus, Settings as SettingsIcon } from 'lucide-react'
+import {
+  Columns3,
+  PanelLeft,
+  Plus,
+  Settings as SettingsIcon,
+  SquarePen,
+  SquarePlay,
+} from 'lucide-react'
 import { useSidePanel } from '@/hooks/useSidePanel'
 import { Button } from '@/components/ui/button'
 import { SaveStatusIndicator, type SaveStatus } from '@/components/SaveStatusIndicator/SaveStatusIndicator'
@@ -194,40 +201,74 @@ interface ModeToggleProps {
   onChange: (mode: 'edit' | 'view') => void
 }
 
+// Edit / Present segmented toggle. Each segment is fixed-width to match the
+// design spec (Edit = 72px, Present = 94px). The selected segment fills with
+// #262626; the unselected segment is transparent and dims its label/icon.
 function ModeToggle({ mode, onChange }: ModeToggleProps) {
-  // Glass-pill toggle that slides between Edit / View. Matches the height of
-  // the adjacent glass-sm buttons (Present / Share) so the cluster reads as
-  // one row.
+  const isEdit = mode === 'edit'
   return (
-    <div className="relative flex items-center h-[34px] rounded-[10px] backdrop-blur-[12px] bg-white/10 border border-white/[0.15] shadow-[0px_8px_32px_0px_rgba(0,0,0,0.4),inset_0px_1px_0px_0px_rgba(255,255,255,0.1)] p-[3px]">
-      {/* Sliding indicator */}
-      <div
-        className="absolute top-[3px] bottom-[3px] w-[60px] rounded-[7px] bg-[rgba(37,99,235,0.4)] pointer-events-none"
-        style={{
-          left: mode === 'edit' ? '3px' : '63px',
-          transition: 'left 200ms ease-out',
-        }}
-      />
-      <button
-        type="button"
+    <div className="flex items-start p-[4px] h-[40px] bg-[#171717] border border-[#262626] rounded-[10px]">
+      <ModeToggleSegment
+        active={isEdit}
+        // When this segment is unselected, the spec uses a slightly different
+        // grey (#9B9EA3) than the inverse case (#A3A3A3). Match exactly.
+        inactiveColor="#9B9EA3"
         onClick={() => onChange('edit')}
-        className={`relative w-[60px] h-full flex items-center justify-center rounded-[7px] font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-colors ${
-          mode === 'edit' ? 'text-[#dadee5]' : 'text-[#c9ced4] hover:text-[#dadee5]'
-        }`}
-        aria-pressed={mode === 'edit'}
-      >
-        Edit
-      </button>
-      <button
-        type="button"
+        icon={<SquarePen size={16} strokeWidth={1} />}
+        label="Edit"
+        width={72}
+      />
+      <ModeToggleSegment
+        active={!isEdit}
+        inactiveColor="#A3A3A3"
         onClick={() => onChange('view')}
-        className={`relative w-[60px] h-full flex items-center justify-center rounded-[7px] font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-colors ${
-          mode === 'view' ? 'text-[#dadee5]' : 'text-[#c9ced4] hover:text-[#dadee5]'
-        }`}
-        aria-pressed={mode === 'view'}
-      >
-        View
-      </button>
+        icon={<SquarePlay size={16} strokeWidth={1} />}
+        label="Present"
+        width={94}
+      />
     </div>
+  )
+}
+
+interface ModeToggleSegmentProps {
+  active: boolean
+  inactiveColor: string
+  onClick: () => void
+  icon: React.ReactNode
+  label: string
+  width: number
+}
+
+function ModeToggleSegment({
+  active,
+  inactiveColor,
+  onClick,
+  icon,
+  label,
+  width,
+}: ModeToggleSegmentProps) {
+  // Selected: bg #262626, label #C9CED4 / #D4D4D4 (label / icon).
+  // Unselected: no bg, label and icon both share `inactiveColor`.
+  const color = active ? '#D4D4D4' : inactiveColor
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`flex items-center justify-center gap-[6px] h-[32px] min-w-[60px] px-[12px] py-[6px] rounded-[6px] transition-colors ${
+        active ? 'bg-[#262626]' : 'bg-transparent hover:bg-white/[0.04]'
+      }`}
+      style={{ width, color }}
+    >
+      <span className="shrink-0" style={{ color }} aria-hidden>
+        {icon}
+      </span>
+      <span
+        className="font-['Avenir',sans-serif] font-normal text-[14px] leading-[20px]"
+        style={{ color: active ? '#C9CED4' : inactiveColor }}
+      >
+        {label}
+      </span>
+    </button>
   )
 }

--- a/src/components/Navigation/GlobalNav.tsx
+++ b/src/components/Navigation/GlobalNav.tsx
@@ -23,6 +23,9 @@ interface GlobalNavProps {
   /** Save status — only rendered on variant="timeline" */
   saveStatus?: SaveStatus
   lastSavedTime?: Date
+  /** Edit/View mode toggle — only rendered on variant="timeline" */
+  mode?: 'edit' | 'view'
+  onModeChange?: (mode: 'edit' | 'view') => void
 }
 
 export function GlobalNav({
@@ -39,6 +42,8 @@ export function GlobalNav({
   onPresentMode,
   saveStatus,
   lastSavedTime,
+  mode = 'edit',
+  onModeChange,
 }: GlobalNavProps) {
   const { isOpen: isPanelOpen, toggle: togglePanel } = useSidePanel()
 
@@ -80,7 +85,7 @@ export function GlobalNav({
 
           {showTitleCluster && (
             <div className="flex flex-col gap-1 min-w-0">
-              {onTimelineTitleChange ? (
+              {onTimelineTitleChange && mode === 'edit' ? (
                 <input
                   type="text"
                   value={timelineTitle ?? ''}
@@ -119,7 +124,7 @@ export function GlobalNav({
         </div>
 
         {/* Center cluster: editor action buttons */}
-        {variant === 'timeline' && (
+        {variant === 'timeline' && mode === 'edit' && (
           <div className="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 items-center gap-2.5">
             {onAddEventClick && (
               <Button variant="glass" size="none" onClick={onAddEventClick}>
@@ -156,6 +161,9 @@ export function GlobalNav({
               <SaveStatusIndicator status={saveStatus} lastSaved={lastSavedTime} />
             </div>
           )}
+          {variant === 'timeline' && onModeChange && (
+            <ModeToggle mode={mode} onChange={onModeChange} />
+          )}
           {variant === 'timeline' && (
             <>
               <Button
@@ -177,6 +185,49 @@ export function GlobalNav({
           )}
         </div>
       </div>
+    </div>
+  )
+}
+
+interface ModeToggleProps {
+  mode: 'edit' | 'view'
+  onChange: (mode: 'edit' | 'view') => void
+}
+
+function ModeToggle({ mode, onChange }: ModeToggleProps) {
+  // Glass-pill toggle that slides between Edit / View. Matches the height of
+  // the adjacent glass-sm buttons (Present / Share) so the cluster reads as
+  // one row.
+  return (
+    <div className="relative flex items-center h-[34px] rounded-[10px] backdrop-blur-[12px] bg-white/10 border border-white/[0.15] shadow-[0px_8px_32px_0px_rgba(0,0,0,0.4),inset_0px_1px_0px_0px_rgba(255,255,255,0.1)] p-[3px]">
+      {/* Sliding indicator */}
+      <div
+        className="absolute top-[3px] bottom-[3px] w-[60px] rounded-[7px] bg-[rgba(37,99,235,0.4)] pointer-events-none"
+        style={{
+          left: mode === 'edit' ? '3px' : '63px',
+          transition: 'left 200ms ease-out',
+        }}
+      />
+      <button
+        type="button"
+        onClick={() => onChange('edit')}
+        className={`relative w-[60px] h-full flex items-center justify-center rounded-[7px] font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-colors ${
+          mode === 'edit' ? 'text-[#dadee5]' : 'text-[#c9ced4] hover:text-[#dadee5]'
+        }`}
+        aria-pressed={mode === 'edit'}
+      >
+        Edit
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange('view')}
+        className={`relative w-[60px] h-full flex items-center justify-center rounded-[7px] font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-colors ${
+          mode === 'view' ? 'text-[#dadee5]' : 'text-[#c9ced4] hover:text-[#dadee5]'
+        }`}
+        aria-pressed={mode === 'view'}
+      >
+        View
+      </button>
     </div>
   )
 }

--- a/src/components/Navigation/GlobalNav.tsx
+++ b/src/components/Navigation/GlobalNav.tsx
@@ -26,7 +26,6 @@ interface GlobalNavProps {
   onEventsClick?: () => void
   onSettingsClick?: () => void
   activePanel?: 'events' | 'settings' | null
-  onPresentMode?: () => void
   /** Save status — only rendered on variant="timeline" */
   saveStatus?: SaveStatus
   lastSavedTime?: Date
@@ -46,7 +45,6 @@ export function GlobalNav({
   onEventsClick,
   onSettingsClick,
   activePanel,
-  onPresentMode,
   saveStatus,
   lastSavedTime,
   mode = 'edit',
@@ -172,23 +170,14 @@ export function GlobalNav({
             <ModeToggle mode={mode} onChange={onModeChange} />
           )}
           {variant === 'timeline' && (
-            <>
-              <Button
-                variant="glass-sm"
-                size="none"
-                onClick={onPresentMode}
-              >
-                Present
-              </Button>
-              <Button
-                variant="glass-sm"
-                size="none"
-                onClick={handleShare}
-                disabled={!timelineId}
-              >
-                Share
-              </Button>
-            </>
+            <Button
+              variant="glass-sm"
+              size="none"
+              onClick={handleShare}
+              disabled={!timelineId}
+            >
+              Share
+            </Button>
           )}
         </div>
       </div>

--- a/src/components/Settings/ApiKeySection.tsx
+++ b/src/components/Settings/ApiKeySection.tsx
@@ -1,0 +1,179 @@
+import { useState } from 'react'
+import {
+  clearAnthropicKey,
+  maskKey,
+  setAnthropicKey,
+  useAnthropicKey,
+} from '@/services/userApiKey'
+import { useAuth } from '@/hooks/useAuth'
+
+interface ApiKeySectionProps {
+  defaultExpanded?: boolean
+}
+
+export function ApiKeySection({ defaultExpanded = false }: ApiKeySectionProps) {
+  const key = useAnthropicKey()
+  const { user } = useAuth()
+  const [editing, setEditing] = useState(defaultExpanded && !key)
+  const [draft, setDraft] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const status: 'byok' | 'server' | 'unconfigured' = key
+    ? 'byok'
+    : user
+      ? 'server'
+      : 'unconfigured'
+
+  const startEdit = () => {
+    setDraft('')
+    setError(null)
+    setEditing(true)
+  }
+
+  const cancelEdit = () => {
+    setEditing(false)
+    setDraft('')
+    setError(null)
+  }
+
+  const save = () => {
+    const trimmed = draft.trim()
+    if (!trimmed) {
+      setError('Paste a key first.')
+      return
+    }
+    if (!trimmed.startsWith('sk-ant-')) {
+      setError('Anthropic keys start with sk-ant-. Double-check and try again.')
+      return
+    }
+    setAnthropicKey(trimmed)
+    setEditing(false)
+    setDraft('')
+    setError(null)
+  }
+
+  const remove = () => {
+    clearAnthropicKey()
+    setEditing(false)
+  }
+
+  return (
+    <div className="flex flex-col gap-2.5">
+      <span className="label-m-type2 text-[#9B9EA3]">AI Settings</span>
+      <div className="h-px bg-[#262626] w-full" />
+
+      <StatusPill status={status} />
+
+      {!editing && key && (
+        <div className="flex items-center justify-between gap-2">
+          <code className="font-['JetBrains_Mono',monospace] text-[12px] text-[#c9ced4] break-all">
+            {maskKey(key)}
+          </code>
+          <div className="flex gap-1.5 shrink-0">
+            <button onClick={startEdit} className={glassButton}>
+              Replace
+            </button>
+            <button onClick={remove} className={glassButton}>
+              Remove
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!editing && !key && (
+        <button onClick={startEdit} className={`${glassButton} self-start`}>
+          Add Anthropic key
+        </button>
+      )}
+
+      {editing && (
+        <div className="flex flex-col gap-2">
+          <input
+            type="password"
+            placeholder="sk-ant-..."
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') save()
+              else if (e.key === 'Escape') cancelEdit()
+            }}
+            autoFocus
+            spellCheck={false}
+            autoComplete="off"
+            className="w-full h-9 bg-[#242526] border border-[#262626] rounded-[8px] px-3 py-[7.5px] body-m text-[#DADEE5] outline-none focus:border-[#404040] font-['JetBrains_Mono',monospace] text-[12px]"
+          />
+          {error && (
+            <p className="body-m text-destructive m-0">{error}</p>
+          )}
+          <div className="flex gap-1.5">
+            <button onClick={save} className={glassButton}>
+              Save
+            </button>
+            <button onClick={cancelEdit} className={glassButton}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      <p className="font-['Avenir',sans-serif] text-[12px] leading-[16px] text-[#6b6e73] m-0">
+        Get a key at{' '}
+        <a
+          href="https://console.anthropic.com/settings/keys"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-[#9B9EA3]"
+        >
+          console.anthropic.com
+        </a>
+        . Stored only in this browser — anyone with access to this device can
+        see it.
+      </p>
+    </div>
+  )
+}
+
+function StatusPill({
+  status,
+}: {
+  status: 'byok' | 'server' | 'unconfigured'
+}) {
+  const config = {
+    byok: {
+      label: 'Using your Anthropic key',
+      dot: '#259E23',
+      text: '#c9ced4',
+    },
+    server: {
+      label: "Using Timeline Academy's server (5/day)",
+      dot: '#9B9EA3',
+      text: '#9B9EA3',
+    },
+    unconfigured: {
+      label: 'Not configured — sign in or add a key',
+      dot: '#FF7D05',
+      text: '#c9ced4',
+    },
+  }[status]
+
+  return (
+    <div className="flex items-center gap-2">
+      <span
+        className="rounded-full size-1.5 shrink-0"
+        style={{ backgroundColor: config.dot }}
+        aria-hidden
+      />
+      <span className="body-m" style={{ color: config.text }}>
+        {config.label}
+      </span>
+    </div>
+  )
+}
+
+const glassButton = `
+  relative px-[11px] py-[6px] rounded-[10px]
+  backdrop-blur-[12px] bg-white/10 border border-white/[0.15]
+  shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
+  font-['Avenir',sans-serif] font-medium text-[14px] text-[#c9ced4]
+  hover:bg-white/20 hover:text-[#dadee5] transition-all
+`

--- a/src/components/Settings/TimelineSettingsPanel.tsx
+++ b/src/components/Settings/TimelineSettingsPanel.tsx
@@ -6,6 +6,7 @@ import type { AddEventsResult } from '../../hooks/useEvents';
 import { exportEventsToExcel } from '../../utils/excelExport';
 import { ConfirmationModal } from '../Modal/ConfirmationModal';
 import { ScaleSelector } from './ScaleSelector';
+import { ApiKeySection } from './ApiKeySection';
 import { SidePanelActionButton } from '../SidePanel/SidePanelActionButton';
 import { DEFAULT_TIMELINE_DESCRIPTION } from '../../constants/defaults';
 import { utils, read } from 'xlsx';
@@ -251,6 +252,9 @@ export function TimelineSettingsPanel({
                       </button>
                     </div>
                   </div>
+
+                  {/* AI Settings (BYOK) */}
+                  <ApiKeySection />
 
                   {/* Spacer */}
                   <div className="flex-1" />

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -4,6 +4,7 @@ import { TimelineGrid } from './TimelineGrid';
 import { TimelineCategoryLabels } from './TimelineCategoryLabels';
 import { TimelineEvent } from './TimelineEvent';
 import { TimelineScrollIndicator } from './TimelineScrollIndicator';
+import { EventActionsMenu } from '../EventActionsMenu/EventActionsMenu';
 import { TimelineEvent as ITimelineEvent, CategoryConfig } from '../../types/event';
 import { TimelineScale } from '../../types/timeline';
 import { getTimelineRange, shiftEventDates } from '../../utils/dateUtils';
@@ -25,10 +26,19 @@ interface TimelineProps {
   isFullScreen?: boolean;
   onAddEvent?: (event: Omit<ITimelineEvent, 'id'>) => ITimelineEvent | void;
   onUpdateEvent?: (event: ITimelineEvent) => void;
+  /** Called when "Delete" is selected from the event actions menu. */
+  onDeleteEvent?: (eventId: string) => void;
+  /** Called when "Open details" is selected (edit mode) or an enriched event is clicked (view mode). */
+  onOpenDetails?: (event: ITimelineEvent) => void;
   scale: TimelineScale;
   groupByCategory?: boolean;
   pendingScrollDate?: string | null;
   onScrollComplete?: () => void;
+  /**
+   * Edit/View mode. In view mode, edit affordances (drag-to-reschedule,
+   * hover-to-add cursor, click-to-edit) are suppressed.
+   */
+  mode?: 'edit' | 'view';
 }
 
 interface CategoryBand {
@@ -49,11 +59,15 @@ export function Timeline({
   isFullScreen,
   onAddEvent,
   onUpdateEvent,
+  onDeleteEvent,
+  onOpenDetails,
   scale,
   groupByCategory = false,
   pendingScrollDate,
-  onScrollComplete
+  onScrollComplete,
+  mode = 'edit',
 }: TimelineProps) {
+  const isEditing = mode === 'edit';
   // Filter visible categories and their events
   const visibleCategories = categories.filter(cat => cat.visible);
   const visibleEvents = events.filter(event =>
@@ -67,6 +81,7 @@ export function Timeline({
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [editingEvent, setEditingEvent] = useState<ITimelineEvent | null>(null);
   const [pendingScrollEventId, setPendingScrollEventId] = useState<string | null>(null);
+  const [menuState, setMenuState] = useState<{ event: ITimelineEvent; x: number; y: number } | null>(null);
 
   const { visibleRange } = useTimelineScroll(scrollContainerRef, months.length * 4);
 
@@ -200,7 +215,7 @@ export function Timeline({
   }, [groupByCategory, visibleEvents, visibleCategories, months, scale.monthWidth]);
 
   const handleMonthClick = useCallback((monthIndex: number) => {
-    if (!onAddEvent || justDraggedRef.current) return;
+    if (!isEditing || !onAddEvent || justDraggedRef.current) return;
 
     const clickedMonth = months[monthIndex];
     if (clickedMonth) {
@@ -209,14 +224,23 @@ export function Timeline({
       setEditingEvent(null);
       setShowEventModal(true);
     }
-  }, [months, onAddEvent, justDraggedRef]);
+  }, [months, onAddEvent, justDraggedRef, isEditing]);
 
-  const handleEventClick = useCallback((event: ITimelineEvent) => {
-    if (!onUpdateEvent || justDraggedRef.current) return;
-    setEditingEvent(event);
-    setSelectedDate(null);
-    setShowEventModal(true);
-  }, [onUpdateEvent, justDraggedRef]);
+  const handleEventClick = useCallback(
+    (event: ITimelineEvent, position: { x: number; y: number }) => {
+      if (justDraggedRef.current) return;
+      if (isEditing) {
+        if (!onUpdateEvent) return;
+        setMenuState({ event, x: position.x, y: position.y });
+        return;
+      }
+      // View mode: open the detail panel directly if the event has details.
+      if (event.description && onOpenDetails) {
+        onOpenDetails(event);
+      }
+    },
+    [onUpdateEvent, justDraggedRef, isEditing, onOpenDetails],
+  );
 
   const handleSubmit = useCallback((eventData: Omit<ITimelineEvent, 'id'>) => {
     let newEventId: string | null = null;
@@ -284,7 +308,7 @@ export function Timeline({
             style={{
               minWidth: `${months.length * scale.monthWidth}px`,
               minHeight: '100%',
-              cursor: onAddEvent ? 'pointer' : 'default'
+              cursor: isEditing && onAddEvent ? 'pointer' : 'default'
             }}
           >
             <TimelineHeader months={months} scale={scale} />
@@ -307,22 +331,27 @@ export function Timeline({
                   onMonthClick={handleMonthClick}
                   scale={scale}
                 />
-                {band.events.map((event) => (
-                  <TimelineEvent
-                    key={event.id}
-                    event={event}
-                    months={months}
-                    categoryOffset={band.offset}
-                    categoryColor={visibleCategories.find(c => c.id === event.category)?.color}
-                    onEventClick={onUpdateEvent ? handleEventClick : undefined}
-                    scale={scale}
-                    isDragging={dragState.isDragging && dragState.draggedEventId === event.id}
-                    dragDeltaPixels={dragState.draggedEventId === event.id ? dragState.deltaPixels : 0}
-                    onPointerDown={onUpdateEvent ? handlePointerDown : undefined}
-                    rowHeight={rowHeight}
-                    onMounted={handleEventMounted}
-                  />
-                ))}
+                {band.events.map((event) => {
+                  const canHandleClick =
+                    (isEditing && !!onUpdateEvent) ||
+                    (!isEditing && !!event.description && !!onOpenDetails);
+                  return (
+                    <TimelineEvent
+                      key={event.id}
+                      event={event}
+                      months={months}
+                      categoryOffset={band.offset}
+                      categoryColor={visibleCategories.find(c => c.id === event.category)?.color}
+                      onEventClick={canHandleClick ? handleEventClick : undefined}
+                      scale={scale}
+                      isDragging={dragState.isDragging && dragState.draggedEventId === event.id}
+                      dragDeltaPixels={dragState.draggedEventId === event.id ? dragState.deltaPixels : 0}
+                      onPointerDown={isEditing && onUpdateEvent ? handlePointerDown : undefined}
+                      rowHeight={rowHeight}
+                      onMounted={handleEventMounted}
+                    />
+                  );
+                })}
               </div>
             ))}
 
@@ -338,8 +367,8 @@ export function Timeline({
               />
             </div>
 
-            {/* Add Event Cursor — hidden during drag */}
-            {hoveredMonth !== null && onAddEvent && !dragState.isDragging && (
+            {/* Add Event Cursor — hidden during drag and in view mode */}
+            {hoveredMonth !== null && isEditing && onAddEvent && !dragState.isDragging && (
               <div
                 className="absolute top-[64px] bottom-0 bg-[#FBFBFB]/25 pointer-events-none transition-transform duration-75 ease-out"
                 style={{
@@ -351,6 +380,26 @@ export function Timeline({
           </div>
         </div>
       </div>
+
+      {/* Event Actions Menu (edit mode click on event) */}
+      {menuState && (
+        <EventActionsMenu
+          event={menuState.event}
+          position={{ x: menuState.x, y: menuState.y }}
+          onClose={() => setMenuState(null)}
+          onEdit={() => {
+            setEditingEvent(menuState.event);
+            setSelectedDate(null);
+            setShowEventModal(true);
+          }}
+          onOpenDetails={() => {
+            if (onOpenDetails) onOpenDetails(menuState.event);
+          }}
+          onDelete={() => {
+            if (onDeleteEvent) onDeleteEvent(menuState.event.id);
+          }}
+        />
+      )}
 
       {/* Event Dialog */}
       <Dialog

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -234,8 +234,9 @@ export function Timeline({
         setMenuState({ event, x: position.x, y: position.y });
         return;
       }
-      // View mode: open the detail panel directly if the event has details.
-      if (event.description && onOpenDetails) {
+      // View / present mode: open the detail panel for any event. The panel
+      // itself handles cached content vs. fresh generation vs. setup-required.
+      if (onOpenDetails) {
         onOpenDetails(event);
       }
     },
@@ -334,7 +335,7 @@ export function Timeline({
                 {band.events.map((event) => {
                   const canHandleClick =
                     (isEditing && !!onUpdateEvent) ||
-                    (!isEditing && !!event.description && !!onOpenDetails);
+                    (!isEditing && !!onOpenDetails);
                   return (
                     <TimelineEvent
                       key={event.id}

--- a/src/components/Timeline/TimelineEvent.tsx
+++ b/src/components/Timeline/TimelineEvent.tsx
@@ -8,7 +8,7 @@ interface TimelineEventProps {
   months: Month[];
   categoryOffset: number;
   categoryColor?: string;
-  onEventClick?: (event: ITimelineEvent) => void;
+  onEventClick?: (event: ITimelineEvent, position: { x: number; y: number }) => void;
   scale?: TimelineScale;
   isDragging?: boolean;
   dragDeltaPixels?: number;
@@ -105,13 +105,13 @@ export const TimelineEvent = memo(function TimelineEvent({
   const isSingleDay = event.startDate === event.endDate;
   const isDraggable = !!onPointerDown;
 
-  const handleClick = () => {
+  const handleClick = (e: React.MouseEvent) => {
     if (wasDraggingRef.current) {
       wasDraggingRef.current = false;
       return;
     }
     if (onEventClick) {
-      onEventClick(event);
+      onEventClick(event, { x: e.clientX, y: e.clientY });
     }
   };
 

--- a/src/components/TimelineViewer/TimelineViewer.tsx
+++ b/src/components/TimelineViewer/TimelineViewer.tsx
@@ -3,6 +3,7 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import { supabase } from '../../lib/supabase';
 import { Timeline } from '../Timeline/Timeline';
 import { TimelineTitle } from '../TimelineTitle/TimelineTitle';
+import { EventDetailPanel } from '../EventDetailPanel/EventDetailPanel';
 import { SCALES } from '../../constants/scales';
 import { DEFAULT_CATEGORIES } from '../../constants/categories';
 import { TimelineEvent, CategoryConfig } from '../../types/event';
@@ -23,6 +24,7 @@ export function TimelineViewer() {
   const [timeline, setTimeline] = useState<TimelineData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [detailPanelEvent, setDetailPanelEvent] = useState<TimelineEvent | null>(null);
 
   useEffect(() => {
     const loadTimeline = async () => {
@@ -92,7 +94,11 @@ export function TimelineViewer() {
           title: event.title,
           startDate: event.start_date,
           endDate: event.end_date || event.start_date,
-          category: event.category
+          category: event.category,
+          description: event.description ?? null,
+          imageUrl: event.image_url ?? null,
+          imageAttribution: event.image_attribution ?? null,
+          sources: event.sources ?? null,
         }));
 
         // Ensure all categories have the visible property
@@ -170,8 +176,22 @@ export function TimelineViewer() {
           categories={timeline.categories}
           scale={SCALES[timeline.scale]}
           groupByCategory={timeline.groupByCategory}
+          mode="view"
+          onOpenDetails={(event) => setDetailPanelEvent(event)}
         />
       </main>
+
+      <EventDetailPanel
+        open={detailPanelEvent !== null}
+        event={detailPanelEvent}
+        timelineTitle={timeline.title}
+        mode="view"
+        onClose={() => setDetailPanelEvent(null)}
+        onEventChange={() => {
+          // Public viewers cannot mutate event details — view mode hides the
+          // footer buttons, so this should never fire. No-op for safety.
+        }}
+      />
     </div>
   );
 }

--- a/src/components/TimelineViewer/TimelineViewer.tsx
+++ b/src/components/TimelineViewer/TimelineViewer.tsx
@@ -8,6 +8,10 @@ import { SCALES } from '../../constants/scales';
 import { DEFAULT_CATEGORIES } from '../../constants/categories';
 import { TimelineEvent, CategoryConfig } from '../../types/event';
 import { getDraft } from '../../utils/draftStorage';
+import {
+  getCachedEvent,
+  setCachedEvent,
+} from '../../services/viewerEventCache';
 
 interface TimelineData {
   title: string;
@@ -88,18 +92,33 @@ export function TimelineViewer() {
           throw eventsError;
         }
 
-        // Format events to match our TimelineEvent type
-        const formattedEvents: TimelineEvent[] = eventsData.map(event => ({
-          id: event.id,
-          title: event.title,
-          startDate: event.start_date,
-          endDate: event.end_date || event.start_date,
-          category: event.category,
-          description: event.description ?? null,
-          imageUrl: event.image_url ?? null,
-          imageAttribution: event.image_attribution ?? null,
-          sources: event.sources ?? null,
-        }));
+        // Format events to match our TimelineEvent type. Owner content from
+        // the DB wins; if the row has no description we fall back to the
+        // viewer's own localStorage cache (populated by past in-session
+        // generations on the same browser).
+        const formattedEvents: TimelineEvent[] = eventsData.map(event => {
+          const base: TimelineEvent = {
+            id: event.id,
+            title: event.title,
+            startDate: event.start_date,
+            endDate: event.end_date || event.start_date,
+            category: event.category,
+            description: event.description ?? null,
+            imageUrl: event.image_url ?? null,
+            imageAttribution: event.image_attribution ?? null,
+            sources: event.sources ?? null,
+          };
+          if (base.description) return base;
+          const cached = getCachedEvent(timelineId, event.id);
+          if (!cached) return base;
+          return {
+            ...base,
+            description: cached.description ?? null,
+            imageUrl: cached.imageUrl ?? null,
+            imageAttribution: cached.imageAttribution ?? null,
+            sources: cached.sources ?? null,
+          };
+        });
 
         // Ensure all categories have the visible property
         const categories = (timelineData.categories || DEFAULT_CATEGORIES).map(cat => ({
@@ -187,9 +206,30 @@ export function TimelineViewer() {
         timelineTitle={timeline.title}
         mode="view"
         onClose={() => setDetailPanelEvent(null)}
-        onEventChange={() => {
-          // Public viewers cannot mutate event details — view mode hides the
-          // footer buttons, so this should never fire. No-op for safety.
+        onEventChange={(updated) => {
+          // Public viewers don't own the timeline row, so generations
+          // they trigger get persisted to their own browser's localStorage
+          // instead of the DB. Owner content from the DB will still take
+          // precedence on subsequent loads (see hydration above).
+          if (timelineId && timelineId !== 'local') {
+            setCachedEvent(timelineId, updated.id, {
+              description: updated.description,
+              imageUrl: updated.imageUrl,
+              imageAttribution: updated.imageAttribution,
+              sources: updated.sources,
+            });
+          }
+          setTimeline((prev) =>
+            prev
+              ? {
+                  ...prev,
+                  events: prev.events.map((e) =>
+                    e.id === updated.id ? updated : e,
+                  ),
+                }
+              : prev,
+          );
+          setDetailPanelEvent(updated);
         }}
       />
     </div>

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -155,7 +155,11 @@ export function useTimeline() {
           title: event.title,
           startDate: event.start_date,
           endDate: event.end_date,
-          category: event.category
+          category: event.category,
+          description: event.description ?? null,
+          imageUrl: event.image_url ?? null,
+          imageAttribution: event.image_attribution ?? null,
+          sources: event.sources ?? null,
         })),
         categories: categories || undefined,
         scale: timeline.scale || 'small',

--- a/src/services/aiTimeline.ts
+++ b/src/services/aiTimeline.ts
@@ -1,5 +1,10 @@
 import { supabase } from '../lib/supabase';
 import { getSessionToken } from './sessionToken';
+import { getAnthropicKey } from './userApiKey';
+import {
+  classifySubjectDirect,
+  generateTimelineDirect,
+} from './anthropicDirect';
 import { TimelineCategory } from '../types/event';
 import type { SubjectType, PillDefinition } from '../constants/pillDefinitions';
 
@@ -20,12 +25,25 @@ export interface ClassificationResult {
 }
 
 /**
- * Calls the Supabase Edge Function to classify a subject into a type.
- * Uses the cheapest/fastest model for ~100ms response.
+ * Classify a subject into a type. Uses the cheapest/fastest model.
+ *
+ * Routes via the BYOK key when present, otherwise hits our edge function.
  */
 export async function classifySubject(
   subject: string
 ): Promise<ClassificationResult> {
+  const validTypes: SubjectType[] = ['person', 'event', 'topic', 'organization'];
+
+  const byokKey = getAnthropicKey();
+  if (byokKey) {
+    const type = await classifySubjectDirect(subject, byokKey);
+    return {
+      type: validTypes.includes(type as SubjectType)
+        ? (type as SubjectType)
+        : 'topic',
+    };
+  }
+
   const { data, error } = await supabase.functions.invoke(
     'generate-timeline',
     {
@@ -44,33 +62,40 @@ export async function classifySubject(
     throw new Error(result.error);
   }
 
-  const validTypes: SubjectType[] = ['person', 'event', 'topic', 'organization'];
   const classified = result as ClassificationResult;
-
-  // Fallback to topic if unexpected value
   if (!validTypes.includes(classified.type)) {
     return { type: 'topic' };
   }
-
   return classified;
 }
 
 /**
- * Calls the Supabase Edge Function to generate a timeline via LLM.
- * Auth JWT is included automatically for logged-in users.
- * Session token is sent for anonymous rate limiting.
+ * Generate a full timeline via LLM.
+ *
+ * Routes via the BYOK key when present (browser-direct, no rate limit),
+ * otherwise hits our edge function with the user's JWT or an anonymous
+ * session token.
  */
 export async function generateTimeline(
   subject: string,
   subjectType?: SubjectType,
   categories?: PillDefinition[]
 ): Promise<GeneratedTimeline> {
-  const body: Record<string, unknown> = { subject };
-
-  if (subjectType) {
-    body.subjectType = subjectType;
+  const byokKey = getAnthropicKey();
+  if (byokKey) {
+    const categoryDefs =
+      categories && categories.length > 0
+        ? categories.map((c) => ({
+            id: c.id,
+            label: c.label,
+            promptSnippet: c.promptSnippet,
+          }))
+        : undefined;
+    return generateTimelineDirect(subject, categoryDefs, byokKey);
   }
 
+  const body: Record<string, unknown> = { subject };
+  if (subjectType) body.subjectType = subjectType;
   if (categories && categories.length > 0) {
     body.categories = categories.map((c) => ({
       id: c.id,
@@ -91,12 +116,9 @@ export async function generateTimeline(
     throw new Error(error.message || 'Failed to generate timeline');
   }
 
-  // supabase.functions.invoke returns parsed JSON when Content-Type is application/json
   const result = data as GeneratedTimeline | { error: string };
-
   if ('error' in result && typeof result.error === 'string') {
     throw new Error(result.error);
   }
-
   return result as GeneratedTimeline;
 }

--- a/src/services/anthropicDirect.ts
+++ b/src/services/anthropicDirect.ts
@@ -1,0 +1,372 @@
+// Browser-direct Anthropic client for BYOK ("Bring Your Own Key") mode.
+// The user pastes their Anthropic API key into Settings; the browser then
+// calls api.anthropic.com directly with their key — bypassing our edge
+// functions, our rate limit, and our billing.
+//
+// Required header: anthropic-dangerous-direct-browser-access: true.
+// Anthropic accepts this on browser-origin requests but warns against it for
+// production server-side use. For BYOK that's exactly the trade-off we want.
+
+import type {
+  EnrichmentStreamHandlers,
+  // re-export for callers via eventEnrichment.ts
+} from './eventEnrichment'
+import {
+  getSystemPrompt,
+  getUserPrompt,
+  CLASSIFICATION_PROMPT,
+  type CategoryDefinition,
+} from './llmPrompts'
+import type { EventSource, TimelineEvent } from '@/types/event'
+import type { GeneratedTimeline } from './aiTimeline'
+
+const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages'
+const MODEL_SONNET = 'claude-sonnet-4-6'
+const MODEL_HAIKU = 'claude-haiku-4-5-20251001'
+
+function headers(key: string): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    'x-api-key': key,
+    'anthropic-version': '2023-06-01',
+    'anthropic-dangerous-direct-browser-access': 'true',
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Event enrichment (streaming)
+// ---------------------------------------------------------------------------
+
+const ENRICH_SYSTEM_PROMPT = `You are writing a 1-2 paragraph description of a historical event for an educational timeline. Use the web_search tool to find authoritative sources before writing. Keep the description concise (max ~150 words for simple events, two short paragraphs for complex ones). Use a neutral encyclopedic tone. Do not include inline citations or footnotes — sources are listed separately. Do not invent facts that aren't in the search results.`
+
+function buildEnrichUserPrompt(
+  event: TimelineEvent,
+  timelineTitle: string,
+): string {
+  const lines: string[] = []
+  lines.push(`Write a description for this event: "${event.title}"`)
+  if (event.startDate || event.endDate) {
+    if (event.startDate && event.endDate && event.startDate !== event.endDate) {
+      lines.push(`Date range: ${event.startDate} to ${event.endDate}`)
+    } else if (event.startDate) {
+      lines.push(`Date: ${event.startDate}`)
+    }
+  }
+  if (timelineTitle) lines.push(`Timeline context: ${timelineTitle}`)
+  lines.push(
+    'Use the web_search tool to find sources, then write the description. Output only the description text — no headings, no source lists.',
+  )
+  return lines.join('\n')
+}
+
+export async function enrichEventDirect(
+  event: TimelineEvent,
+  timelineTitle: string,
+  handlers: EnrichmentStreamHandlers,
+  apiKey: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  let res: Response
+  try {
+    res = await fetch(ANTHROPIC_URL, {
+      method: 'POST',
+      headers: headers(apiKey),
+      body: JSON.stringify({
+        model: MODEL_SONNET,
+        max_tokens: 1024,
+        system: ENRICH_SYSTEM_PROMPT,
+        tools: [
+          {
+            type: 'web_search_20250305',
+            name: 'web_search',
+            max_uses: 3,
+          },
+        ],
+        messages: [
+          { role: 'user', content: buildEnrichUserPrompt(event, timelineTitle) },
+        ],
+        stream: true,
+      }),
+      signal,
+    })
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') return
+    handlers.onError((err as Error).message || 'Network error')
+    return
+  }
+
+  if (!res.ok || !res.body) {
+    let message = `Anthropic API error (${res.status})`
+    try {
+      const body = await res.text()
+      // Most Anthropic errors include a useful `.error.message`.
+      try {
+        const parsed = JSON.parse(body) as {
+          error?: { message?: string; type?: string }
+        }
+        if (parsed?.error?.message) message = parsed.error.message
+      } catch {
+        if (body) message = body.slice(0, 200)
+      }
+    } catch {
+      // ignore
+    }
+    handlers.onError(message)
+    return
+  }
+
+  const sources: EventSource[] = []
+  const seenUrls = new Set<string>()
+  const blockTypes = new Map<number, string>()
+
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      let idx
+      while ((idx = buffer.indexOf('\n\n')) !== -1) {
+        const rawEvent = buffer.slice(0, idx)
+        buffer = buffer.slice(idx + 2)
+        const lines = rawEvent.split('\n')
+        let eventName = ''
+        let dataStr = ''
+        for (const line of lines) {
+          if (line.startsWith('event: ')) eventName = line.slice(7).trim()
+          else if (line.startsWith('data: ')) dataStr += line.slice(6)
+        }
+        if (!dataStr) continue
+        let data: Record<string, unknown>
+        try {
+          data = JSON.parse(dataStr)
+        } catch {
+          continue
+        }
+
+        if (eventName === 'content_block_start') {
+          const index = data.index as number
+          const block = data.content_block as Record<string, unknown>
+          if (block && typeof block.type === 'string') {
+            blockTypes.set(index, block.type)
+          }
+          if (block?.type === 'web_search_tool_result') {
+            const content = block.content as Array<Record<string, unknown>> | undefined
+            if (Array.isArray(content)) {
+              for (const item of content) {
+                if (item.type === 'web_search_result') {
+                  const url = item.url as string | undefined
+                  const title = (item.title as string | undefined) ?? ''
+                  if (url && !seenUrls.has(url)) {
+                    seenUrls.add(url)
+                    sources.push({ title: title || url, url })
+                  }
+                }
+              }
+            }
+          }
+        } else if (eventName === 'content_block_delta') {
+          const index = data.index as number
+          const delta = data.delta as Record<string, unknown>
+          const blockType = blockTypes.get(index)
+          if (blockType === 'text' && delta?.type === 'text_delta') {
+            const text = delta.text as string
+            if (text) handlers.onDelta(text)
+          }
+        }
+      }
+    }
+
+    handlers.onSources(sources)
+    handlers.onDone()
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') return
+    handlers.onError((err as Error).message || 'Stream interrupted')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Timeline generation (non-streaming JSON)
+// ---------------------------------------------------------------------------
+
+function stripCodeFence(text: string): string {
+  const t = text.trim()
+  if (!t.startsWith('```')) return t
+  return t.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '').trim()
+}
+
+function parseTimelineJson(text: string): GeneratedTimeline {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(stripCodeFence(text))
+  } catch {
+    throw new Error('LLM returned invalid JSON')
+  }
+
+  const obj = parsed as Record<string, unknown>
+  if (typeof obj.timelineTitle !== 'string' || !obj.timelineTitle) {
+    throw new Error('Missing timelineTitle in LLM response')
+  }
+  if (typeof obj.timelineDescription !== 'string') {
+    throw new Error('Missing timelineDescription in LLM response')
+  }
+  if (!Array.isArray(obj.events) || obj.events.length === 0) {
+    throw new Error('Missing or empty events array in LLM response')
+  }
+
+  const validCategories = new Set([
+    'category_1',
+    'category_2',
+    'category_3',
+    'category_4',
+  ])
+
+  const events = (obj.events as Array<Record<string, unknown>>)
+    .filter(
+      (e) =>
+        typeof e.category === 'string' && validCategories.has(e.category),
+    )
+    .map((e, i) => {
+      if (typeof e.title !== 'string' || !e.title) {
+        throw new Error(`Event ${i}: missing title`)
+      }
+      if (typeof e.startDate !== 'string' || !e.startDate) {
+        throw new Error(`Event ${i}: missing startDate`)
+      }
+      if (typeof e.endDate !== 'string' || !e.endDate) {
+        throw new Error(`Event ${i}: missing endDate`)
+      }
+      return {
+        title: (e.title as string).slice(0, 55),
+        startDate: e.startDate as string,
+        endDate: e.endDate as string,
+        category: e.category as
+          | 'category_1'
+          | 'category_2'
+          | 'category_3'
+          | 'category_4',
+      }
+    })
+
+  if (events.length === 0) {
+    throw new Error('No valid events in LLM response')
+  }
+
+  let categoryMapping: Record<string, string> | undefined
+  if (
+    obj.categoryMapping &&
+    typeof obj.categoryMapping === 'object' &&
+    !Array.isArray(obj.categoryMapping)
+  ) {
+    categoryMapping = obj.categoryMapping as Record<string, string>
+  }
+
+  return {
+    timelineTitle: obj.timelineTitle as string,
+    timelineDescription: obj.timelineDescription as string,
+    categoryMapping,
+    events,
+  }
+}
+
+export async function generateTimelineDirect(
+  subject: string,
+  categories: CategoryDefinition[] | undefined,
+  apiKey: string,
+): Promise<GeneratedTimeline> {
+  const userPrompt = categories
+    ? getUserPrompt(subject, categories)
+    : `Generate a biographical timeline for: ${subject}`
+
+  const res = await fetch(ANTHROPIC_URL, {
+    method: 'POST',
+    headers: headers(apiKey),
+    body: JSON.stringify({
+      model: MODEL_SONNET,
+      max_tokens: 4096,
+      system: getSystemPrompt(),
+      messages: [{ role: 'user', content: userPrompt }],
+      temperature: 0.4,
+    }),
+  })
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    let message = `Anthropic API error (${res.status})`
+    try {
+      const parsed = JSON.parse(body) as { error?: { message?: string } }
+      if (parsed?.error?.message) message = parsed.error.message
+    } catch {
+      if (body) message = body.slice(0, 200)
+    }
+    throw new Error(message)
+  }
+
+  const json = await res.json()
+  const block = json.content?.[0]
+  if (!block || block.type !== 'text') {
+    throw new Error('Empty response from Anthropic')
+  }
+
+  return parseTimelineJson(block.text as string)
+}
+
+// ---------------------------------------------------------------------------
+// Subject classification (cheap, non-streaming)
+// ---------------------------------------------------------------------------
+
+export async function classifySubjectDirect(
+  subject: string,
+  apiKey: string,
+): Promise<string> {
+  const validTypes = new Set(['person', 'event', 'topic', 'organization'])
+
+  const res = await fetch(ANTHROPIC_URL, {
+    method: 'POST',
+    headers: headers(apiKey),
+    body: JSON.stringify({
+      model: MODEL_HAIKU,
+      max_tokens: 32,
+      messages: [
+        {
+          role: 'user',
+          content: CLASSIFICATION_PROMPT.replace('{subject}', subject),
+        },
+        { role: 'assistant', content: '{"type": "' },
+      ],
+      temperature: 0,
+    }),
+  })
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    let message = `Anthropic API error (${res.status})`
+    try {
+      const parsed = JSON.parse(body) as { error?: { message?: string } }
+      if (parsed?.error?.message) message = parsed.error.message
+    } catch {
+      if (body) message = body.slice(0, 200)
+    }
+    throw new Error(message)
+  }
+
+  const json = await res.json()
+  const block = json.content?.[0]
+  if (!block || block.type !== 'text') {
+    throw new Error('Empty response from Anthropic')
+  }
+
+  // We prefilled with '{"type": "' so the response continues from there.
+  const text = '{"type": "' + (block.text as string)
+  let parsed: { type: string }
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    throw new Error('LLM returned invalid JSON for classification')
+  }
+
+  return validTypes.has(parsed.type) ? parsed.type : 'topic'
+}

--- a/src/services/eventEnrichment.ts
+++ b/src/services/eventEnrichment.ts
@@ -1,4 +1,6 @@
 import { supabase } from '../lib/supabase'
+import { enrichEventDirect } from './anthropicDirect'
+import { getAnthropicKey } from './userApiKey'
 import type { EventSource, TimelineEvent } from '../types/event'
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string
@@ -38,13 +40,29 @@ export async function fetchEventImage(title: string): Promise<{
   }
 }
 
+/**
+ * Enrich an event with AI-generated description, sources, and image.
+ *
+ * Routing:
+ *   - User has BYOK key set → call Anthropic directly from the browser.
+ *     Bypasses our edge function, our rate limit, and our billing.
+ *   - Otherwise (signed-in user, no key) → use the edge function with their JWT.
+ *   - Logged-out user without a key → returns a "needs setup" error so the
+ *     panel can surface the BYOK / sign-in prompt.
+ */
 export async function enrichEvent(
   event: TimelineEvent,
   timelineTitle: string,
   handlers: EnrichmentStreamHandlers,
   signal?: AbortSignal,
 ): Promise<void> {
-  // Use the user's JWT — anonymous enrichment is rejected by the edge function.
+  const byokKey = getAnthropicKey()
+  if (byokKey) {
+    await enrichEventDirect(event, timelineTitle, handlers, byokKey, signal)
+    return
+  }
+
+  // Server path — requires a signed-in user.
   const session = await supabase.auth.getSession()
   const token = session.data.session?.access_token
   if (!token) {

--- a/src/services/eventEnrichment.ts
+++ b/src/services/eventEnrichment.ts
@@ -1,0 +1,134 @@
+import { supabase } from '../lib/supabase'
+import type { EventSource, TimelineEvent } from '../types/event'
+
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string
+
+export interface EnrichmentStreamHandlers {
+  onDelta: (text: string) => void
+  onSources: (sources: EventSource[]) => void
+  onDone: () => void
+  onError: (message: string) => void
+}
+
+export async function fetchEventImage(title: string): Promise<{
+  imageUrl: string | null
+  attribution: string | null
+}> {
+  try {
+    const res = await fetch(
+      `${SUPABASE_URL}/functions/v1/fetch-event-image`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: SUPABASE_ANON_KEY,
+        },
+        body: JSON.stringify({ title }),
+      },
+    )
+    if (!res.ok) return { imageUrl: null, attribution: null }
+    const json = await res.json()
+    return {
+      imageUrl: json?.imageUrl ?? null,
+      attribution: json?.attribution ?? null,
+    }
+  } catch {
+    return { imageUrl: null, attribution: null }
+  }
+}
+
+export async function enrichEvent(
+  event: TimelineEvent,
+  timelineTitle: string,
+  handlers: EnrichmentStreamHandlers,
+  signal?: AbortSignal,
+): Promise<void> {
+  // Use the user's JWT — anonymous enrichment is rejected by the edge function.
+  const session = await supabase.auth.getSession()
+  const token = session.data.session?.access_token
+  if (!token) {
+    handlers.onError('You must be signed in to generate event details.')
+    return
+  }
+
+  let res: Response
+  try {
+    res = await fetch(`${SUPABASE_URL}/functions/v1/enrich-event`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        apikey: SUPABASE_ANON_KEY,
+      },
+      body: JSON.stringify({
+        eventTitle: event.title,
+        startDate: event.startDate,
+        endDate: event.endDate,
+        timelineTitle,
+      }),
+      signal,
+    })
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') return
+    handlers.onError((err as Error).message || 'Network error')
+    return
+  }
+
+  if (!res.ok || !res.body) {
+    let message = `Request failed (${res.status})`
+    try {
+      const json = await res.json()
+      if (json?.error) message = json.error
+    } catch {
+      // ignore parse errors
+    }
+    handlers.onError(message)
+    return
+  }
+
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      let idx
+      while ((idx = buffer.indexOf('\n\n')) !== -1) {
+        const rawEvent = buffer.slice(0, idx)
+        buffer = buffer.slice(idx + 2)
+        const lines = rawEvent.split('\n')
+        let eventName = ''
+        let dataStr = ''
+        for (const line of lines) {
+          if (line.startsWith('event: ')) eventName = line.slice(7).trim()
+          else if (line.startsWith('data: ')) dataStr += line.slice(6)
+        }
+        if (!dataStr) continue
+        let data: Record<string, unknown>
+        try {
+          data = JSON.parse(dataStr)
+        } catch {
+          continue
+        }
+        if (eventName === 'delta') {
+          const text = data.text as string | undefined
+          if (text) handlers.onDelta(text)
+        } else if (eventName === 'sources') {
+          const sources = (data.sources as EventSource[] | undefined) ?? []
+          handlers.onSources(sources)
+        } else if (eventName === 'done') {
+          handlers.onDone()
+        } else if (eventName === 'error') {
+          handlers.onError((data.message as string) || 'Generation failed')
+        }
+      }
+    }
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') return
+    handlers.onError((err as Error).message || 'Stream interrupted')
+  }
+}

--- a/src/services/llmPrompts.ts
+++ b/src/services/llmPrompts.ts
@@ -1,0 +1,72 @@
+// Browser-direct mirror of supabase/functions/_shared/prompts.ts.
+// Keep these two files identical so the BYOK client and the edge function
+// produce equivalent outputs. Source of truth: _shared/prompts.ts.
+
+export interface CategoryDefinition {
+  id: string
+  label: string
+  promptSnippet: string
+}
+
+export function getSystemPrompt(): string {
+  return `You are a timeline generator. You receive a subject, category lenses, and their definitions. Your ONLY job is to find events that match the provided categories.
+
+HARD RULES:
+1. CATEGORY LOCK-IN — Every event MUST belong to one of the provided categories. Never invent or add extra categories.
+2. BALANCED DISTRIBUTION — Generate 4–8 events per category. Distribute roughly evenly. If a category has fewer than 2 events, note this in the timeline description.
+3. EVENT QUALITY — Max 55 characters per title. Prefer specific facts over vague summaries.
+   BAD:  "Had a successful career"
+   GOOD: "Scored 81 points vs. Raptors"
+4. DATE FORMAT — YYYY-MM-DD. Year-only → January 1. Ranges → use startDate/endDate span. Chronological order.
+5. JSON ONLY — No markdown, no code fences, no explanation.
+
+RESPONSE SCHEMA:
+{
+  "timelineTitle": "<descriptive title>",
+  "timelineDescription": "<1–2 sentence summary of scope>",
+  "categoryMapping": {
+    "category_1": "<first category label>",
+    "category_2": "<second category label>",
+    "category_3": "<third category label>",
+    "category_4": "<fourth category label>"
+  },
+  "events": [
+    {
+      "title": "<max 55 chars>",
+      "startDate": "YYYY-MM-DD",
+      "endDate": "YYYY-MM-DD",
+      "category": "category_1"
+    }
+  ]
+}`
+}
+
+export function getUserPrompt(
+  subject: string,
+  categories?: CategoryDefinition[],
+): string {
+  if (!categories || categories.length === 0) {
+    return `Generate a biographical timeline for: ${subject}`
+  }
+
+  const categoryLines = categories
+    .map((c, i) => `- category_${i + 1}: "${c.label}" → ${c.promptSnippet}`)
+    .join('\n')
+
+  return `Generate a timeline of: ${subject}
+
+Category lenses (use ONLY these):
+${categoryLines}`
+}
+
+// Classification prompt mirror — used by anthropicDirect for the classify step.
+export const CLASSIFICATION_PROMPT = `Classify the following subject into exactly one type.
+Types:
+- "person" — an individual human (living or dead)
+- "event" — a bounded historical occurrence with a beginning and end
+- "topic" — a broad concept, movement, genre, or field of study
+- "organization" — a company, band, institution, team, or formal group
+
+Subject: "{subject}"
+
+Return ONLY valid JSON: {"type": "<type>"}`

--- a/src/services/userApiKey.ts
+++ b/src/services/userApiKey.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react'
+
+const STORAGE_KEY = 'timeline_byok_anthropic_key'
+
+function read(): string | null {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY)
+    return v && v.trim() ? v : null
+  } catch {
+    return null
+  }
+}
+
+export function getAnthropicKey(): string | null {
+  return read()
+}
+
+export function setAnthropicKey(key: string): void {
+  const trimmed = key.trim()
+  if (!trimmed) {
+    clearAnthropicKey()
+    return
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, trimmed)
+    // Notify listeners in this tab — `storage` events only fire in OTHER tabs.
+    window.dispatchEvent(new Event('byok:changed'))
+  } catch {
+    // ignore — quota or disabled storage
+  }
+}
+
+export function clearAnthropicKey(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+    window.dispatchEvent(new Event('byok:changed'))
+  } catch {
+    // ignore
+  }
+}
+
+export function maskKey(key: string): string {
+  if (!key) return ''
+  if (key.length <= 12) return `${key.slice(0, 4)}…`
+  return `${key.slice(0, 8)}…${key.slice(-4)}`
+}
+
+// React hook — re-renders when the key changes in this tab or any other.
+export function useAnthropicKey(): string | null {
+  const [key, setKey] = useState<string | null>(() => read())
+
+  useEffect(() => {
+    const sync = () => setKey(read())
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) sync()
+    }
+    window.addEventListener('storage', onStorage)
+    window.addEventListener('byok:changed', sync)
+    return () => {
+      window.removeEventListener('storage', onStorage)
+      window.removeEventListener('byok:changed', sync)
+    }
+  }, [])
+
+  return key
+}

--- a/src/services/viewerEventCache.ts
+++ b/src/services/viewerEventCache.ts
@@ -1,0 +1,58 @@
+// Per-event AI enrichment cache for public viewers of /view/:id timelines.
+//
+// Public viewers don't own the timeline row, so generations they trigger with
+// their own BYOK key (or via the server path) can't be persisted to Supabase.
+// Instead we stash the four enrichment fields in localStorage keyed by
+// <timelineId>:<eventId>. Owner-generated content from the DB always wins —
+// this cache is only the fallback when the row has nothing.
+
+import type { EventSource } from '../types/event'
+
+const PREFIX = 'timeline_viewer_event_'
+
+export interface CachedEnrichment {
+  description?: string | null
+  imageUrl?: string | null
+  imageAttribution?: string | null
+  sources?: EventSource[] | null
+}
+
+function key(timelineId: string, eventId: string): string {
+  return `${PREFIX}${timelineId}:${eventId}`
+}
+
+export function getCachedEvent(
+  timelineId: string,
+  eventId: string,
+): CachedEnrichment | null {
+  try {
+    const raw = localStorage.getItem(key(timelineId, eventId))
+    if (!raw) return null
+    return JSON.parse(raw) as CachedEnrichment
+  } catch {
+    return null
+  }
+}
+
+export function setCachedEvent(
+  timelineId: string,
+  eventId: string,
+  value: CachedEnrichment,
+): void {
+  try {
+    localStorage.setItem(key(timelineId, eventId), JSON.stringify(value))
+  } catch {
+    // ignore — quota / disabled storage
+  }
+}
+
+export function clearCachedEvent(
+  timelineId: string,
+  eventId: string,
+): void {
+  try {
+    localStorage.removeItem(key(timelineId, eventId))
+  } catch {
+    // ignore
+  }
+}

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,9 +1,20 @@
+export interface EventSource {
+  title: string;
+  url: string;
+}
+
 export interface TimelineEvent {
   id: string;
   title: string;
   startDate: string; // ISO date string
   endDate: string; // ISO date string
   category: TimelineCategory;
+  // AI-generated detail fields. Populated only after the user opens
+  // "Open details" on an event in edit mode and the enrichment completes.
+  description?: string | null;
+  imageUrl?: string | null;
+  imageAttribution?: string | null;
+  sources?: EventSource[] | null;
 }
 
 export type TimelineCategory = 'category_1' | 'category_2' | 'category_3' | 'category_4';

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -119,6 +119,14 @@ export const formatDateDisplay = (dateStr: string): string => {
   return format(date, 'MM/dd/yyyy')
 }
 
+// Long-form date for the event detail panel header. e.g. "Jun 12, 1943".
+export const formatDateLong = (dateStr: string): string => {
+  if (!dateStr) return ''
+  const date = parseDate(dateStr)
+  if (!date) return ''
+  return format(date, 'MMM d, yyyy')
+}
+
 // Dark theme classNames for Calendar component
 export const darkCalendarClassNames = {
   day_selected: "bg-[rgba(37,99,235,0.8)] text-white hover:bg-[rgba(37,99,235,0.9)] focus:bg-[rgba(37,99,235,0.9)]",

--- a/src/utils/saveEvents.ts
+++ b/src/utils/saveEvents.ts
@@ -1,5 +1,5 @@
 import { supabase } from '../lib/supabase';
-import type { TimelineEvent } from '../types/event';
+import type { TimelineEvent, EventSource } from '../types/event';
 
 interface DbEvent {
   id: string;
@@ -7,6 +7,22 @@ interface DbEvent {
   start_date: string;
   end_date: string;
   category: string;
+  description: string | null;
+  image_url: string | null;
+  image_attribution: string | null;
+  sources: EventSource[] | null;
+}
+
+function sourcesEqual(a: EventSource[] | null | undefined, b: EventSource[] | null | undefined): boolean {
+  const aArr = a ?? null;
+  const bArr = b ?? null;
+  if (aArr === null && bArr === null) return true;
+  if (aArr === null || bArr === null) return false;
+  if (aArr.length !== bArr.length) return false;
+  for (let i = 0; i < aArr.length; i++) {
+    if (aArr[i].title !== bArr[i].title || aArr[i].url !== bArr[i].url) return false;
+  }
+  return true;
 }
 
 /**
@@ -20,7 +36,7 @@ export async function saveTimelineEvents(
   // 1. Fetch current server events for this timeline
   const { data: serverRows, error: fetchError } = await supabase
     .from('events')
-    .select('id, title, start_date, end_date, category')
+    .select('id, title, start_date, end_date, category, description, image_url, image_attribution, sources')
     .eq('timeline_id', timelineId);
 
   if (fetchError) throw fetchError;
@@ -41,7 +57,11 @@ export async function saveTimelineEvents(
       existing.title !== event.title ||
       existing.start_date !== event.startDate ||
       existing.end_date !== event.endDate ||
-      existing.category !== event.category
+      existing.category !== event.category ||
+      (existing.description ?? null) !== (event.description ?? null) ||
+      (existing.image_url ?? null) !== (event.imageUrl ?? null) ||
+      (existing.image_attribution ?? null) !== (event.imageAttribution ?? null) ||
+      !sourcesEqual(existing.sources, event.sources)
     ) {
       toUpdate.push(event);
     }
@@ -63,6 +83,10 @@ export async function saveTimelineEvents(
         start_date: event.startDate,
         end_date: event.endDate,
         category: event.category,
+        description: event.description ?? null,
+        image_url: event.imageUrl ?? null,
+        image_attribution: event.imageAttribution ?? null,
+        sources: event.sources ?? null,
       })
       .eq('id', event.id)
       .eq('timeline_id', timelineId);
@@ -93,6 +117,10 @@ export async function saveTimelineEvents(
           start_date: event.startDate,
           end_date: event.endDate,
           category: event.category,
+          description: event.description ?? null,
+          image_url: event.imageUrl ?? null,
+          image_attribution: event.imageAttribution ?? null,
+          sources: event.sources ?? null,
         }))
       );
 

--- a/supabase/functions/enrich-event/index.ts
+++ b/supabase/functions/enrich-event/index.ts
@@ -1,0 +1,284 @@
+// AI-powered event enrichment with web search grounding.
+//
+// Streams a 1-2 paragraph encyclopedic description of a historical event over
+// SSE, then emits a `sources` event with the URLs Claude actually visited via
+// the web_search tool. URLs are extracted from web_search_tool_result blocks
+// only — never from inline citations the model invents.
+
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { corsHeaders } from "../_shared/cors.ts";
+import { checkRateLimit, recordUsage } from "../_shared/rate-limiter.ts";
+
+interface EnrichRequest {
+  eventTitle?: string;
+  startDate?: string;
+  endDate?: string;
+  timelineTitle?: string;
+}
+
+interface SourceItem {
+  title: string;
+  url: string;
+}
+
+const SYSTEM_PROMPT = `You are writing a 1-2 paragraph description of a historical event for an educational timeline. Use the web_search tool to find authoritative sources before writing. Keep the description concise (max ~150 words for simple events, two short paragraphs for complex ones). Use a neutral encyclopedic tone. Do not include inline citations or footnotes — sources are listed separately. Do not invent facts that aren't in the search results.`;
+
+function buildUserPrompt(req: EnrichRequest): string {
+  const lines: string[] = [];
+  lines.push(`Write a description for this event: "${req.eventTitle ?? ""}"`);
+  if (req.startDate || req.endDate) {
+    if (req.startDate && req.endDate && req.startDate !== req.endDate) {
+      lines.push(`Date range: ${req.startDate} to ${req.endDate}`);
+    } else if (req.startDate) {
+      lines.push(`Date: ${req.startDate}`);
+    }
+  }
+  if (req.timelineTitle) {
+    lines.push(`Timeline context: ${req.timelineTitle}`);
+  }
+  lines.push(
+    `Use the web_search tool to find sources, then write the description. Output only the description text — no headings, no source lists.`
+  );
+  return lines.join("\n");
+}
+
+function sseEncode(event: string, data: unknown): Uint8Array {
+  const payload = JSON.stringify(data);
+  return new TextEncoder().encode(`event: ${event}\ndata: ${payload}\n\n`);
+}
+
+async function authenticateUser(req: Request): Promise<string | null> {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader) return null;
+  try {
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_ANON_KEY")!,
+      { global: { headers: { Authorization: authHeader } } }
+    );
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    return user?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  // Auth — no anonymous enrichment.
+  const userId = await authenticateUser(req);
+  if (!userId) {
+    return new Response(
+      JSON.stringify({ error: "Authentication required." }),
+      {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
+  }
+
+  // Rate limit (5 enrichments per user per 24h).
+  const sessionKey = `enrich:${userId}`;
+  const { allowed } = await checkRateLimit(sessionKey);
+  if (!allowed) {
+    return new Response(
+      JSON.stringify({
+        error:
+          "You've reached the daily limit for AI event enrichment. Please try again tomorrow.",
+      }),
+      {
+        status: 429,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
+  }
+
+  let body: EnrichRequest;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON body." }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  if (!body.eventTitle || !body.eventTitle.trim()) {
+    return new Response(
+      JSON.stringify({ error: "Missing eventTitle." }),
+      {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
+  }
+
+  const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
+  if (!apiKey) {
+    return new Response(
+      JSON.stringify({ error: "ANTHROPIC_API_KEY not configured." }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
+  }
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const send = (event: string, data: unknown) => {
+        controller.enqueue(sseEncode(event, data));
+      };
+
+      try {
+        const anthropicRes = await fetch(
+          "https://api.anthropic.com/v1/messages",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "x-api-key": apiKey,
+              "anthropic-version": "2023-06-01",
+            },
+            body: JSON.stringify({
+              model: "claude-sonnet-4-6",
+              max_tokens: 1024,
+              system: SYSTEM_PROMPT,
+              tools: [
+                {
+                  type: "web_search_20250305",
+                  name: "web_search",
+                  max_uses: 3,
+                },
+              ],
+              messages: [
+                { role: "user", content: buildUserPrompt(body) },
+              ],
+              stream: true,
+            }),
+          }
+        );
+
+        if (!anthropicRes.ok || !anthropicRes.body) {
+          const errText = await anthropicRes.text().catch(() => "");
+          send("error", {
+            message: `Anthropic API error (${anthropicRes.status}): ${errText.slice(0, 200)}`,
+          });
+          controller.close();
+          return;
+        }
+
+        // Track sources discovered via web_search tool results.
+        const sources: SourceItem[] = [];
+        const seenUrls = new Set<string>();
+
+        // Track current content block index → block type (so deltas can be
+        // routed correctly). Anthropic's stream emits content_block_start
+        // events with type info, then content_block_delta events.
+        const blockTypes = new Map<number, string>();
+
+        const reader = anthropicRes.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+
+          // Anthropic SSE: events delimited by \n\n.
+          let idx;
+          while ((idx = buffer.indexOf("\n\n")) !== -1) {
+            const rawEvent = buffer.slice(0, idx);
+            buffer = buffer.slice(idx + 2);
+            const lines = rawEvent.split("\n");
+            let eventName = "";
+            let dataStr = "";
+            for (const line of lines) {
+              if (line.startsWith("event: ")) eventName = line.slice(7).trim();
+              else if (line.startsWith("data: ")) dataStr += line.slice(6);
+            }
+            if (!dataStr) continue;
+            let data: Record<string, unknown>;
+            try {
+              data = JSON.parse(dataStr);
+            } catch {
+              continue;
+            }
+
+            if (eventName === "content_block_start") {
+              const index = data.index as number;
+              const block = data.content_block as Record<string, unknown>;
+              if (block && typeof block.type === "string") {
+                blockTypes.set(index, block.type);
+              }
+              // web_search_tool_result blocks come fully-formed in
+              // content_block_start (or sometimes via deltas) — extract URLs
+              // immediately if present.
+              if (block?.type === "web_search_tool_result") {
+                const content = block.content as Array<Record<string, unknown>> | undefined;
+                if (Array.isArray(content)) {
+                  for (const item of content) {
+                    if (item.type === "web_search_result") {
+                      const url = item.url as string | undefined;
+                      const title = (item.title as string | undefined) ?? "";
+                      if (url && !seenUrls.has(url)) {
+                        seenUrls.add(url);
+                        sources.push({ title: title || url, url });
+                      }
+                    }
+                  }
+                }
+              }
+            } else if (eventName === "content_block_delta") {
+              const index = data.index as number;
+              const delta = data.delta as Record<string, unknown>;
+              const blockType = blockTypes.get(index);
+              // Only emit description text from text blocks (not tool input).
+              if (blockType === "text" && delta?.type === "text_delta") {
+                const text = delta.text as string;
+                if (text) send("delta", { text });
+              }
+            } else if (eventName === "message_stop") {
+              // End of stream; loop will exit when reader is done.
+            }
+          }
+        }
+
+        send("sources", { sources });
+        send("done", {});
+        controller.close();
+
+        // Record usage after a successful run (not blocking the response).
+        recordUsage(sessionKey).catch(() => {});
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        try {
+          send("error", { message });
+        } catch {
+          // controller may already be closed
+        }
+        try {
+          controller.close();
+        } catch {
+          // already closed
+        }
+      }
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      ...corsHeaders,
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+});

--- a/supabase/functions/fetch-event-image/index.ts
+++ b/supabase/functions/fetch-event-image/index.ts
@@ -1,0 +1,130 @@
+// Wikimedia image lookup for an event title. Best-effort: any failure path
+// returns { imageUrl: null, attribution: null } rather than erroring so the
+// detail panel can render gracefully without an image.
+
+import { corsHeaders } from "../_shared/cors.ts";
+
+interface ImageResponse {
+  imageUrl: string | null;
+  attribution: string | null;
+}
+
+const EMPTY: ImageResponse = { imageUrl: null, attribution: null };
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+// Strip HTML tags from Wikimedia attribution metadata (Commons returns rich HTML).
+function stripHtml(input: string): string {
+  return input.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
+}
+
+async function searchPage(title: string): Promise<string | null> {
+  const url = `https://en.wikipedia.org/w/rest.php/v1/search/page?q=${encodeURIComponent(
+    title
+  )}&limit=1`;
+  const res = await fetch(url, {
+    headers: { "User-Agent": "TimelineAcademy/1.0 (image-lookup)" },
+  });
+  if (!res.ok) return null;
+  const json = await res.json();
+  const page = json?.pages?.[0];
+  if (!page?.title) return null;
+  return page.title as string;
+}
+
+async function fetchPageImage(
+  pageTitle: string
+): Promise<{ thumbUrl: string | null; fileTitle: string | null }> {
+  const url = `https://en.wikipedia.org/w/api.php?action=query&prop=pageimages&pithumbsize=600&piprop=thumbnail|name&titles=${encodeURIComponent(
+    pageTitle
+  )}&format=json&origin=*`;
+  const res = await fetch(url, {
+    headers: { "User-Agent": "TimelineAcademy/1.0 (image-lookup)" },
+  });
+  if (!res.ok) return { thumbUrl: null, fileTitle: null };
+  const json = await res.json();
+  const pages = json?.query?.pages;
+  if (!pages) return { thumbUrl: null, fileTitle: null };
+  const firstKey = Object.keys(pages)[0];
+  const page = pages[firstKey];
+  const thumbUrl = page?.thumbnail?.source ?? null;
+  const fileName = page?.pageimage ?? null;
+  const fileTitle = fileName ? `File:${fileName}` : null;
+  return { thumbUrl, fileTitle };
+}
+
+async function fetchImageMeta(
+  fileTitle: string
+): Promise<{ author: string | null; license: string | null }> {
+  const url = `https://en.wikipedia.org/w/api.php?action=query&titles=${encodeURIComponent(
+    fileTitle
+  )}&prop=imageinfo&iiprop=extmetadata&format=json&origin=*`;
+  const res = await fetch(url, {
+    headers: { "User-Agent": "TimelineAcademy/1.0 (image-lookup)" },
+  });
+  if (!res.ok) return { author: null, license: null };
+  const json = await res.json();
+  const pages = json?.query?.pages;
+  if (!pages) return { author: null, license: null };
+  const firstKey = Object.keys(pages)[0];
+  const page = pages[firstKey];
+  const meta = page?.imageinfo?.[0]?.extmetadata;
+  if (!meta) return { author: null, license: null };
+  const author = meta.Artist?.value ? stripHtml(meta.Artist.value) : null;
+  const license =
+    meta.LicenseShortName?.value ??
+    meta.UsageTerms?.value ??
+    null;
+  return { author, license };
+}
+
+function buildAttribution(
+  author: string | null,
+  license: string | null
+): string {
+  if (author && license) return `Photo: ${author} / ${license}`;
+  if (author) return `Photo: ${author}`;
+  if (license) return `Photo: Wikimedia Commons / ${license}`;
+  return "Photo: Wikimedia Commons";
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const { title } = await req.json();
+    if (!title || typeof title !== "string" || !title.trim()) {
+      return jsonResponse(EMPTY, 200);
+    }
+
+    const pageTitle = await searchPage(title.trim());
+    if (!pageTitle) return jsonResponse(EMPTY, 200);
+
+    const { thumbUrl, fileTitle } = await fetchPageImage(pageTitle);
+    if (!thumbUrl) return jsonResponse(EMPTY, 200);
+
+    let author: string | null = null;
+    let license: string | null = null;
+    if (fileTitle) {
+      const meta = await fetchImageMeta(fileTitle);
+      author = meta.author;
+      license = meta.license;
+    }
+
+    return jsonResponse({
+      imageUrl: thumbUrl,
+      attribution: buildAttribution(author, license),
+    });
+  } catch (err) {
+    console.error("fetch-event-image error:", err);
+    // Always degrade gracefully — the panel handles a null image.
+    return jsonResponse(EMPTY, 200);
+  }
+});

--- a/supabase/migrations/20260430000000_add_event_details.sql
+++ b/supabase/migrations/20260430000000_add_event_details.sql
@@ -1,0 +1,18 @@
+-- Add nullable columns to events for AI-generated detail panel content.
+-- All four are populated only when a user opens "Open details" on an event;
+-- existing rows remain valid with NULL values.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'events' AND column_name = 'description') THEN
+    ALTER TABLE events ADD COLUMN description text;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'events' AND column_name = 'image_url') THEN
+    ALTER TABLE events ADD COLUMN image_url text;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'events' AND column_name = 'image_attribution') THEN
+    ALTER TABLE events ADD COLUMN image_attribution text;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'events' AND column_name = 'sources') THEN
+    ALTER TABLE events ADD COLUMN sources jsonb;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
This PR adds AI-powered event enrichment capabilities and a read-only view mode to the timeline application. Users can now generate encyclopedic descriptions, fetch relevant images, and discover sources for historical events. A new detail panel displays this enriched content, and a view mode allows sharing timelines without edit affordances.

## Key Changes

### Event Enrichment System
- **`supabase/functions/enrich-event/index.ts`**: New edge function that uses Claude's web search tool to generate 1-2 paragraph event descriptions with grounded sources. Streams results via SSE with rate limiting (5 enrichments per user per 24h).
- **`supabase/functions/fetch-event-image/index.ts`**: New edge function that searches Wikipedia for event-related images and fetches attribution metadata from Wikimedia Commons.
- **`src/services/eventEnrichment.ts`**: Client-side service that orchestrates enrichment by calling the edge functions and parsing SSE streams. Handles authentication, abort signals, and error recovery.

### Detail Panel Component
- **`src/components/EventDetailPanel/EventDetailPanel.tsx`**: New side panel (mobile: full-screen overlay, desktop: right sidebar) that displays enriched event content including description, image with attribution, and sources. Features:
  - Auto-generates content when opening a fresh event in edit mode
  - Caches generated content on the event object
  - Regenerate and Remove buttons in edit mode
  - Confirmation modal for destructive actions
  - Streaming text display with loading states

### Event Actions Menu
- **`src/components/EventActionsMenu/EventActionsMenu.tsx`**: New context menu for events with "Edit event", "Open details", and "Delete" options. Automatically repositions to stay within viewport.

### View Mode
- **`src/App.tsx`**: Added `mode` state ('edit' | 'view') and detail panel state management
- **`src/components/Navigation/GlobalNav.tsx`**: New `ModeToggle` component to switch between edit and view modes. Hides edit affordances in view mode.
- **`src/components/Timeline/Timeline.tsx`**: 
  - Added `mode` prop and `onDeleteEvent`, `onOpenDetails` callbacks
  - In edit mode: click event to open actions menu
  - In view mode: click enriched event to open detail panel directly
  - Suppresses drag-to-reschedule and add-event affordances in view mode
- **`src/components/TimelineViewer/TimelineViewer.tsx`**: Integrated detail panel for public timeline viewing

### Data Model & Persistence
- **`src/types/event.ts`**: Added `EventSource` interface and optional enrichment fields (`description`, `imageUrl`, `imageAttribution`, `sources`) to `TimelineEvent`
- **`supabase/migrations/20260430000000_add_event_details.sql`**: Database migration adding nullable columns for enriched content
- **`src/utils/saveEvents.ts`**: Updated to persist enrichment fields; includes source equality comparison for change detection
- **`src/hooks/useTimeline.ts`**: Updated to hydrate enrichment fields from database

### UI/UX Updates
- **`src/components/Layout/Header.tsx`**: Passes mode prop to child components
- **`src/components/Timeline/TimelineEvent.tsx`**: Updated click handler to pass position for context menu
- **`src/utils/dateUtils.ts`**: Added `formatDateLong()` utility for detail panel date display

## Implementation Details

- **Streaming**: Enrichment uses SSE to stream description text in real-time while image fetch happens in parallel
- **Abort handling**: All async operations respect abort signals for cleanup when panel closes or user navigates away
- **Graceful degradation**: Image fetch failures return null/null rather than erroring; detail panel renders without image
- **Rate limiting**: Server-side rate limit (5 per user per 24h) prevents abuse of Claude API
- **Source extraction**: Sources come only from Claude's web_search tool results, never from invented citations
- **Portal rendering**: Detail panel and actions menu use React portals to avoid z-index stacking issues

https://claude.ai/code/session_01AdvgoFpWDZKpdqfS3GBWdD