### PR TITLE
Refactor toolbar to floating pill on desktop, sticky footer on mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -539,10 +539,6 @@ export function App() {
         onTimelineTitleChange={setTitle}
         events={events}
         timelineAccentColor={timelineAccentColor}
-        onAddEventClick={handleAddEventClick}
-        onEventsClick={() => setActivePanel(prev => prev === 'events' ? null : 'events')}
-        onSettingsClick={() => setActivePanel(prev => prev === 'settings' ? null : 'settings')}
-        activePanel={activePanel}
         saveStatus={saveStatus}
         lastSavedTime={lastSavedTime}
         mode={mode}

--- a/src/components/FloatingToolbar/FloatingToolbar.tsx
+++ b/src/components/FloatingToolbar/FloatingToolbar.tsx
@@ -1,5 +1,6 @@
 import { Plus, CalendarFold, Bolt } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { useSidePanel } from '@/hooks/useSidePanel'
 
 interface FloatingToolbarProps {
   onAddEventClick: () => void
@@ -8,24 +9,37 @@ interface FloatingToolbarProps {
   activePanel: 'events' | 'settings' | null
 }
 
+// Width of the floating side panel (matches GlobalLayout). The desktop pill
+// recenters over the timeline area by shifting half this distance to the right
+// when the panel is open.
+const SIDE_PANEL_WIDTH = 320
+
 export function FloatingToolbar({
   onAddEventClick,
   onEventsClick,
   onSettingsClick,
   activePanel,
 }: FloatingToolbarProps) {
+  const { isOpen: isSidePanelOpen } = useSidePanel()
+  const desktopTranslateX = isSidePanelOpen
+    ? `calc(-50% + ${SIDE_PANEL_WIDTH / 2}px)`
+    : '-50%'
+
   return (
     <>
-      {/* Desktop: floating pill, centered at bottom */}
+      {/* Desktop: floating pill, centered over the visible timeline area.
+          Animates with the side panel's push transition (300ms ease-out). */}
       <div
         className="
           hidden md:flex
-          fixed bottom-6 left-1/2 -translate-x-1/2 z-30
+          fixed bottom-6 left-1/2 z-30
           flex-row items-start gap-1.5 p-2
           w-[373px] h-[58px]
           bg-[rgba(23,23,23,0.8)] border border-[#262626] backdrop-blur-[2px]
           rounded-[20px]
+          transition-transform duration-300 ease-out will-change-transform
         "
+        style={{ transform: `translateX(${desktopTranslateX})` }}
       >
         <Button variant="glass" size="none" onClick={onAddEventClick}>
           <Plus size={20} />

--- a/src/components/FloatingToolbar/FloatingToolbar.tsx
+++ b/src/components/FloatingToolbar/FloatingToolbar.tsx
@@ -1,4 +1,4 @@
-import { Plus, Columns3, Settings } from 'lucide-react'
+import { Plus, CalendarFold, Bolt } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
 interface FloatingToolbarProps {
@@ -12,14 +12,23 @@ export function FloatingToolbar({
   onAddEventClick,
   onEventsClick,
   onSettingsClick,
-  activePanel
+  activePanel,
 }: FloatingToolbarProps) {
   return (
     <>
-      {/* Desktop */}
-      <div className="hidden md:flex items-center gap-2.5">
+      {/* Desktop: floating pill, centered at bottom */}
+      <div
+        className="
+          hidden md:flex
+          fixed bottom-6 left-1/2 -translate-x-1/2 z-30
+          flex-row items-start gap-1.5 p-2
+          w-[373px] h-[58px]
+          bg-[rgba(23,23,23,0.8)] border border-[#262626] backdrop-blur-[2px]
+          rounded-[20px]
+        "
+      >
         <Button variant="glass" size="none" onClick={onAddEventClick}>
-          <Plus size={18} />
+          <Plus size={20} />
           Add Event
         </Button>
         <Button
@@ -27,45 +36,39 @@ export function FloatingToolbar({
           data-active={activePanel === 'events'}
           onClick={onEventsClick}
         >
-          <Columns3 size={18} />
-          Event
-        </Button>
-        <Button
-          variant="glass" size="none"
-          data-active={activePanel === 'settings'}
-          onClick={onSettingsClick}
-        >
-          <Settings size={18} />
-          Settings
-        </Button>
-      </div>
-
-      {/* Mobile: Fixed bottom bar */}
-      <div className="fixed bottom-0 left-0 right-0 z-30 w-full flex md:hidden justify-around items-center gap-2 px-4 pt-2 pb-6 bg-black border-t border-[#3d3e40]">
-        <Button
-          variant="glass" size="none"
-          className="flex-col gap-1 h-auto px-3 py-2 text-[11px] min-w-0"
-          onClick={onAddEventClick}
-        >
-          <Plus size={20} />
-          Add
-        </Button>
-        <Button
-          variant="glass" size="none"
-          className="flex-col gap-1 h-auto px-3 py-2 text-[11px] min-w-0"
-          data-active={activePanel === 'events'}
-          onClick={onEventsClick}
-        >
-          <Columns3 size={20} />
+          <CalendarFold size={20} />
           Events
         </Button>
         <Button
           variant="glass" size="none"
-          className="flex-col gap-1 h-auto px-3 py-2 text-[11px] min-w-0"
           data-active={activePanel === 'settings'}
           onClick={onSettingsClick}
         >
-          <Settings size={20} />
+          <Bolt size={20} />
+          Settings
+        </Button>
+      </div>
+
+      {/* Mobile: full-width sticky footer */}
+      <div className="fixed bottom-0 left-0 right-0 z-30 w-full flex md:hidden justify-center items-center gap-1.5 px-4 pt-2 pb-6 bg-black border-t border-[#3d3e40]">
+        <Button variant="glass" size="none" onClick={onAddEventClick}>
+          <Plus size={20} />
+          Add Event
+        </Button>
+        <Button
+          variant="glass" size="none"
+          data-active={activePanel === 'events'}
+          onClick={onEventsClick}
+        >
+          <CalendarFold size={20} />
+          Events
+        </Button>
+        <Button
+          variant="glass" size="none"
+          data-active={activePanel === 'settings'}
+          onClick={onSettingsClick}
+        >
+          <Bolt size={20} />
           Settings
         </Button>
       </div>

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -72,17 +72,13 @@ export function Header({
 
   return (
     <>
-      {/* Mobile toolbar — desktop toolbar lives in GlobalNav.
-          Hidden in view mode (no editing affordances). */}
       {mode === 'edit' && (
-        <div className="md:hidden">
-          <FloatingToolbar
-            onAddEventClick={onAddEventClick}
-            onEventsClick={() => togglePanel('events')}
-            onSettingsClick={() => togglePanel('settings')}
-            activePanel={activePanel}
-          />
-        </div>
+        <FloatingToolbar
+          onAddEventClick={onAddEventClick}
+          onEventsClick={() => togglePanel('events')}
+          onSettingsClick={() => togglePanel('settings')}
+          activePanel={activePanel}
+        />
       )}
 
       <Dialog open={showAddEventModal} onOpenChange={(open) => { if (!open) onCloseAddEventModal(); }}>

--- a/src/components/Navigation/GlobalNav.tsx
+++ b/src/components/Navigation/GlobalNav.tsx
@@ -1,9 +1,6 @@
 import { type CSSProperties } from 'react'
 import {
-  Columns3,
   PanelLeft,
-  Plus,
-  Settings as SettingsIcon,
   SquarePen,
   SquarePlay,
 } from 'lucide-react'
@@ -21,11 +18,6 @@ interface GlobalNavProps {
   onTimelineTitleChange?: (title: string) => void
   events?: TimelineEvent[]
   timelineAccentColor?: string
-  /** Toolbar actions — only rendered on variant="timeline" */
-  onAddEventClick?: () => void
-  onEventsClick?: () => void
-  onSettingsClick?: () => void
-  activePanel?: 'events' | 'settings' | null
   /** Save status — only rendered on variant="timeline" */
   saveStatus?: SaveStatus
   lastSavedTime?: Date
@@ -41,10 +33,6 @@ export function GlobalNav({
   onTimelineTitleChange,
   events = [],
   timelineAccentColor = '#4196E4',
-  onAddEventClick,
-  onEventsClick,
-  onSettingsClick,
-  activePanel,
   saveStatus,
   lastSavedTime,
   mode = 'edit',
@@ -127,36 +115,6 @@ export function GlobalNav({
             </div>
           )}
         </div>
-
-        {/* Center cluster: editor action buttons */}
-        {variant === 'timeline' && mode === 'edit' && (
-          <div className="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 items-center gap-2.5">
-            {onAddEventClick && (
-              <Button variant="glass" size="none" onClick={onAddEventClick}>
-                <Plus size={18} />
-                Add Event
-              </Button>
-            )}
-            <Button
-              variant="glass"
-              size="none"
-              data-active={activePanel === 'events'}
-              onClick={onEventsClick}
-            >
-              <Columns3 size={18} />
-              Events
-            </Button>
-            <Button
-              variant="glass"
-              size="none"
-              data-active={activePanel === 'settings'}
-              onClick={onSettingsClick}
-            >
-              <SettingsIcon size={18} />
-              Settings
-            </Button>
-          </div>
-        )}
 
         {/* Right cluster: save status + action buttons */}
         <div className="ml-auto flex items-center gap-2">


### PR DESCRIPTION
## Summary
Consolidated toolbar UI into a dedicated `FloatingToolbar` component that works across all screen sizes, removing duplicate toolbar logic from `GlobalNav`. The toolbar now displays as a centered floating pill on desktop and a full-width sticky footer on mobile.

## Key Changes
- **FloatingToolbar component**: Now handles both desktop and mobile layouts with responsive styling
  - Desktop: Fixed centered floating pill at bottom with `rounded-[20px]` styling
  - Mobile: Full-width sticky footer with centered button layout
  - Updated icon imports: `Columns3` → `CalendarFold`, `Settings` → `Bolt`
  - Increased icon sizes from 18px to 20px for better visibility
  - Fixed "Event" label to "Events" for consistency

- **GlobalNav refactor**: Removed duplicate toolbar button cluster that was centered in the header
  - Removed toolbar-related props: `onAddEventClick`, `onEventsClick`, `onSettingsClick`, `activePanel`
  - Removed unused icon imports related to toolbar buttons
  - Simplified component to focus on navigation concerns only

- **Header component**: Simplified to always render `FloatingToolbar` in edit mode
  - Removed `md:hidden` wrapper since FloatingToolbar now handles responsive display internally
  - Cleaner prop passing to toolbar

- **App.tsx**: Removed toolbar props from GlobalNav invocation
  - Props now only passed to FloatingToolbar in Header component

## Implementation Details
- Toolbar positioning uses Tailwind's fixed positioning with `bottom-6` on desktop and `bottom-0` on mobile
- Desktop pill uses `backdrop-blur-[2px]` and semi-transparent background `rgba(23,23,23,0.8)` for visual polish
- Mobile layout uses `justify-center` to center buttons within the full-width footer
- Removed custom flex-col styling from mobile buttons, relying on Button component defaults

https://claude.ai/code/session_01KwbMDp6q1xKq9papwPYYjE