### PR TITLE
Add third timeline scale and rename existing ones

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -290,7 +290,7 @@ export function App() {
       } else {
         resetCategories();
       }
-      handleScaleChange(newScale || 'small');
+      handleScaleChange(newScale || 'medium');
       handleGroupByCategoryChange(newGroupByCategory ?? false);
     } catch (error) {
       console.error('Error switching timeline:', error);

--- a/src/TIMELINE_ARCHITECTURE.md
+++ b/src/TIMELINE_ARCHITECTURE.md
@@ -84,11 +84,11 @@ interface Timeline {
   title: string
   updated_at: string | null
   user_id: string
-  scale: 'large' | 'small'
+  scale: 'large' | 'medium' | 'small'
 }
 
 interface TimelineScale {
-  value: 'large' | 'small'
+  value: 'large' | 'medium' | 'small'
   monthWidth: number
   quarterWidth: number
 }
@@ -528,14 +528,15 @@ A translucent vertical band that follows the user's hovered month while the time
 
 ## Scale / Zoom System
 
-Two scales live in `src/constants/scales.ts`:
+Three scales live in `src/constants/scales.ts`:
 
 | `value` | `monthWidth` | `quarterWidth` |
 |---|---|---|
 | `large` | `28` | `7` |
-| `small` | `20` | `5` |
+| `medium` | `20` | `5` |
+| `small` | `12` | `3` |
 
-`useTimelineScale(initialScale = 'small')` holds the active scale and exposes `currentScale` (the full `TimelineScale` object). The selected scale is persisted to `timelines.scale` (`'large' | 'small'`) by `useAutosave`.
+`useTimelineScale(initialScale = 'medium')` holds the active scale and exposes `currentScale` (the full `TimelineScale` object). The selected scale is persisted to `timelines.scale` (`'large' | 'medium' | 'small'`) by `useAutosave`.
 
 Switching scale recalculates all event positions: the grid math (§21) is unchanged but the pixel widths differ. CSS transitions on `min-width`, `grid-template-columns`, and span positions animate the change. Month abbreviations only render at `large` scale (see §7).
 
@@ -604,7 +605,7 @@ useTimelineState
   ├── useEvents             ─ events array, addEvent / addEvents / updateEvent / setEvents / clearEvents
   ├── useTimelineTitle      ─ title, description
   ├── useCategories         ─ category configs (defaults to DEFAULT_CATEGORIES)
-  ├── useTimelineScale      ─ scale toggle ('large' | 'small') and the current TimelineScale object
+  ├── useTimelineScale      ─ scale toggle ('large' | 'medium' | 'small') and the current TimelineScale object
   └── useGroupByCategory    ─ boolean toggle
 ```
 
@@ -665,7 +666,8 @@ useEventDrag          ─ drag interaction state machine (consumed by Timeline.t
 | `value` | `monthWidth` | `quarterWidth` |
 |---|---|---|
 | `large` | `28` | `7` |
-| `small` | `20` | `5` |
+| `medium` | `20` | `5` |
+| `small` | `12` | `3` |
 
 **`src/constants/categories.ts`** — `DEFAULT_CATEGORIES`:
 
@@ -703,7 +705,7 @@ Hooks consumed (directly or via composition) by the timeline page.
 | `useTimeline` | `hooks/useTimeline.ts` | Loads / creates / saves the timeline record from Supabase; enforces plan limits before creation |
 | `useEvents` | `hooks/useEvents.ts` | Local event CRUD (add, update, batch-add with dedup, clear) |
 | `useAutosave` | `hooks/useAutosave.ts` | Debounced persistence (2000 ms), beforeunload guard, online retry |
-| `useTimelineScale` | `hooks/useTimelineScale.ts` | Scale toggle (`large` / `small`) + current `TimelineScale` |
+| `useTimelineScale` | `hooks/useTimelineScale.ts` | Scale toggle (`large` / `medium` / `small`) + current `TimelineScale` |
 | `useTimelineTitle` | `hooks/useTimelineTitle.ts` | Title and description state |
 | `useCategories` | `hooks/useCategories.ts` | Category config state with `DEFAULT_CATEGORIES` fallback |
 | `useGroupByCategory` | `hooks/useGroupByCategory.ts` | `groupByCategory` boolean toggle |

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -23,8 +23,8 @@ interface HeaderProps {
   categories: CategoryConfig[];
   onCategoriesChange: (categories: CategoryConfig[]) => void;
   onEventsChange: (events: TimelineEvent[]) => void;
-  scale: 'large' | 'small';
-  onScaleChange: (scale: 'large' | 'small') => void;
+  scale: 'large' | 'medium' | 'small';
+  onScaleChange: (scale: 'large' | 'medium' | 'small') => void;
   groupByCategory: boolean;
   onGroupByCategoryChange: (value: boolean) => void;
   activePanel: 'events' | 'settings' | null;

--- a/src/components/Settings/ScaleSelector.tsx
+++ b/src/components/Settings/ScaleSelector.tsx
@@ -1,10 +1,10 @@
 interface ScaleSelectorProps {
-  value: 'large' | 'small';
-  onChange: (scale: 'large' | 'small') => void;
+  value: 'large' | 'medium' | 'small';
+  onChange: (scale: 'large' | 'medium' | 'small') => void;
 }
 
 export function ScaleSelector({ value, onChange }: ScaleSelectorProps) {
-  const handleScaleChange = (newScale: 'large' | 'small') => {
+  const handleScaleChange = (newScale: 'large' | 'medium' | 'small') => {
     if (onChange) {
       onChange(newScale);
     }
@@ -13,18 +13,25 @@ export function ScaleSelector({ value, onChange }: ScaleSelectorProps) {
   const tabClass = (active: boolean) =>
     `flex items-center justify-center w-[60px] min-w-[60px] h-8 px-3 py-1.5 rounded-[6px] transition-colors body-m ${
       active
-        ? 'bg-[#262626] text-[#C9CED4]'
-        : 'bg-transparent text-[#9B9EA3] hover:text-[#C9CED4]'
+        ? 'bg-[#262626] text-text-secondary'
+        : 'bg-transparent text-text-tertiary hover:text-text-secondary'
     }`;
 
   return (
-    <div className="flex flex-row items-start p-1 w-[128px] h-10 bg-[#171717] border border-[#262626] rounded-[10px]">
+    <div className="flex flex-row items-start p-1 w-[188px] h-10 bg-surface-secondary border border-[#262626] rounded-[10px]">
       <button
         type="button"
         onClick={() => handleScaleChange('small')}
         className={tabClass(value === 'small')}
       >
         Small
+      </button>
+      <button
+        type="button"
+        onClick={() => handleScaleChange('medium')}
+        className={tabClass(value === 'medium')}
+      >
+        Medium
       </button>
       <button
         type="button"

--- a/src/components/Settings/TimelineSettingsPanel.tsx
+++ b/src/components/Settings/TimelineSettingsPanel.tsx
@@ -28,8 +28,8 @@ interface TimelineSettingsPanelProps {
   onClearTimeline: () => void;
   onTitleChange: (title: string) => void;
   onDescriptionChange: (description: string) => void;
-  scale: 'large' | 'small';
-  onScaleChange: (scale: 'large' | 'small') => void;
+  scale: 'large' | 'medium' | 'small';
+  onScaleChange: (scale: 'large' | 'medium' | 'small') => void;
   groupByCategory: boolean;
   onGroupByCategoryChange: (value: boolean) => void;
   categories: CategoryConfig[];

--- a/src/components/TimelineViewer/TimelineViewer.tsx
+++ b/src/components/TimelineViewer/TimelineViewer.tsx
@@ -18,7 +18,7 @@ interface TimelineData {
   description: string;
   events: TimelineEvent[];
   categories: CategoryConfig[];
-  scale: 'large' | 'small';
+  scale: 'large' | 'medium' | 'small';
   groupByCategory: boolean;
 }
 
@@ -57,7 +57,7 @@ export function TimelineViewer() {
             description: draft.description || '',
             events: draft.events || [],
             categories,
-            scale: draft.scale || 'small',
+            scale: draft.scale || 'medium',
             groupByCategory: draft.groupByCategory ?? false
           });
         } catch {
@@ -131,7 +131,7 @@ export function TimelineViewer() {
           description: timelineData.description || '',
           events: formattedEvents,
           categories: categories,
-          scale: timelineData.scale || 'small',
+          scale: timelineData.scale || 'medium',
           groupByCategory: timelineData.group_by_category ?? false
         });
       } catch (err) {

--- a/src/constants/scales.ts
+++ b/src/constants/scales.ts
@@ -1,14 +1,19 @@
 import { TimelineScale } from '../types/timeline';
 
-export const SCALES: Record<'large' | 'small', TimelineScale> = {
+export const SCALES: Record<'large' | 'medium' | 'small', TimelineScale> = {
   large: {
     value: 'large',
     monthWidth: 28,
     quarterWidth: 7
   },
-  small: {
-    value: 'small',
+  medium: {
+    value: 'medium',
     monthWidth: 20,
     quarterWidth: 5
+  },
+  small: {
+    value: 'small',
+    monthWidth: 12,
+    quarterWidth: 3
   }
 };

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -11,7 +11,7 @@ interface TimelineData {
   description: string;
   events: TimelineEvent[];
   categories: CategoryConfig[];
-  scale: 'large' | 'small';
+  scale: 'large' | 'medium' | 'small';
   groupByCategory: boolean;
 }
 

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -40,7 +40,7 @@ interface TimelineData {
   description?: string;
   events: TimelineEvent[];
   categories?: CategoryConfig[];
-  scale?: 'large' | 'small';
+  scale?: 'large' | 'medium' | 'small';
   groupByCategory?: boolean;
 }
 
@@ -117,7 +117,7 @@ export function useTimeline() {
           description: '',
           events: [],
           categories: undefined, // Will use default categories
-          scale: 'small',
+          scale: 'medium',
           groupByCategory: false
         };
       }
@@ -162,7 +162,7 @@ export function useTimeline() {
           sources: event.sources ?? null,
         })),
         categories: categories || undefined,
-        scale: timeline.scale || 'small',
+        scale: timeline.scale || 'medium',
         groupByCategory: timeline.group_by_category ?? false
       };
     } catch (error) {
@@ -172,7 +172,7 @@ export function useTimeline() {
     }
   }, [user, timelineId]);
 
-  const saveTimeline = useCallback(async (title: string, events: TimelineEvent[], scale: 'large' | 'small' = 'small') => {
+  const saveTimeline = useCallback(async (title: string, events: TimelineEvent[], scale: 'large' | 'medium' | 'small' = 'medium') => {
     if (!user) throw new Error('Must be signed in to save');
 
     try {

--- a/src/hooks/useTimelineScale.ts
+++ b/src/hooks/useTimelineScale.ts
@@ -2,10 +2,10 @@ import { useState, useCallback } from 'react';
 import { SCALES } from '../constants/scales';
 import { TimelineScale } from '../types/timeline';
 
-export function useTimelineScale(initialScale: 'large' | 'small' = 'small') {
-  const [scale, setScale] = useState<'large' | 'small'>(initialScale);
+export function useTimelineScale(initialScale: 'large' | 'medium' | 'small' = 'medium') {
+  const [scale, setScale] = useState<'large' | 'medium' | 'small'>(initialScale);
 
-  const handleScaleChange = useCallback((newScale: 'large' | 'small') => {
+  const handleScaleChange = useCallback((newScale: 'large' | 'medium' | 'small') => {
     setScale(newScale);
   }, []);
 

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -8,11 +8,11 @@ export interface Timeline {
   title: string;
   updated_at: string | null;
   user_id: string;
-  scale: 'large' | 'small';
+  scale: 'large' | 'medium' | 'small';
 }
 
 export interface TimelineScale {
-  value: 'large' | 'small';
+  value: 'large' | 'medium' | 'small';
   monthWidth: number;
   quarterWidth: number;
 }

--- a/src/utils/draftStorage.ts
+++ b/src/utils/draftStorage.ts
@@ -9,7 +9,7 @@ export interface LocalDraft {
   description: string
   events: TimelineEvent[]
   categories: CategoryConfig[]
-  scale: 'large' | 'small'
+  scale: 'large' | 'medium' | 'small'
   groupByCategory?: boolean
   savedAt: string
 }
@@ -81,7 +81,7 @@ export function createDraft(): LocalDraft | null {
     description: '',
     events: [],
     categories: [...DEFAULT_CATEGORIES],
-    scale: 'small',
+    scale: 'medium',
     groupByCategory: false,
     savedAt: new Date().toISOString(),
   }

--- a/supabase/migrations/20260502000000_rename_small_to_medium_add_small.sql
+++ b/supabase/migrations/20260502000000_rename_small_to_medium_add_small.sql
@@ -1,0 +1,34 @@
+/*
+  # Rename existing 'small' scale to 'medium' and introduce a new 'small' scale
+
+  1. Drop the existing CHECK constraint on `timelines.scale`
+  2. UPDATE all rows where scale = 'small' to scale = 'medium'
+  3. Add new CHECK constraint allowing ('large', 'medium', 'small')
+  4. Update default value to 'medium'
+
+  All steps run in a single transaction so a failure rolls everything back.
+*/
+
+BEGIN;
+
+-- 1. Drop the existing CHECK constraint.
+--    The original constraint was created inline via ADD COLUMN ... CHECK (...) so
+--    Postgres auto-named it. Verify the actual name with:
+--      SELECT conname FROM pg_constraint
+--      WHERE conrelid = 'timelines'::regclass AND contype = 'c';
+--    Common auto-name is `timelines_scale_check`. Adjust below if different.
+ALTER TABLE timelines DROP CONSTRAINT IF EXISTS timelines_scale_check;
+
+-- 2. Migrate existing 'small' rows to 'medium'.
+--    Today's 'small' (20px) becomes tomorrow's 'medium' (same 20px).
+UPDATE timelines SET scale = 'medium' WHERE scale = 'small';
+
+-- 3. Add new CHECK constraint with all three allowed values.
+ALTER TABLE timelines
+  ADD CONSTRAINT timelines_scale_check
+  CHECK (scale IN ('large', 'medium', 'small'));
+
+-- 4. Set new default for inserts that omit the scale column.
+ALTER TABLE timelines ALTER COLUMN scale SET DEFAULT 'medium';
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Renames the current `small` scale (20px/month) to `medium` and introduces a new `small` scale at 12px/month — `medium` becomes the new default. Existing `small` rows are migrated to `medium` so their visual size is preserved.
- Widens the scale union to `'large' | 'medium' | 'small'` everywhere, replaces every `'small'` fallback default with `'medium'`, and updates the new-row CHECK constraint and column DEFAULT in a single transactional migration.
- Grows `ScaleSelector` from two to three buttons (`128px` → `188px`) and migrates `bg-[#171717]`, `text-[#C9CED4]`, `text-[#9B9EA3]` to existing tokens (`bg-surface-secondary`, `text-text-secondary`, `text-text-tertiary`); `#262626` stays raw because no semantic token currently exposes that value.

## Files

- New: `supabase/migrations/20260502000000_rename_small_to_medium_add_small.sql`
- Updated: `src/constants/scales.ts`, `src/types/timeline.ts`, `src/hooks/useTimelineScale.ts`, `src/hooks/useTimeline.ts`, `src/hooks/useAutosave.ts`, `src/utils/draftStorage.ts`, `src/components/Settings/ScaleSelector.tsx`, `src/components/Settings/TimelineSettingsPanel.tsx`, `src/components/Layout/Header.tsx`, `src/components/TimelineViewer/TimelineViewer.tsx`, `src/App.tsx`, `src/TIMELINE_ARCHITECTURE.md`

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` passes (TS strict catches missed union sites)
- [x] Verification greps: zero stale `'large' | 'small'` matches; only intentional `'small'` literals remain
- [ ] Apply migration to Supabase; confirm with `SELECT scale, COUNT(*) FROM timelines GROUP BY scale` (no rows with old-meaning `'small'`); confirm invalid scale insert is rejected
- [ ] Open an existing timeline previously stored as `small` → renders identically (now `medium`, same 20px/month)
- [ ] Settings → ScaleSelector shows three buttons; **Medium** is active by default
- [ ] Click **Small** → timeline visibly compresses to 12px/month; reload → still Small
- [ ] Click **Large** → expands; month abbreviations appear; **Medium** returns to default
- [ ] Logged-in: create new timeline → defaults to `medium` in DB
- [ ] Logged-out: create new draft → `scale: 'medium'` in `timeline_drafts` localStorage

https://claude.ai/code/session_01CdxPRGXB3RxuwmYzDNPXva

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdxPRGXB3RxuwmYzDNPXva)_