### PR TITLE
Rewrite TIMELINE_ARCHITECTURE.md to match current code

### DIFF
--- a/src/TIMELINE_ARCHITECTURE.md
+++ b/src/TIMELINE_ARCHITECTURE.md
@@ -1,431 +1,118 @@
 # Timeline Architecture
 
-> Living documentation of how the timeline page works. Update this file whenever timeline logic changes.
+> **Living documentation** of how the timeline page works.
+>
+> **Maintenance contract:** any PR that changes timeline rendering, layout, scaling, stacking, scrolling, drag, modes, or persistence must update this doc in the same PR. If the doc and the code disagree, **the code is correct and the doc is a bug** — open a follow-up PR to fix the doc.
+>
+> **Source of truth:** `src/components/Timeline/Timeline.tsx` and the files it imports. Constants live in `src/constants/`, types in `src/types/`, hooks in `src/hooks/`.
+
+---
 
 ## Table of Contents
 
 1. [Component Hierarchy](#component-hierarchy)
-2. [Layout System](#layout-system)
-3. [Grid System](#grid-system)
-4. [Category Labels (Left Sidebar)](#category-labels-left-sidebar)
-5. [Header (Year & Month Labels)](#header-year--month-labels)
-6. [Scroll Indicator (Floating Year)](#scroll-indicator-floating-year)
-7. [Event Rendering](#event-rendering)
-8. [Event Stacking Algorithm](#event-stacking-algorithm)
-9. [Category Height Calculation](#category-height-calculation)
-10. [Drag-and-Drop System](#drag-and-drop-system)
-11. [Scale / Zoom System](#scale--zoom-system)
-12. [Date-to-Grid Math](#date-to-grid-math)
-13. [Timeline Range Calculation](#timeline-range-calculation)
-14. [Data Flow & Persistence](#data-flow--persistence)
-15. [Key Constants](#key-constants)
-16. [Key Types](#key-types)
-17. [Hook Reference](#hook-reference)
+2. [Data Model](#data-model)
+3. [Layout System](#layout-system)
+4. [Grouping Modes](#grouping-modes)
+5. [Edit / View Modes](#edit--view-modes)
+6. [Grid System](#grid-system)
+7. [Header (Year & Month Labels)](#header-year--month-labels)
+8. [Scroll Indicator](#scroll-indicator)
+9. [Vertical Lines](#vertical-lines)
+10. [Category Labels](#category-labels)
+11. [Event Rendering](#event-rendering)
+12. [Event Stacking Algorithm](#event-stacking-algorithm)
+13. [Band Height Calculation](#band-height-calculation)
+14. [Drag-and-Drop System](#drag-and-drop-system)
+15. [Wheel → Horizontal Scroll](#wheel--horizontal-scroll)
+16. [Scroll-to-Date](#scroll-to-date)
+17. [Add-Event Cursor](#add-event-cursor)
+18. [Event Actions Menu](#event-actions-menu)
+19. [Event Form Dialog](#event-form-dialog)
+20. [Scale / Zoom System](#scale--zoom-system)
+21. [Date-to-Grid Math](#date-to-grid-math)
+22. [Timeline Range Calculation](#timeline-range-calculation)
+23. [Data Flow & Persistence](#data-flow--persistence)
+24. [Key Constants](#key-constants)
+25. [Hook Reference](#hook-reference)
 
 ---
 
 ## Component Hierarchy
 
+`Timeline.tsx` is the top-level orchestrator. It renders the following tree (children marked _conditional_ render only when the noted predicate is true):
+
 ```
-Timeline.tsx                    ← Main orchestrator
-├── TimelineCategoryLabels      ← Absolutely positioned left sidebar (150px)
-├── Scroll Container            ← Horizontal overflow, houses everything below
-│   ├── TimelineHeader          ← Sticky header row
-│   │   ├── TimelineYearLabels  ← Year spans across months
-│   │   └── TimelineMonthLabels ← Individual month columns
-│   ├── Category Sections       ← One section per visible category
-│   │   ├── TimelineGrid        ← Transparent interaction overlay (month hover/click)
-│   │   └── TimelineEvent[]     ← Events positioned in CSS Grid
-│   └── Month Hover Overlay     ← Semi-transparent highlight on hovered month
-└── TimelineScrollIndicator     ← Floating year label at left edge
+Timeline
+├── TimelineCategoryLabels                ─ conditional: groupByCategory
+│                                           (overlay, absolute, top = SCROLL_INDICATOR_HEIGHT + HEADER_HEIGHT)
+├── inner column wrapper
+│   ├── TimelineScrollIndicator
+│   └── scroll container (overflow-auto, scrollbar-hide)
+│       └── timeline-grid wrapper
+│           ├── TimelineHeader
+│           │   ├── TimelineYearLabels
+│           │   └── TimelineMonthLabels
+│           ├── body column
+│           │   ├── TimelineVerticalLines
+│           │   ├── layout.bands.map(band)               ─ 1 band by default; N bands when groupByCategory
+│           │   │   ├── TimelineGrid                     ─ interaction overlay sized to the band
+│           │   │   └── TimelineEvent[]                  ─ events placed into the band's CSS Grid
+│           │   └── filler column
+│           │       └── TimelineGrid                     ─ fills remaining vertical space below events
+│           └── Add-Event Cursor                         ─ conditional: hoveredMonth !== null
+│                                                         && isEditing && onAddEvent && !dragState.isDragging
+├── EventActionsMenu                       ─ conditional: menuState (event clicked in edit mode)
+└── Dialog (shadcn) > EventForm            ─ conditional: showEventModal
 ```
+
+`TimelineCategoryLabels` and the `Dialog` are siblings of the scroll-container subtree, not children of it. The category-labels overlay is positioned absolutely to align with the bands while staying outside the horizontal scroll.
 
 ---
 
-## Layout System
-
-The timeline uses a **two-column layout**:
-
-```
-┌─────────────┬──────────────────────────────────────────────────┐
-│  Category   │  Scrollable Timeline Content                     │
-│  Labels     │  ┌────────────────────────────────────────────┐  │
-│  (150px)    │  │ Year Labels    │ 2020 │ 2021 │ 2022 │ ... │  │
-│  absolute   │  ├────────────────────────────────────────────┤  │
-│  z-10       │  │ Month Labels   │ Jan│Feb│Mar│Apr│... │     │  │
-│             │  ├────────────────────────────────────────────┤  │
-│  ┌────────┐ │  │ Category 1   [===Event===]  [==Event==]   │  │
-│  │Cat 1   │ │  │              [====Event====]              │  │
-│  ├────────┤ │  ├────────────────────────────────────────────┤  │
-│  │Cat 2   │ │  │ Category 2        [===Event===]           │  │
-│  ├────────┤ │  ├────────────────────────────────────────────┤  │
-│  │Cat 3   │ │  │ Category 3   [==Event==]                  │  │
-│  └────────┘ │  └────────────────────────────────────────────┘  │
-└─────────────┴──────────────────────────────────────────────────┘
-```
-
-- **Left sidebar**: `absolute left-0 top-[64px] w-[150px] z-10 bg-black`
-- **Scroll container**: `overflow-x-auto scrollbar-hide` with `margin-left: -150px` and `padding-left: 150px` to keep the sidebar fixed while content scrolls
-
-The root div uses `h-[calc(100vh-6rem)]` in fullscreen mode or `relative mb-16` in normal mode.
-
----
-
-## Grid System
-
-The timeline content is a **CSS Grid** where each column represents one quarter of a month.
-
-```
-Grid columns = months.length × 4
-Column width  = scale.quarterWidth (8px large / 6.5px small)
-```
-
-```css
-grid-template-columns: repeat(${months.length * 4}, ${scale.quarterWidth}px);
-```
-
-**Example:** A 10-year timeline (120 months) at large scale = 120 × 4 = 480 columns, each 8px wide = 3,840px total width.
-
-Each category section gets its own grid with the same column template. Events are placed via `gridColumn` start/end spans.
-
----
-
-## Category Labels (Left Sidebar)
-
-**Component:** `TimelineCategoryLabels.tsx`
-
-Rendered as a vertical stack of colored boxes, one per visible category. Each label:
-
-- **Background:** `${category.color}47` (hex color with 47 alpha suffix for transparency)
-- **Border:** `border-2 border-black` with rounded corners
-- **Right accent:** `absolute top-0 right-0 w-1 h-full` in solid category color
-- **Text:** `text-sm font-medium uppercase break-words` in `#fbfbfb`
-- **Height:** Matches corresponding category section height (dynamic, based on event stacking)
-
-Parent container: `relative h-full ml-3`
-
----
-
-## Header (Year & Month Labels)
-
-**Component:** `TimelineHeader.tsx` → wraps `TimelineYearLabels` + `TimelineMonthLabels`
-
-The header uses a CSS Grid with one column per month:
-
-```css
-grid-template-columns: repeat(${months.length}, ${scale.monthWidth}px);
-```
-
-### Year Labels (`TimelineYearLabels.tsx`)
-- Spans full grid width: `gridColumn: 1 / span ${months.length}`
-- Flexbox row where each year section width = `monthsInYear × scale.monthWidth`
-- Height: 32px (`h-8`)
-- Year text: `text-sm text-gray-400 text-center font-mono`
-- Animated width transitions: `transition-[width] duration-200 ease-in-out`
-
-### Month Labels (`TimelineMonthLabels.tsx`)
-- Grid: one cell per month, each `${scale.monthWidth}px` wide
-- Height: 32px (`h-8`)
-- Month text: `text-[10px] text-gray-500 font-mono`, formatted via `date-fns` → `'MMM'` (Jan, Feb, etc.)
-- Vertical borders: `border-r border-gray-700` between months
-
----
-
-## Scroll Indicator (Floating Year)
-
-**Component:** `TimelineScrollIndicator.tsx`
-
-A fixed indicator at the left edge of the timeline that shows which year the user is currently viewing.
-
-- **Position:** `absolute left-[150px] top-[32px] bottom-[32px]`
-- **Visual:** 4px wide white vertical bar with upper extension line (24px)
-- **Year display:** `text-2xl` monospace text, 8px above the indicator bar
-
-**Logic:** Uses `getCurrentTimelinePosition()` from `timelineUtils.ts` which:
-1. Reads `scrollLeft` from the scroll container
-2. Calculates which month index corresponds to that scroll position
-3. Returns current month, next month, and whether December is ending
-4. The indicator displays the corresponding year
-
----
-
-## Event Rendering
-
-**Component:** `TimelineEvent.tsx` (React.memo wrapped)
-
-Each event renders as a horizontal bar within its category's CSS Grid:
-
-### Grid Positioning
-```
-gridColumn: ${startColumn} / ${endColumn}
-gridRow:    ${event.stackIndex + 1}
-```
-
-Start/end columns are calculated from dates:
-- Find the month index in the timeline's months array
-- Calculate the quarter within that month: `Math.floor((day - 1) / 8)`
-- Column number: `(monthIndex × 4) + quarterIndex + 1` (1-indexed for CSS Grid)
-
-### Visual Styling
-- **Multi-day events:** Background `${categoryColor}73` (color with 73 alpha), left accent bar (8px solid category color), rounded
-- **Single-day events:** Transparent background, only the accent bar is visible
-- **Text:** White, truncated with `overflow-hidden text-ellipsis whitespace-nowrap`
-- **Hover:** `hover:brightness-110` with transition
-- **Cursor:** `grab` (idle) / `grabbing` (while dragging)
-
-### During Drag
-- **Transform:** `translateX(${dragDeltaPixels}px) scale(1.04)`
-- **Z-index:** 1000 (elevated above all other events)
-- **Box shadow:** `0 8px 24px rgba(0, 0, 0, 0.45)`
-- **Opacity:** 0.92
-- **Ghost placeholder:** Remains at original position with opacity 0.3 and `pointer-events: none`
-
----
-
-## Event Stacking Algorithm
-
-**File:** `src/utils/eventStacking.ts`
-
-Determines vertical positioning of events within a category to avoid overlaps.
-
-### Algorithm
-
-```
-Input:  events[] (for one category), months[]
-Output: StackedEvent[] (each event gets a stackIndex)
-
-1. Sort events by start date ASC, then by duration ASC (shorter events first)
-
-2. For each event:
-   a. Calculate startColumn from start date → month index × 4 + quarter
-   b. Calculate endColumn from end date → month index × 4 + quarter
-   c. Calculate title width in columns:
-      titleColumns = ceil(max(EVENT_MIN_WIDTH, title.length × 8) / monthWidth)
-   d. Visual end = max(endColumn, startColumn + titleColumns - 1)
-
-   e. Find first available stackIndex (starting from 0):
-      - Check collision with all already-placed events at that stackIndex
-      - Collision = (newStart ≤ existingVisualEnd) AND (existingStart ≤ newVisualEnd)
-      - Assign first collision-free stackIndex
-
-3. Return events with stackIndex added
-```
-
-### Key Details
-- `EVENT_MIN_WIDTH` = 120px ensures short events still have enough room for title text
-- Title width approximation: 8px per character
-- The "visual end" concept prevents title text from overlapping even if the date range is narrow
-
----
-
-## Category Height Calculation
-
-**Hook:** `useCategoryHeights.ts`
-
-Determines the pixel height of each category section based on how many events stack vertically.
-
-```
-For each category:
-  maxStack = highest stackIndex among events in that category + 1
-  height   = max(CATEGORY_MIN_HEIGHT, maxStack × EVENT_ROW_HEIGHT + CATEGORY_PADDING)
-```
-
-Where:
-- `CATEGORY_MIN_HEIGHT` = 80px (minimum even for empty categories)
-- `EVENT_ROW_HEIGHT` = 38px (EVENT_HEIGHT 36px + 2px gap)
-- `CATEGORY_PADDING` = 8px
-
-The hook also uses `doEventsOverlap()` and `getMaxOverlappingEvents()` for an alternative overlap-counting approach (counting maximum concurrent events using date-range overlap detection).
-
----
-
-## Drag-and-Drop System
-
-**Hook:** `useEventDrag.ts`
-
-Allows users to drag events horizontally to change their dates.
-
-### Flow
-
-1. **Pointer Down** (`handlePointerDown`):
-   - Records start X position and current scroll offset
-   - Sets `draggedEventId`
-
-2. **Pointer Move** (`handlePointerMove`):
-   - Calculates total pixel delta (including scroll changes since drag start)
-   - Applies `DRAG_THRESHOLD` (5px) — movement below this is treated as a click, not a drag
-   - Converts pixels to quarters: `deltaQuarters = Math.round(deltaPixels / scale.quarterWidth)`
-   - Updates `dragState: { isDragging, draggedEventId, deltaQuarters, deltaPixels }`
-
-3. **Pointer Up** → `handleDragEnd` in `Timeline.tsx`:
-   - Calls `shiftEventDates(event, deltaQuarters)` from `dateUtils.ts`
-   - Each quarter = 7 days: shifts both start and end dates by `deltaQuarters × 7` days
-   - Updates event via `onUpdateEvent` callback
-
-4. **Anti-click guard:** `justDraggedRef` prevents click handlers from firing immediately after a drag ends
-
-### Edge-of-viewport scrolling
-Timeline.tsx uses `requestAnimationFrame` to auto-scroll the container when dragging near edges.
-
----
-
-## Scale / Zoom System
-
-**Hook:** `useTimelineScale.ts`
-**Constants:** `src/constants/scales.ts`
-
-Two scale options:
-
-| Scale   | monthWidth | quarterWidth | Use case        |
-|---------|-----------|-------------|-----------------|
-| `large` | 32px      | 8px         | Default, detail |
-| `small` | 26px      | 6.5px       | Overview, dense |
-
-- Scale selection persists to the `timelines.scale` column in Supabase
-- Changing scale recalculates all event positions (same grid math, different pixel widths)
-- `useAutosave` saves scale changes automatically
-
----
-
-## Date-to-Grid Math
-
-How dates map to CSS Grid columns:
-
-```
-Month Index   = findIndex in months[] where month.year === date.year && month.month === date.month
-Quarter Index = Math.floor((day - 1) / 8)
-  Day  1–8  → Quarter 0
-  Day  9–16 → Quarter 1
-  Day 17–24 → Quarter 2
-  Day 25–31 → Quarter 3
-
-Grid Column = (monthIndex × 4) + quarterIndex + 1    (1-indexed for CSS Grid)
-```
-
-**Pixel position of a column:**
-```
-pixelX = (gridColumn - 1) × scale.quarterWidth
-```
-
-**Reverse (drag delta to date shift):**
-```
-deltaQuarters = Math.round(deltaPixels / scale.quarterWidth)
-dateDelta     = deltaQuarters × 7 days
-```
-
-Each quarter represents approximately 7–8 days. The mapping is approximate but provides consistent visual spacing.
-
----
-
-## Timeline Range Calculation
-
-**File:** `src/utils/dateUtils.ts`
-
-Determines which months to render based on event dates.
-
-### Rules
-1. **Empty timeline:** DEFAULT_START_YEAR (2014) to DEFAULT_END_YEAR (2024)
-2. **With events:** Min year and max year extracted from all event start/end dates
-3. **Minimum span:** Always at least 10 years (adds padding on both ends if needed)
-4. **Bounds:** MIN_YEAR = 1900, MAX_YEAR = 2100
-
-### Month Generation
-`generateMonthsRange(startYear, endYear)` creates a `Month[]` array with one entry per month:
-```ts
-{ year: number, month: number }  // month is 0-indexed (0 = January)
-```
-
-This array is the backbone of the entire grid — its length determines column count and event positioning.
-
----
-
-## Data Flow & Persistence
-
-### Hooks Architecture
-
-```
-useTimelineState    ← Composes all timeline state hooks into a single entry point
-  ├── useEvents     ← Local event state (add, update, delete, batch)
-  ├── useCategories ← Category labels/colors/visibility
-  ├── useTimelineTitle ← Title + description state
-  └── useTimelineScale ← Scale toggle (large/small)
-
-useTimeline         ← Loads/saves timeline record + events from/to Supabase
-useAutosave         ← Watches for changes, debounced save (2000ms)
-useLocalDraft       ← localStorage backup for unsaved work
-useTimelineScroll   ← Scroll position tracking for the scroll indicator
-useEventDrag        ← Drag interaction state machine
-```
-
-### Save Flow
-
-1. User makes a change (edit event, drag, rename, etc.)
-2. `useAutosave.handleChange()` is called, starts 2000ms debounce timer
-4. Save status → `'saving'`
-5. `saveTimelineEvents()` performs **diff-based sync**:
-   - Fetches current server events
-   - Classifies each as INSERT, UPDATE, or DELETE
-   - Executes in order: UPDATE → DELETE → INSERT
-6. Save status → `'saved'` (or `'error'` on failure)
-7. Network recovery: if save failed, retries automatically on `window.online` event
-8. Beforeunload warning: prompts user if unsaved changes exist when closing tab
-
-### Event Operations
-- **Create:** `useEvents.addEvent()` generates UUID via `crypto.randomUUID()`
-- **Update:** `useEvents.updateEvent()` replaces by id in local state
-- **Batch add:** `useEvents.addEvents()` deduplicates by (title + dates + category)
-- **Delete:** Filter event out of local state; `saveTimelineEvents()` detects the removal
-- **Limit:** Maximum 3 timelines per user (enforced in `useTimeline`)
-
-### Local Draft
-`useLocalDraft` saves to localStorage with 500ms debounce as a safety net:
-```ts
-{ title, description, events, categories, scale, savedAt }
-```
-
----
-
-## Key Constants
-
-**File:** `src/constants/timeline.ts`
-
-| Constant             | Value  | Description                              |
-|---------------------|--------|------------------------------------------|
-| `EVENT_HEIGHT`       | 36px   | Height of an event bar                   |
-| `EVENT_ROW_HEIGHT`   | 38px   | Event height + 2px vertical gap          |
-| `EVENT_MIN_WIDTH`    | 120px  | Minimum event width for title visibility |
-| `CATEGORY_PADDING`   | 8px    | Vertical padding within category section |
-| `CATEGORY_MIN_HEIGHT`| 80px   | Minimum height for empty categories      |
-
-**File:** `src/constants/scales.ts`
-
-| Scale   | monthWidth | quarterWidth |
-|---------|-----------|-------------|
-| `large` | 32px      | 8px         |
-| `small` | 26px      | 6.5px       |
-
-**File:** `src/constants/categories.ts`
-
-| Category     | Label      | Color     |
-|-------------|------------|-----------|
-| `category_1` | Category 1 | `#A770EC` (Purple) |
-| `category_2` | Category 2 | `#FF7D05` (Orange) |
-| `category_3` | Category 3 | `#259E23` (Green)  |
-| `category_4` | Category 4 | `#4196E4` (Blue)   |
-
----
-
-## Key Types
-
-**File:** `src/types/event.ts`
+## Data Model
 
 ```ts
+// src/types/timeline.ts
+interface Month {
+  year: number
+  month: number    // 0-indexed (0 = January)
+}
+
+interface Timeline {
+  id: string
+  title: string
+  updated_at: string | null
+  user_id: string
+  scale: 'large' | 'small'
+}
+
+interface TimelineScale {
+  value: 'large' | 'small'
+  monthWidth: number
+  quarterWidth: number
+}
+```
+
+```ts
+// src/types/event.ts
+interface EventSource {
+  title: string
+  url: string
+}
+
 interface TimelineEvent {
   id: string
   title: string
-  startDate: string   // ISO YYYY-MM-DD
-  endDate: string     // ISO YYYY-MM-DD
+  startDate: string                  // ISO YYYY-MM-DD
+  endDate: string                    // ISO YYYY-MM-DD
   category: TimelineCategory
+  // AI-generated detail fields. Populated only after the user opens
+  // "Open details" on an event in edit mode and the enrichment completes.
+  description?: string | null
+  imageUrl?: string | null
+  imageAttribution?: string | null
+  sources?: EventSource[] | null
 }
 
 type TimelineCategory = 'category_1' | 'category_2' | 'category_3' | 'category_4'
@@ -433,79 +120,597 @@ type TimelineCategory = 'category_1' | 'category_2' | 'category_3' | 'category_4
 interface CategoryConfig {
   id: TimelineCategory
   label: string
-  color: string       // Hex color
+  color: string
   visible: boolean
 }
 ```
 
-**File:** `src/types/timeline.ts`
-
 ```ts
-interface Month {
-  year: number
-  month: number       // 0-indexed (0 = January)
-}
-
-interface Timeline {
-  id: string
-  title: string
-  updated_at: string
-  user_id: string
-  scale: 'large' | 'small'
-}
-
-interface TimelineScale {
-  value: 'large' | 'small'
-  monthWidth: number    // 32 or 26
-  quarterWidth: number  // 8 or 6.5
-}
-```
-
-**File:** `src/utils/eventStacking.ts`
-
-```ts
+// src/utils/eventStacking.ts
 interface StackedEvent extends TimelineEvent {
-  stackIndex: number   // Vertical row index within category (0-based)
+  stackIndex: number   // Vertical row index within the band (0-based)
 }
 ```
+
+---
+
+## Layout System
+
+The root element switches between two outer modes based on `isFullScreen`:
+
+```tsx
+isFullScreen
+  ? 'h-[calc(100vh-6rem)] relative'
+  : 'flex-1 min-h-0 flex flex-col relative'
+```
+
+Inside the root, the page is a vertical stack:
+
+1. `TimelineScrollIndicator` — height `SCROLL_INDICATOR_HEIGHT` (36px), in normal flow at the top.
+2. Scroll container (`overflow-auto scrollbar-hide`).
+   - Inside, the `timeline-grid` wrapper has `min-width: months.length * scale.monthWidth` and `min-height: 100%`.
+   - First child is `TimelineHeader` (year + month labels, total 64px tall).
+   - Below that is the body column, which contains `TimelineVerticalLines`, the layout bands, and a `flex-1` filler.
+
+When `groupByCategory` is true, a separate `TimelineCategoryLabels` overlay is rendered as the first child of the root, with `position: absolute; left: 0; z-10; pointer-events: none` and `top: SCROLL_INDICATOR_HEIGHT + HEADER_HEIGHT` (= 100px). Its height matches `layout.totalHeight`. The overlay sits outside the horizontal scroll container, so it stays pinned to the left edge as the user scrolls horizontally.
+
+---
+
+## Grouping Modes
+
+Controlled by the `groupByCategory` prop on `Timeline.tsx`. State lives in `useGroupByCategory` and is persisted on the `timelines.group_by_category` column via `useAutosave`.
+
+| `groupByCategory` | Bands | Row height | Category labels |
+|---|---|---|---|
+| `false` (default) | One band containing every visible event, stacked together. | `EVENT_ROW_HEIGHT` (38px) | Hidden |
+| `true` | One band per visible category, in `visibleCategories` order. Each band runs its own stacking pass. | `EVENT_HEIGHT` (36px) | Rendered as the absolute overlay (see §3) |
+
+In grouped mode, each `TimelineEvent` receives `categoryOffset = band.offset` so the event renders at the correct vertical position within the overall body. In default mode, all events share `offset = 0`.
+
+---
+
+## Edit / View Modes
+
+The `mode` prop is `'edit' | 'view'` and defaults to `'edit'`. `Timeline.tsx` derives `const isEditing = mode === 'edit'`.
+
+| Affordance | Edit mode | View mode |
+|---|---|---|
+| Drag-to-reschedule | Enabled (`onPointerDown` is wired only when `isEditing && onUpdateEvent`). | Suppressed. |
+| Add-Event Cursor (hover band) | Rendered when `onAddEvent` is provided. | Not rendered. |
+| Click on event | Opens `EventActionsMenu` at the click position. | Calls `onOpenDetails(event)`. |
+| Click on a month cell | Opens the `EventForm` Dialog seeded with that month's first day. | No-op (`handleMonthClick` returns early). |
+
+---
+
+## Grid System
+
+Two CSS Grids run in parallel:
+
+**Header (`TimelineHeader`)** — one column per month:
+
+```css
+grid-template-columns: repeat(${months.length}, ${scale.monthWidth}px);
+```
+
+**Each body band** — one column per quarter (4× as many columns as months), with rows derived from stack index:
+
+```css
+grid-template-columns: repeat(${months.length * 4}, ${scale.quarterWidth}px);
+grid-auto-rows:       ${rowHeight}px;
+gap:                  0;
+```
+
+Where `rowHeight` is `EVENT_HEIGHT` when `groupByCategory` is true, else `EVENT_ROW_HEIGHT`. Events are placed into a band via `gridColumn: ${startColumn} / ${endColumn}` and `gridRow: ${stackIndex + 1}`.
+
+---
+
+## Header (Year & Month Labels)
+
+`TimelineHeader` is a CSS Grid with one column per month; it composes `TimelineYearLabels` and `TimelineMonthLabels`.
+
+### `TimelineYearLabels.tsx`
+
+- Spans the full grid: `gridColumn: 1 / span ${months.length}`, `display: flex`.
+- Container: `border-l border-line-default relative h-8 transition-[width] duration-200 ease-in-out`.
+- One inner div per year, width = `monthsInYear × scale.monthWidth`, `border-r border-line-year-boundary`, `shrink-0`.
+- Year text: `text-sm text-[#9b9ea3] text-center font-mono`.
+
+### `TimelineMonthLabels.tsx`
+
+- Container: `border-l border-line-default`, with its own grid: `repeat(${months.length}, ${scale.monthWidth}px)`.
+- Each month cell: `border-r ${getMonthBorderClass(month)}` (where `getMonthBorderClass` returns `border-line-year-boundary` for December and `border-line-default` otherwise), `flex items-center justify-center h-8`.
+- Month abbreviation text only renders when `scale.value === 'large'`:
+  ```tsx
+  {scale.value === 'large' && (
+    <span className="text-[10px] text-[#9b9ea3] font-mono ...">
+      {format(new Date(month.year, month.month), 'MMM')}
+    </span>
+  )}
+  ```
+  At `small` scale the cell is empty (vertical borders only).
+
+---
+
+## Scroll Indicator
+
+`TimelineScrollIndicator.tsx` is a single year label rendered in normal flow at the top of the timeline column. It is **not** an absolutely-positioned vertical bar.
+
+```tsx
+<div
+  className="flex items-start px-[24px] pointer-events-none font-mono text-[24px] text-[#9b9ea3] whitespace-nowrap"
+  style={{ height: SCROLL_INDICATOR_HEIGHT }}
+>
+  {leftYear != null && <span>{leftYear}</span>}
+</div>
+```
+
+The displayed year is `months[Math.max(0, Math.floor(visibleRange.start / 4))]?.year`, where `visibleRange.start` comes from `useTimelineScroll` and is expressed in quarter-columns. `Math.floor(... / 4)` converts back to a month index.
+
+---
+
+## Vertical Lines
+
+`TimelineVerticalLines.tsx` overlays a vertical line at every month boundary plus a trailing edge. The component is `aria-hidden`, `pointer-events-none`, and absolute-positioned to fill its parent.
+
+For each month index `i`, a `<span>` is placed at `left: i * scale.monthWidth` with class `bg-line-year-boundary` if its left-side neighbor is December, else `bg-line-default`. A trailing `<span>` is placed at `left: months.length * scale.monthWidth`.
+
+Reveal animation: an `IntersectionObserver` rooted on the scroll container marks each line `data-revealed="true"` the first time it intersects the viewport (the CSS for `.timeline-vertical-line[data-revealed]` handles the reveal). When `window.matchMedia('(prefers-reduced-motion: reduce)').matches`, every line is revealed immediately and the observer is skipped.
+
+The observer effect re-runs only when the months range key (`first..last`) or the scroll container ref changes — scale changes are handled by CSS transitions, not a new observer.
+
+---
+
+## Category Labels
+
+`TimelineCategoryLabels.tsx` renders the per-category pill labels that align with each band when `groupByCategory` is true.
+
+```tsx
+<div className="relative h-full">
+  {categories.map(cat => (
+    <div className="flex items-start pt-2 pl-6" style={{ height: `${cat.height}px` }}>
+      <div
+        className="rounded-[4px] p-2 backdrop-blur-[2px] leading-none"
+        style={{ backgroundColor: `${color}4D` }}
+      >
+        <span className="label-small-allcaps whitespace-nowrap">{label}</span>
+      </div>
+    </div>
+  ))}
+</div>
+```
+
+The `4D` suffix is the alpha byte (~30%) appended to the category color. The component receives a `categories: { id, height }[]` array (from `layout.bands`) plus the full `customCategories` list to look up label and color. It is rendered only when `groupByCategory` is true, inside the absolute overlay described in §3.
+
+---
+
+## Event Rendering
+
+`TimelineEvent.tsx` is a `React.memo` wrapper that places one event into its band's CSS Grid.
+
+### Positioning
+
+```ts
+gridColumn: `${startColumn} / ${endColumn}`
+gridRow:    event.stackIndex + 1
+minWidth:   EVENT_MIN_WIDTH (120px)
+height:     EVENT_ROW_HEIGHT (38px)
+zIndex:     isDragging ? 1000 : event.stackIndex + 1
+```
+
+`startColumn` / `endColumn` are derived from the event's start and end dates via the date-to-grid math in §21.
+
+### Visual styling
+
+- **Multi-day event:** inner content has `backgroundColor: ${categoryColor}73` (color with `73` alpha), an 8px-wide accent bar in the solid category color on the left, and the title in `body-lg`.
+- **Single-day event** (`startDate === endDate`): inner content has `backgroundColor: 'transparent'` — only the 8px accent bar is visible, with the title beside it.
+- **Hover:** `hover:brightness-110 transition-colors hover:text-text-primary`.
+- **Cursor:** `grab` when draggable and idle, `grabbing` while dragging, `pointer` when only clickable (e.g. view mode).
+
+### Drag visuals
+
+When `isDragging` is true:
+
+```ts
+transform:  `translateX(${dragDeltaPixels}px) scale(1.04)`
+boxShadow:  '0 8px 24px rgba(0, 0, 0, 0.45)'
+opacity:    0.92
+zIndex:     1000
+transition: 'box-shadow 150ms ease, opacity 150ms ease'
+```
+
+A second element renders at the original `gridColumn`/`gridRow` with `opacity: 0.3` and `pointer-events: none` — the **ghost placeholder** that holds the slot until the drag ends.
+
+### Stack-reflow animation (FLIP)
+
+When `event.stackIndex` changes between renders (e.g. after a drag, an add, or a delete causes other events to re-stack), the component runs a 220ms FLIP animation:
+
+1. `useLayoutEffect` detects the stack change, computes `delta = (prevStack - newStack) * rowHeight`, sets phase `'jumping'` with `transform: translateY(delta)` and `transition: 'none'`.
+2. After two RAFs, phase flips to `'animating'` with `transform: translateY(0)` and `transition: transform 220ms ease`.
+3. `onTransitionEnd` returns the phase to `'idle'`.
+
+Drag transforms take priority over FLIP transforms — the dragged event is excluded from FLIP and animates separately via its own drag styles.
+
+### Mount callback
+
+`onMounted(eventId, node)` is called from a ref callback. `Timeline.tsx` uses it to detect when a freshly-added event has rendered, then calls `node.scrollIntoView` to bring it into view. See §16 Scroll-to-Date.
+
+---
+
+## Event Stacking Algorithm
+
+`src/utils/eventStacking.ts` exports `calculateEventStacks(events, months, monthWidth) → StackedEvent[]`.
+
+### Inputs and outputs
+
+- **Input:** the events for one band, the month range, and the active `monthWidth`.
+- **Output:** the same events with a `stackIndex: number` assigned (0-based row within the band).
+
+### Algorithm
+
+1. **Sort** events by `startDate` ascending (stable; same-start events keep their original order).
+2. For each event:
+   - Compute `startColumn` and `endColumn` from the start/end month indices.
+   - Compute the title's required pixel width via canvas-based `measureTextWidth`, rounded up to whole columns:
+     ```ts
+     displayPx  = max(EVENT_MIN_WIDTH, textPx + TITLE_CHROME_WIDTH)
+     requiredPx = displayPx + TRAILING_BUFFER_PX
+     requiredColumns = ceil(requiredPx / monthWidth)
+     ```
+   - Compute `visualEndColumn = max(endColumn, startColumn + requiredColumns - 1)`. This guarantees the title's pixel footprint is honored even when the date range is narrow (e.g. a single-day event with a long title).
+   - **First-fit:** starting from `stackIndex = 0`, find the first row where the new placement does not overlap any existing placement. Two placements collide iff:
+     ```ts
+     existing.stackIndex === new.stackIndex
+       && new.startColumn <= existing.visualEndColumn
+       && existing.startColumn <= new.visualEndColumn
+     ```
+
+### Text measurement
+
+```ts
+TITLE_FONT          = '400 16px Avenir, sans-serif'
+TITLE_CHROME_WIDTH  = 20   // pixels: outer 2px + inner 2px + 8px accent + 4px padding + 2px + 2px
+TRAILING_BUFFER_PX  = 24   // empty space reserved after each event so adjacent same-row events don't visually touch
+```
+
+`measureTextWidth` lazily creates a 2D canvas context and caches it in module-level state. When `typeof document === 'undefined'` (SSR / non-browser), it falls back to `text.length * 8` pixels.
+
+---
+
+## Band Height Calculation
+
+Band heights are computed inline in `Timeline.tsx`'s `layout` `useMemo` (no separate hook).
+
+**`groupByCategory: true`** — one band per visible category:
+
+```ts
+maxStack = max(stackedEvents.stackIndex, 0)
+height   = max((maxStack + 1) * EVENT_HEIGHT + CATEGORY_PADDING, CATEGORY_MIN_HEIGHT)
+```
+
+Bands are stacked vertically; each band records its `offset` (sum of prior heights) so events know where their band starts.
+
+**`groupByCategory: false`** — single band containing every visible event:
+
+```ts
+maxStack = max(stackedEvents.stackIndex, 0)
+height   = stackedEvents.length === 0
+            ? EVENT_ROW_HEIGHT
+            : (maxStack + 1) * EVENT_ROW_HEIGHT + CATEGORY_PADDING
+```
+
+`layout.totalHeight` sums the band heights and is used to size the category-labels overlay in grouped mode.
+
+---
+
+## Drag-and-Drop System
+
+`useEventDrag(scale, scrollContainerRef, onDragEnd) → { dragState, handlePointerDown, justDraggedRef }`.
+
+### Flow
+
+1. **`handlePointerDown(eventId, e)`** — only the primary button (`e.button === 0`) starts a drag. Records start client X and the scroll container's `scrollLeft`. Attaches window listeners for `pointermove`, `pointerup`, `pointercancel`, and `blur`.
+2. **`handlePointerMove(e)`** — computes `deltaPixels = (e.clientX - startX) + (currentScrollLeft - startScrollLeft)`, so simultaneously scrolling the container during a drag is accounted for. Until `|deltaPixels| > DRAG_THRESHOLD` (5px), no drag state is published — the pointer is treated as a potential click. Once the threshold is crossed, `deltaQuarters = round(deltaPixels / scale.quarterWidth)` is published; `dragState.deltaPixels` is then snapped to `deltaQuarters * quarterWidth` so the dragged event quantizes visually to grid columns.
+3. **`handlePointerUp`** — if a drag actually started, sets `justDraggedRef.current = true` for one rAF (so the next click on the event or the grid is suppressed) and calls `onDragEnd(eventId, lastDeltaQuarters)` when the delta is non-zero. All listeners are removed.
+
+### `Timeline.tsx`'s `handleDragEnd`
+
+```ts
+const { startDate, endDate } = shiftEventDates(event, deltaQuarters)
+onUpdateEvent({ ...event, startDate, endDate })
+```
+
+`shiftEventDates` (in `src/utils/dateUtils.ts`) shifts both dates by `deltaQuarters * 7` days, preserving exact duration.
+
+### Anti-click guard
+
+`justDraggedRef` is also consulted by `handleMonthClick` and `handleEventClick` so that the click event the browser emits at the end of a drag does not fire month-creation or open the actions menu.
+
+---
+
+## Wheel → Horizontal Scroll
+
+A `useEffect` in `Timeline.tsx` attaches a non-passive `wheel` listener to the scroll container that translates vertical wheel motion into smooth horizontal scroll.
+
+- Skip the translation (let native vertical scroll proceed) when `e.ctrlKey || e.metaKey` (browser zoom), when `|e.deltaX| > |e.deltaY|` (predominantly-horizontal wheel, e.g. trackpad sideways), or when `e.deltaY === 0`.
+- Normalize `deltaMode`: `1` (line) → multiply by `16`; `2` (page) → multiply by `el.clientHeight`; `0` (pixel) → use `e.deltaY` directly.
+- Maintain a `target` scroll position; clamp it to `[0, scrollWidth - clientWidth]`.
+- A `requestAnimationFrame` step lerps the actual `el.scrollLeft` toward `target` with factor **`0.18`** per frame, snapping when within `0.5px` of target.
+
+The listener is scoped to the scroll container ref, so wheel events inside side panels and dialogs (rendered outside this subtree) keep their native vertical scroll.
+
+---
+
+## Scroll-to-Date
+
+`scrollToDate(dateStr)` is defined in `Timeline.tsx`:
+
+```ts
+const monthIndex   = months.findIndex(m => m.year === year && m.month === month - 1)
+const pixelOffset  = monthIndex * scale.monthWidth
+const viewportWidth = scrollContainerRef.current.clientWidth
+const targetLeft   = pixelOffset - (viewportWidth / 2) + (scale.monthWidth / 2)
+scrollContainerRef.current.scrollTo({ left: targetLeft, behavior: 'smooth' })
+```
+
+It centers the requested month within the viewport.
+
+### Entry points
+
+1. **`pendingScrollDate` prop.** Used by `EventTableEditor` after a bulk add. A `useEffect` runs `scrollToDate(pendingScrollDate)` inside `requestAnimationFrame` and then calls `onScrollComplete?.()` so the parent can clear its pending state.
+2. **`handleSubmit` after add/edit.** After dismissing the dialog, `scrollToDate(eventData.startDate)` runs in a rAF. For a newly-created event, the event's `id` is stashed in `pendingScrollEventId` so that when its DOM node mounts, `handleEventMounted` can call `node.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' })`. `scrollIntoView` handles vertical alignment; horizontal alignment is handled by `scrollToDate`.
+
+---
+
+## Add-Event Cursor
+
+A translucent vertical band that follows the user's hovered month while the timeline is in edit mode.
+
+```tsx
+{hoveredMonth !== null && isEditing && onAddEvent && !dragState.isDragging && (
+  <div
+    className="absolute top-[64px] bottom-0 bg-[#FBFBFB]/25 pointer-events-none transition-transform duration-75 ease-out"
+    style={{
+      transform: `translateX(${hoveredMonth * scale.monthWidth}px)`,
+      width: `${scale.monthWidth}px`,
+    }}
+  />
+)}
+```
+
+- `hoveredMonth` is set by `TimelineGrid`'s `onMouseEnter` / `onMouseLeave` (per-month).
+- `top-[64px]` aligns the band's top with the bottom of the header (= `HEADER_HEIGHT`).
+- The band is hidden in view mode, when no `onAddEvent` prop is provided, and during drag.
+
+---
+
+## Event Actions Menu
+
+`EventActionsMenu.tsx` is a portal-mounted floating menu shown when an event is clicked in edit mode.
+
+- Triggered by `handleEventClick(event, { x: e.clientX, y: e.clientY })` in `Timeline.tsx`. The menu is rendered when `menuState !== null`.
+- Position: `fixed; left: x; top: y` initially, then a `useLayoutEffect` flips horizontally / vertically to keep the menu inside the viewport (8px margin).
+- Three items:
+  1. **Edit event** → calls `onEdit`, which sets `editingEvent` and opens the `EventForm` Dialog.
+  2. **Open details** → calls `onOpenDetails(event)` (handed up to the page, which opens the side panel).
+  3. **Delete** → calls `onDeleteEvent(event.id)`. Styled `destructive`.
+- An invisible full-viewport click-catcher (`fixed inset-0 z-[999]`) sits behind the menu and absorbs `mousedown` to close, preventing the underlying timeline grid from receiving a click that would otherwise create a new event.
+- Closes on `Escape` (via a window `keydown` listener) and on outside `mousedown`/`contextmenu`.
+
+---
+
+## Event Form Dialog
+
+`Timeline.tsx` renders shadcn's `Dialog` from `@/components/ui/dialog`:
+
+```tsx
+<DialogContent
+  className="bg-surface-secondary border-[rgba(210,210,210,0.15)] max-w-[360px] rounded-[20px] px-5 py-6"
+>
+  <DialogHeader>
+    <DialogTitle className="header-small text-[#c9ced4] text-center">
+      {editingEvent ? 'Edit Event' : 'Add Event'}
+    </DialogTitle>
+  </DialogHeader>
+  <EventForm
+    onSubmit={handleSubmit}
+    categories={visibleCategories}
+    initialStartDate={selectedDate}
+    initialEvent={editingEvent}
+  />
+</DialogContent>
+```
+
+`handleSubmit` calls `onUpdateEvent` (when `editingEvent` is set) or `onAddEvent` (otherwise), closes the modal, queues a smooth `scrollToDate(eventData.startDate)`, and (for adds) sets `pendingScrollEventId` so the new event's mount callback can `scrollIntoView`.
+
+`EventForm` handles its own state: title (max 55 chars), category (single-select pill grid of `visibleCategories`), and `startDate`/`endDate` (text input with calendar popover; end date is optional and falls back to start date on submit).
+
+---
+
+## Scale / Zoom System
+
+Two scales live in `src/constants/scales.ts`:
+
+| `value` | `monthWidth` | `quarterWidth` |
+|---|---|---|
+| `large` | `28` | `7` |
+| `small` | `20` | `5` |
+
+`useTimelineScale(initialScale = 'small')` holds the active scale and exposes `currentScale` (the full `TimelineScale` object). The selected scale is persisted to `timelines.scale` (`'large' | 'small'`) by `useAutosave`.
+
+Switching scale recalculates all event positions: the grid math (§21) is unchanged but the pixel widths differ. CSS transitions on `min-width`, `grid-template-columns`, and span positions animate the change. Month abbreviations only render at `large` scale (see §7).
+
+---
+
+## Date-to-Grid Math
+
+```
+monthIndex   = months.findIndex(m => m.year === date.year && m.month === date.month - 1)
+quarterIndex = Math.floor((day - 1) / 8)
+                 // Day  1– 8 → 0
+                 // Day  9–16 → 1
+                 // Day 17–24 → 2
+                 // Day 25–31 → 3
+
+startColumn  = monthIndex * 4 + quarterIndex + 1     // CSS Grid is 1-indexed
+endColumn    = endMonthIndex * 4 + endQuarter + 2    // exclusive end for `gridColumn: start / end`
+pixelX       = (column - 1) * scale.quarterWidth
+```
+
+**Reverse (drag delta → date shift):**
+
+```
+deltaQuarters = Math.round(deltaPixels / scale.quarterWidth)
+daysDelta     = deltaQuarters * 7
+```
+
+Each quarter represents ~7 days. The mapping is approximate but visually consistent across all events at all scales.
+
+---
+
+## Timeline Range Calculation
+
+`getTimelineRange(events)` in `src/utils/dateUtils.ts` decides which months to render.
+
+```
+1. If events is empty:
+     [DEFAULT_START_YEAR, DEFAULT_END_YEAR] = [2014, 2024]
+
+2. Otherwise:
+     startYear = max(MIN_YEAR, min over all event start/end years)
+     endYear   = min(MAX_YEAR, max over all event start/end years)
+
+3. Ensure at least 10 years of span:
+     if (endYear - startYear < 9) {
+       midYear   = floor((startYear + endYear) / 2)
+       startYear = max(MIN_YEAR, midYear - 5)
+       endYear   = min(MAX_YEAR, midYear + 5)
+     }
+
+4. Add 3-year scroll padding on both sides (clamped to [MIN_YEAR, MAX_YEAR]).
+
+5. Generate one Month per (year, 0..11) in the range.
+```
+
+Constants: `MIN_YEAR = 1900`, `MAX_YEAR = 2100`, `DEFAULT_START_YEAR = 2014`, `DEFAULT_END_YEAR = 2024`.
+
+---
+
+## Data Flow & Persistence
+
+### Composition
+
+```
+useTimelineState
+  ├── useEvents             ─ events array, addEvent / addEvents / updateEvent / setEvents / clearEvents
+  ├── useTimelineTitle      ─ title, description
+  ├── useCategories         ─ category configs (defaults to DEFAULT_CATEGORIES)
+  ├── useTimelineScale      ─ scale toggle ('large' | 'small') and the current TimelineScale object
+  └── useGroupByCategory    ─ boolean toggle
+```
+
+Other timeline-page hooks live alongside but are not composed by `useTimelineState`:
+
+```
+useTimeline           ─ load / create / save the timeline record itself
+useAutosave           ─ debounced persistence + status state
+useLocalDraft         ─ localStorage drafts
+useTimelineScroll     ─ scroll position + visible quarter range (consumed by Timeline.tsx)
+useEventDrag          ─ drag interaction state machine (consumed by Timeline.tsx)
+```
+
+### Save flow
+
+1. User makes a change (event edit, drag, rename, scale toggle, group toggle, etc.).
+2. `useAutosave.handleChange(data)` sets `saveStatus = 'saving'`, marks `hasUnsavedChanges`, and starts a 2000 ms debounce.
+3. After the debounce fires, `save(data)`:
+   - `UPDATE` the `timelines` row (title, description, scale, group_by_category, updated_at).
+   - `saveTimelineEvents(timelineId, events)` performs a diff-based sync: classifies each event as INSERT / UPDATE / DELETE relative to the server, then executes UPDATE → DELETE → INSERT.
+4. On success: `saveStatus = 'saved'`, `lastSavedTime = now`, `hasUnsavedChanges = false`.
+5. On failure: `saveStatus = 'error'`. A `window.online` listener retries `save(timelineData)` when the browser comes back online.
+6. A `beforeunload` listener fires `e.preventDefault()` while `hasUnsavedChanges` is true, prompting the browser's "leave site?" dialog.
+
+### Local draft
+
+`useLocalDraft` exposes `loadAllDrafts`, `loadDraft`, `saveDraft` (debounced 500 ms), `saveDraftImmediate`, `createDraft`, `deleteDraft`, `clearAllDrafts`, `getDraftCount`. It delegates persistence to `src/utils/draftStorage.ts`; the payload type is `LocalDraft` exported from that module.
+
+### Event operations
+
+- **Create:** `useEvents.addEvent(omit)` generates `id` via `crypto.randomUUID()` and returns the new event.
+- **Update:** `useEvents.updateEvent(event)` replaces by `id` in local state.
+- **Batch add:** `useEvents.addEvents(omits) → { added, duplicates }` deduplicates against the existing list by `(title, startDate, endDate, category)`.
+- **Delete:** the page filters the event out of local state; `saveTimelineEvents` detects the missing `id` and emits a DELETE.
+
+### Plan limits
+
+`src/lib/limits.ts` defines `LimitReachedError` (with `kind: 'event' | 'timeline'` and `limit: number`). `useTimeline.checkCreateTimelineLimits(userId)` runs before creating a new timeline (or saving the first version of one) and throws `LimitReachedError` if either the per-user event count or timeline count exceeds the current plan's limit (looked up via `getCurrentLimits()` in `lib/limits.ts`).
+
+---
+
+## Key Constants
+
+**`src/constants/timeline.ts`**
+
+| Constant | Value | Description |
+|---|---|---|
+| `SCROLL_INDICATOR_HEIGHT` | `36` | Height of the year indicator row above the grid |
+| `HEADER_HEIGHT` | `64` | Year labels (32) + month labels (32) |
+| `EVENT_HEIGHT` | `36` | Height of one event row (used in grouped mode) |
+| `EVENT_ROW_HEIGHT` | `38` | `EVENT_HEIGHT` + 2px vertical gap (used in default mode) |
+| `EVENT_MIN_WIDTH` | `120` | Minimum width for event title visibility |
+| `CATEGORY_PADDING` | `8` | Vertical padding within a band |
+| `CATEGORY_MIN_HEIGHT` | `80` | Minimum height of an empty band |
+
+**`src/constants/scales.ts`**
+
+| `value` | `monthWidth` | `quarterWidth` |
+|---|---|---|
+| `large` | `28` | `7` |
+| `small` | `20` | `5` |
+
+**`src/constants/categories.ts`** — `DEFAULT_CATEGORIES`:
+
+| `id` | `label` | `color` |
+|---|---|---|
+| `category_1` | `Category 1` | `#A770EC` (Purple) |
+| `category_2` | `Category 2` | `#FF7D05` (Orange) |
+| `category_3` | `Category 3` | `#259E23` (Green) |
+| `category_4` | `Category 4` | `#4196E4` (Blue) |
+
+**Other notable constants referenced above**
+
+| Constant | Defined in | Value |
+|---|---|---|
+| `DRAG_THRESHOLD` | `src/hooks/useEventDrag.ts` | `5` (px) |
+| `TITLE_CHROME_WIDTH` | `src/utils/eventStacking.ts` | `20` (px) |
+| `TRAILING_BUFFER_PX` | `src/utils/eventStacking.ts` | `24` (px) |
+| `TITLE_FONT` | `src/utils/eventStacking.ts` | `'400 16px Avenir, sans-serif'` |
+| `MIN_YEAR` / `MAX_YEAR` | `src/utils/dateUtils.ts` | `1900` / `2100` |
+| `DEFAULT_START_YEAR` / `DEFAULT_END_YEAR` | `src/utils/dateUtils.ts` | `2014` / `2024` |
+| `STACK_TRANSITION_MS` | `src/components/Timeline/TimelineEvent.tsx` | `220` |
+| Wheel lerp factor | `src/components/Timeline/Timeline.tsx` | `0.18` |
+| Autosave debounce | `src/hooks/useAutosave.ts` | `2000` ms |
+| Local draft debounce | `src/hooks/useLocalDraft.ts` | `500` ms |
 
 ---
 
 ## Hook Reference
 
+Hooks consumed (directly or via composition) by the timeline page.
+
 | Hook | File | Purpose |
-|------|------|---------|
-| `useTimelineState` | `hooks/useTimelineState.ts` | Composes events, title, categories, and scale into a single state hook |
-| `useTimeline` | `hooks/useTimeline.ts` | Load/save timeline records and events from Supabase |
-| `useEvents` | `hooks/useEvents.ts` | Local event CRUD state management |
-| `useAutosave` | `hooks/useAutosave.ts` | Debounced persistence with status tracking |
-| `useTimelineScale` | `hooks/useTimelineScale.ts` | Scale toggle (large/small) |
-| `useCategories` | `hooks/useCategories.ts` | Category config state |
+|---|---|---|
+| `useTimelineState` | `hooks/useTimelineState.ts` | Composes events, title, categories, scale, and groupByCategory into a single state hook |
+| `useTimeline` | `hooks/useTimeline.ts` | Loads / creates / saves the timeline record from Supabase; enforces plan limits before creation |
+| `useEvents` | `hooks/useEvents.ts` | Local event CRUD (add, update, batch-add with dedup, clear) |
+| `useAutosave` | `hooks/useAutosave.ts` | Debounced persistence (2000 ms), beforeunload guard, online retry |
+| `useTimelineScale` | `hooks/useTimelineScale.ts` | Scale toggle (`large` / `small`) + current `TimelineScale` |
 | `useTimelineTitle` | `hooks/useTimelineTitle.ts` | Title and description state |
-| `useEventDrag` | `hooks/useEventDrag.ts` | Drag-and-drop interaction handling |
-| `useTimelineScroll` | `hooks/useTimelineScroll.ts` | Scroll position and visible range tracking for the scroll indicator |
-| `useLocalDraft` | `hooks/useLocalDraft.ts` | localStorage draft backup |
-| `useAIMode` | `hooks/useAIMode.ts` | AI-powered timeline generation |
-| `useTimelines` | `hooks/useTimelines.ts` | Timeline list with real-time subscription |
-| `useTimelineMetadata` | `hooks/useTimelineMetadata.ts` | Event count and year range for timeline cards |
-| `useSidePanel` | `hooks/useSidePanel.ts` | Side panel open/close state |
-
----
-
-## Interaction Overlay
-
-**Component:** `TimelineGrid.tsx`
-
-An invisible overlay grid that sits on top of each category section to capture mouse events.
-
-- **Grid:** Same column template as the content grid (one column per month at `scale.monthWidth`)
-- **Style:** `pointer-events-none` on parent, `pointerEvents: 'auto'` on individual month divs
-- **Events:**
-  - `onMouseEnter` → sets hovered month index (triggers highlight overlay)
-  - `onMouseLeave` → clears hover
-  - `onClick` → opens event creation modal for that month
-
-**Month hover overlay** (rendered in `Timeline.tsx`):
-- `bg-[#FBFBFB]/25` semi-transparent highlight
-- Positioned at hovered month's grid column
-- Full height of the category section
+| `useCategories` | `hooks/useCategories.ts` | Category config state with `DEFAULT_CATEGORIES` fallback |
+| `useGroupByCategory` | `hooks/useGroupByCategory.ts` | `groupByCategory` boolean toggle |
+| `useTimelineScroll` | `hooks/useTimelineScroll.ts` | Tracks `scrollLeft`, container/content widths, and `visibleRange` (in quarter-columns) |
+| `useEventDrag` | `hooks/useEventDrag.ts` | Pointer-driven drag state machine; defines `DRAG_THRESHOLD = 5` |
+| `useLocalDraft` | `hooks/useLocalDraft.ts` | localStorage draft CRUD with 500 ms debounced save |
+| `useTimelines` | `hooks/useTimelines.ts` | List of the user's timelines with realtime subscription and retry-with-backoff |
+| `useTimelineMetadata` | `hooks/useTimelineMetadata.ts` | Per-timeline event count, year range, and dominant category color (for timeline cards) |
+| `useSidePanel` | `hooks/useSidePanel.ts` | Accesses `SidePanelContext` (open/close state for the event details side panel) |
+| `useAuth` | `hooks/useAuth.ts` | Accesses `AuthContext` (current user) |


### PR DESCRIPTION
## Summary

- Replaces `src/TIMELINE_ARCHITECTURE.md` with a from-scratch rewrite verified against `Timeline.tsx` and the files it imports. Every numeric value, prop name, hex code, and Tailwind class in the doc was re-grepped from source rather than copied from the old doc.
- Adds a **Maintenance Contract** block at the top — future PRs that change timeline rendering, layout, scaling, stacking, scrolling, drag, modes, or persistence are required to update the doc in the same PR.
- Adds new sections for features that were never documented: `groupByCategory`, edit/view modes, `TimelineVerticalLines`, wheel-to-horizontal scroll, scroll-to-date, Add-Event Cursor, `EventActionsMenu`, and the `EventForm` Dialog. Layout, scroll-indicator, category-labels, header, and stacking sections are rewritten to match the current components.
- Doc-only change. No `.tsx` / `.ts` / `.css` / migration files were touched.

## Drift fixes

- Scale values: `28/7` and `20/5` (was `32/8` and `26/6.5`).
- Category-labels styling: pill with `rounded-[4px] p-2 backdrop-blur-[2px]` and `${color}4D` background (was `border-2 border-black` with right accent and `${color}47`).
- `TimelineScrollIndicator`: a single year label in normal flow (was described as a 4px-wide white vertical bar).
- `TimelineMonthLabels`: month abbreviations only render at `large` scale.
- Header colors: `text-[#9b9ea3]`, `border-line-default` / `border-line-year-boundary` (was `text-gray-500` / `border-gray-700`).
- Layout: replaces the old "absolute sidebar with `margin-left: -150px` / `padding-left: 150px`" framing with the actual current overlay-positioned-by-`SCROLL_INDICATOR_HEIGHT + HEADER_HEIGHT` model.
- Hook reference: drops `useCategoryHeights` (deleted) and `useAIMode` (no longer consumed by the timeline page).

## Test plan

- [x] All "drift" greps from the PRD return no matches outside legitimate references (`top-[64px]` survives only in the Add-Event Cursor section, which describes the actual className).
- [x] All "coverage" greps (groupByCategory, view mode, TimelineVerticalLines, EventActionsMenu, EventForm, scrollToDate, wheel, Add-Event Cursor, SCROLL_INDICATOR_HEIGHT/HEADER_HEIGHT, Maintenance contract) return ≥1 match.
- [x] `npm run lint` passes with no warnings.
- [x] `npm run build` passes.
- [x] `git diff --stat` shows only `src/TIMELINE_ARCHITECTURE.md` modified.
- [x] Reviewer click-test: confirm Table of Contents anchors resolve in the GitHub Markdown preview.

https://claude.ai/code/session_011dZ4medFqGed4Rgna7ybnw

---
_Generated by [Claude Code](https://claude.ai/code/session_011dZ4medFqGed4Rgna7ybnw)_