### PR TITLE
Add per-timeline vertical scale (event height) setting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ export function App() {
     title, description, setTitle, setDescription,
     categories, updateCategories, resetCategories,
     scale, currentScale, handleScaleChange,
+    verticalScale, currentVerticalScale, handleVerticalScaleChange,
     groupByCategory, handleGroupByCategoryChange,
   } = useTimelineState();
   const { user } = useAuth();
@@ -67,6 +68,7 @@ export function App() {
     events,
     categories,
     scale: currentScale.value,
+    verticalScale: currentVerticalScale.value,
     groupByCategory,
   };
 
@@ -102,10 +104,11 @@ export function App() {
         events,
         categories,
         scale: currentScale.value,
+        verticalScale: currentVerticalScale.value,
         groupByCategory,
       });
     }
-  }, [timelineId, title, description, events, categories, currentScale.value, groupByCategory, handleChange]);
+  }, [timelineId, title, description, events, categories, currentScale.value, currentVerticalScale.value, groupByCategory, handleChange]);
 
   // Hydrate from localStorage draft if logged out
   useEffect(() => {
@@ -139,6 +142,7 @@ export function App() {
         setEvents(imported);
         updateCategories(newDraft.categories);
         handleScaleChange(newDraft.scale);
+        handleVerticalScaleChange(newDraft.verticalScale ?? 'small');
         if (imported.length > 0) {
           const earliest = imported.reduce((a, b) => a.startDate < b.startDate ? a : b);
           setPendingScrollDate(earliest.startDate);
@@ -160,6 +164,7 @@ export function App() {
         setEvents(aiEvents);
         updateCategories(aiCategories);
         handleScaleChange(newDraft.scale);
+        handleVerticalScaleChange(newDraft.verticalScale ?? 'small');
         if (aiEvents.length > 0) {
           const earliest = aiEvents.reduce((a, b) => a.startDate < b.startDate ? a : b);
           setPendingScrollDate(earliest.startDate);
@@ -179,6 +184,7 @@ export function App() {
         setEvents(newDraft.events);
         updateCategories(newDraft.categories);
         handleScaleChange(newDraft.scale);
+        handleVerticalScaleChange(newDraft.verticalScale ?? 'small');
       } else if (routeState?.draftId) {
         // Resuming a local draft (e.g. from the side panel)
         const draft = loadDraft(routeState.draftId);
@@ -189,6 +195,7 @@ export function App() {
           setEvents(draft.events);
           updateCategories(draft.categories);
           handleScaleChange(draft.scale);
+          handleVerticalScaleChange(draft.verticalScale ?? 'small');
           handleGroupByCategoryChange(draft.groupByCategory ?? false);
         } else {
           routerNavigate('/', { replace: true });
@@ -206,6 +213,7 @@ export function App() {
           setEvents(mostRecent.events);
           updateCategories(mostRecent.categories);
           handleScaleChange(mostRecent.scale);
+          handleVerticalScaleChange(mostRecent.verticalScale ?? 'small');
           handleGroupByCategoryChange(mostRecent.groupByCategory ?? false);
         } else {
           routerNavigate('/', { replace: true });
@@ -218,7 +226,7 @@ export function App() {
       // Clear the route state so refreshing doesn't re-trigger
       routerNavigate('/editor', { replace: true, state: {} });
     }
-  }, [user, draftHydrated, createDraft, handleScaleChange, handleGroupByCategoryChange, loadAllDrafts, loadDraft, location.state, routerNavigate, setDescription, setEvents, setTitle, updateCategories]);
+  }, [user, draftHydrated, createDraft, handleScaleChange, handleVerticalScaleChange, handleGroupByCategoryChange, loadAllDrafts, loadDraft, location.state, routerNavigate, setDescription, setEvents, setTitle, updateCategories]);
 
   // Save to localStorage when logged out
   useEffect(() => {
@@ -230,11 +238,12 @@ export function App() {
         events,
         categories,
         scale: currentScale.value,
+        verticalScale: currentVerticalScale.value,
         groupByCategory,
         savedAt: new Date().toISOString()
       });
     }
-  }, [user, draftHydrated, activeDraftId, title, description, events, categories, currentScale.value, groupByCategory, saveDraft]);
+  }, [user, draftHydrated, activeDraftId, title, description, events, categories, currentScale.value, currentVerticalScale.value, groupByCategory, saveDraft]);
 
   // Migrate localStorage drafts to Supabase on login
   useEffect(() => {
@@ -248,7 +257,7 @@ export function App() {
       (async () => {
         for (const draft of draftsWithEvents) {
           try {
-            await saveTimeline(draft.title, draft.events, draft.scale);
+            await saveTimeline(draft.title, draft.events, draft.scale, draft.verticalScale ?? 'small');
           } catch (err: unknown) {
             if (err instanceof LimitReachedError) {
               alert(
@@ -278,6 +287,7 @@ export function App() {
         events: newEvents,
         categories: newCategories,
         scale: newScale,
+        verticalScale: newVerticalScale,
         groupByCategory: newGroupByCategory,
       } = await loadTimeline(newTimelineId);
 
@@ -291,6 +301,7 @@ export function App() {
         resetCategories();
       }
       handleScaleChange(newScale || 'medium');
+      handleVerticalScaleChange(newVerticalScale ?? 'small');
       handleGroupByCategoryChange(newGroupByCategory ?? false);
     } catch (error) {
       console.error('Error switching timeline:', error);
@@ -305,7 +316,7 @@ export function App() {
       }
       alert('Failed to load timeline. Please try again.');
     }
-  }, [loadTimeline, setTitle, setDescription, setEvents, updateCategories, resetCategories, handleScaleChange, handleGroupByCategoryChange, routerNavigate, setActiveTimelineId]);
+  }, [loadTimeline, setTitle, setDescription, setEvents, updateCategories, resetCategories, handleScaleChange, handleVerticalScaleChange, handleGroupByCategoryChange, routerNavigate, setActiveTimelineId]);
 
   // Handle navigation from AI mode or the side panel with a specific timeline to load
   useEffect(() => {
@@ -399,6 +410,7 @@ export function App() {
     setEvents(draft.events);
     updateCategories(draft.categories);
     handleScaleChange(draft.scale);
+    handleVerticalScaleChange(draft.verticalScale ?? 'small');
     handleGroupByCategoryChange(draft.groupByCategory ?? false);
   };
 
@@ -562,6 +574,8 @@ export function App() {
         onEventsChange={handleBulkEventsChange}
         scale={scale}
         onScaleChange={handleScaleChange}
+        verticalScale={verticalScale}
+        onVerticalScaleChange={handleVerticalScaleChange}
         groupByCategory={groupByCategory}
         onGroupByCategoryChange={handleGroupByCategoryChange}
         activePanel={activePanel}
@@ -614,6 +628,7 @@ export function App() {
             onDeleteEvent={mode === 'edit' ? handleDeleteEvent : undefined}
             onOpenDetails={(event) => setDetailPanelEvent(event)}
             scale={currentScale}
+            verticalScale={currentVerticalScale}
             groupByCategory={groupByCategory}
             pendingScrollDate={pendingScrollDate}
             onScrollComplete={() => setPendingScrollDate(null)}

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -25,6 +25,8 @@ interface HeaderProps {
   onEventsChange: (events: TimelineEvent[]) => void;
   scale: 'large' | 'medium' | 'small';
   onScaleChange: (scale: 'large' | 'medium' | 'small') => void;
+  verticalScale: 'small' | 'medium';
+  onVerticalScaleChange: (scale: 'small' | 'medium') => void;
   groupByCategory: boolean;
   onGroupByCategoryChange: (value: boolean) => void;
   activePanel: 'events' | 'settings' | null;
@@ -50,6 +52,8 @@ export function Header({
   onEventsChange,
   scale,
   onScaleChange,
+  verticalScale,
+  onVerticalScaleChange,
   groupByCategory,
   onGroupByCategoryChange,
   activePanel,
@@ -109,6 +113,8 @@ export function Header({
         onCategoriesChange={onCategoriesChange}
         scale={scale}
         onScaleChange={onScaleChange}
+        verticalScale={verticalScale}
+        onVerticalScaleChange={onVerticalScaleChange}
         groupByCategory={groupByCategory}
         onGroupByCategoryChange={onGroupByCategoryChange}
         onDeleteTimeline={onDeleteTimeline}

--- a/src/components/Settings/TimelineSettingsPanel.tsx
+++ b/src/components/Settings/TimelineSettingsPanel.tsx
@@ -6,6 +6,7 @@ import type { AddEventsResult } from '../../hooks/useEvents';
 import { exportEventsToExcel } from '../../utils/excelExport';
 import { ConfirmationModal } from '../Modal/ConfirmationModal';
 import { ScaleSelector } from './ScaleSelector';
+import { VerticalScaleSelector } from './VerticalScaleSelector';
 import { ApiKeySection } from './ApiKeySection';
 import { SidePanelActionButton } from '../SidePanel/SidePanelActionButton';
 import { DEFAULT_TIMELINE_DESCRIPTION } from '../../constants/defaults';
@@ -30,6 +31,8 @@ interface TimelineSettingsPanelProps {
   onDescriptionChange: (description: string) => void;
   scale: 'large' | 'medium' | 'small';
   onScaleChange: (scale: 'large' | 'medium' | 'small') => void;
+  verticalScale: 'small' | 'medium';
+  onVerticalScaleChange: (scale: 'small' | 'medium') => void;
   groupByCategory: boolean;
   onGroupByCategoryChange: (value: boolean) => void;
   categories: CategoryConfig[];
@@ -48,6 +51,8 @@ export function TimelineSettingsPanel({
   onDescriptionChange,
   scale,
   onScaleChange,
+  verticalScale,
+  onVerticalScaleChange,
   groupByCategory,
   onGroupByCategoryChange,
   categories,
@@ -229,6 +234,14 @@ export function TimelineSettingsPanel({
                     <div className="flex flex-row items-center justify-between h-10">
                       <span className="label-m-type2 text-[#9B9EA3]">Timeline scale</span>
                       <ScaleSelector value={scale} onChange={onScaleChange} />
+                    </div>
+
+                    <div className="h-px bg-[#262626] w-full" />
+
+                    {/* Event height row */}
+                    <div className="flex flex-row items-center justify-between h-10">
+                      <span className="label-m-type2 text-[#9B9EA3]">Event height</span>
+                      <VerticalScaleSelector value={verticalScale} onChange={onVerticalScaleChange} />
                     </div>
 
                     <div className="h-px bg-[#262626] w-full" />

--- a/src/components/Settings/VerticalScaleSelector.tsx
+++ b/src/components/Settings/VerticalScaleSelector.tsx
@@ -1,0 +1,38 @@
+interface VerticalScaleSelectorProps {
+  value: 'small' | 'medium';
+  onChange: (scale: 'small' | 'medium') => void;
+}
+
+export function VerticalScaleSelector({ value, onChange }: VerticalScaleSelectorProps) {
+  const handleChange = (newScale: 'small' | 'medium') => {
+    if (onChange) {
+      onChange(newScale);
+    }
+  };
+
+  const tabClass = (active: boolean) =>
+    `flex items-center justify-center w-[60px] min-w-[60px] h-8 px-3 py-1.5 rounded-[6px] transition-colors body-m ${
+      active
+        ? 'bg-[#262626] text-text-secondary'
+        : 'bg-transparent text-text-tertiary hover:text-text-secondary'
+    }`;
+
+  return (
+    <div className="flex flex-row items-start p-1 w-[136px] h-10 bg-surface-secondary border border-[#262626] rounded-[10px]">
+      <button
+        type="button"
+        onClick={() => handleChange('small')}
+        className={tabClass(value === 'small')}
+      >
+        Small
+      </button>
+      <button
+        type="button"
+        onClick={() => handleChange('medium')}
+        className={tabClass(value === 'medium')}
+      >
+        Medium
+      </button>
+    </div>
+  );
+}

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -7,12 +7,12 @@ import { TimelineEvent } from './TimelineEvent';
 import { TimelineScrollIndicator } from './TimelineScrollIndicator';
 import { EventActionsMenu } from '../EventActionsMenu/EventActionsMenu';
 import { TimelineEvent as ITimelineEvent, CategoryConfig } from '../../types/event';
-import { TimelineScale } from '../../types/timeline';
+import { TimelineScale, TimelineVerticalScale } from '../../types/timeline';
 import { getTimelineRange, shiftEventDates } from '../../utils/dateUtils';
 import { calculateEventStacks, StackedEvent } from '../../utils/eventStacking';
 import { useTimelineScroll } from '../../hooks/useTimelineScroll';
 import { useEventDrag } from '../../hooks/useEventDrag';
-import { EVENT_HEIGHT, EVENT_ROW_HEIGHT, CATEGORY_PADDING, CATEGORY_MIN_HEIGHT, SCROLL_INDICATOR_HEIGHT, HEADER_HEIGHT } from '../../constants/timeline';
+import { CATEGORY_PADDING, CATEGORY_MIN_HEIGHT, SCROLL_INDICATOR_HEIGHT, HEADER_HEIGHT } from '../../constants/timeline';
 import { EventForm } from '../EventForm/EventForm';
 import {
   Dialog,
@@ -32,6 +32,7 @@ interface TimelineProps {
   /** Called when "Open details" is selected (edit mode) or an enriched event is clicked (view mode). */
   onOpenDetails?: (event: ITimelineEvent) => void;
   scale: TimelineScale;
+  verticalScale: TimelineVerticalScale;
   groupByCategory?: boolean;
   pendingScrollDate?: string | null;
   onScrollComplete?: () => void;
@@ -63,6 +64,7 @@ export function Timeline({
   onDeleteEvent,
   onOpenDetails,
   scale,
+  verticalScale,
   groupByCategory = false,
   pendingScrollDate,
   onScrollComplete,
@@ -183,7 +185,7 @@ export function Timeline({
         const stackedEvents = calculateEventStacks(categoryEvents, months, scale.monthWidth);
         const maxStack = Math.max(...stackedEvents.map(event => event.stackIndex), 0);
 
-        const height = (maxStack + 1) * EVENT_HEIGHT + CATEGORY_PADDING;
+        const height = (maxStack + 1) * verticalScale.eventHeight + CATEGORY_PADDING;
 
         const band: CategoryBand = {
           id: category.id,
@@ -206,14 +208,14 @@ export function Timeline({
     const stackedEvents = calculateEventStacks(visibleEvents, months, scale.monthWidth);
     const maxStack = Math.max(...stackedEvents.map(event => event.stackIndex), 0);
     const height = stackedEvents.length === 0
-      ? EVENT_ROW_HEIGHT
-      : (maxStack + 1) * EVENT_ROW_HEIGHT + CATEGORY_PADDING;
+      ? verticalScale.eventRowHeight
+      : (maxStack + 1) * verticalScale.eventRowHeight + CATEGORY_PADDING;
 
     return {
       bands: [{ id: 'all', height, offset: 0, events: stackedEvents }],
       totalHeight: height,
     };
-  }, [groupByCategory, visibleEvents, visibleCategories, months, scale.monthWidth]);
+  }, [groupByCategory, visibleEvents, visibleCategories, months, scale.monthWidth, verticalScale.eventHeight, verticalScale.eventRowHeight]);
 
   const handleMonthClick = useCallback((monthIndex: number) => {
     if (!isEditing || !onAddEvent || justDraggedRef.current) return;
@@ -280,7 +282,7 @@ export function Timeline({
   }, [pendingScrollEventId]);
 
   const showCategoryLabels = groupByCategory;
-  const rowHeight = groupByCategory ? EVENT_HEIGHT : EVENT_ROW_HEIGHT;
+  const rowHeight = groupByCategory ? verticalScale.eventHeight : verticalScale.eventRowHeight;
 
   return (
     <div className={isFullScreen ? 'h-[calc(100vh-6rem)] relative' : 'flex-1 min-h-0 flex flex-col relative'}>

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -289,7 +289,7 @@ export function Timeline({
       {showCategoryLabels && (
         <div
           className="absolute left-0 z-10 pointer-events-none"
-          style={{ top: SCROLL_INDICATOR_HEIGHT + HEADER_HEIGHT, height: layout.totalHeight }}
+          style={{ top: SCROLL_INDICATOR_HEIGHT + HEADER_HEIGHT, height: layout.totalHeight, transition: 'height 220ms ease' }}
         >
           <TimelineCategoryLabels
             categories={layout.bands.map(b => ({ id: b.id, height: b.height }))}
@@ -332,6 +332,7 @@ export function Timeline({
                     gridTemplateColumns: `repeat(${months.length * 4}, ${scale.quarterWidth}px)`,
                     gridAutoRows: `${rowHeight}px`,
                     gap: 0,
+                    transition: 'height 220ms ease',
                   }}
                 >
                   <TimelineGrid

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -330,9 +330,10 @@ export function Timeline({
                     height: band.height,
                     display: 'grid',
                     gridTemplateColumns: `repeat(${months.length * 4}, ${scale.quarterWidth}px)`,
-                    gridAutoRows: `${rowHeight}px`,
+                    ['--event-row-height' as string]: `${rowHeight}px`,
+                    gridAutoRows: 'var(--event-row-height)',
                     gap: 0,
-                    transition: 'height 220ms ease',
+                    transition: 'height 220ms ease, --event-row-height 220ms ease',
                   }}
                 >
                   <TimelineGrid

--- a/src/components/Timeline/TimelineEvent.tsx
+++ b/src/components/Timeline/TimelineEvent.tsx
@@ -153,20 +153,20 @@ export const TimelineEvent = memo(function TimelineEvent({
 
   // Build the transform/transition for the main element. Drag takes priority
   // over the stack-reflow transition (the dragged event animates separately).
-  // The default `height ...` transition smooths vertical-scale changes; the
-  // 'jumping' phase explicitly clears it for one frame so the FLIP layout
-  // snap can happen without interpolation.
+  // Height interpolation is handled by the parent band's animated
+  // `--event-row-height` custom property — declaring `height` here too would
+  // start a competing transition and visibly desync the event from the grid.
   let transform: string | undefined;
-  let transition: string | undefined = `height ${STACK_TRANSITION_MS}ms ease`;
+  let transition: string | undefined;
   if (isDragging) {
     transform = `translateX(${dragDeltaPixels}px) scale(1.04)`;
-    transition = `box-shadow 150ms ease, opacity 150ms ease, height ${STACK_TRANSITION_MS}ms ease`;
+    transition = 'box-shadow 150ms ease, opacity 150ms ease';
   } else if (animPhase === 'jumping') {
     transform = `translateY(${animOffset}px)`;
     transition = 'none';
   } else if (animPhase === 'animating') {
     transform = 'translateY(0px)';
-    transition = `transform ${STACK_TRANSITION_MS}ms ease, height ${STACK_TRANSITION_MS}ms ease`;
+    transition = `transform ${STACK_TRANSITION_MS}ms ease`;
   }
 
   return (

--- a/src/components/Timeline/TimelineEvent.tsx
+++ b/src/components/Timeline/TimelineEvent.tsx
@@ -177,7 +177,7 @@ export const TimelineEvent = memo(function TimelineEvent({
             gridRow: event.stackIndex + 1,
             backgroundColor: 'transparent',
             minWidth: `${EVENT_MIN_WIDTH}px`,
-            height: `${EVENT_ROW_HEIGHT}px`,
+            height: `${rowHeight}px`,
             zIndex: event.stackIndex,
             opacity: 0.3,
           }}
@@ -197,7 +197,7 @@ export const TimelineEvent = memo(function TimelineEvent({
           gridRow: event.stackIndex + 1,
           backgroundColor: 'transparent',
           minWidth: `${EVENT_MIN_WIDTH}px`,
-          height: `${EVENT_ROW_HEIGHT}px`,
+          height: `${rowHeight}px`,
           zIndex: isDragging ? 1000 : event.stackIndex + 1,
           transform,
           boxShadow: isDragging

--- a/src/components/Timeline/TimelineEvent.tsx
+++ b/src/components/Timeline/TimelineEvent.tsx
@@ -180,7 +180,7 @@ export const TimelineEvent = memo(function TimelineEvent({
             gridRow: event.stackIndex + 1,
             backgroundColor: 'transparent',
             minWidth: `${EVENT_MIN_WIDTH}px`,
-            height: `${rowHeight}px`,
+            height: 'var(--event-row-height)',
             zIndex: event.stackIndex,
             opacity: 0.3,
           }}
@@ -200,7 +200,7 @@ export const TimelineEvent = memo(function TimelineEvent({
           gridRow: event.stackIndex + 1,
           backgroundColor: 'transparent',
           minWidth: `${EVENT_MIN_WIDTH}px`,
-          height: `${rowHeight}px`,
+          height: 'var(--event-row-height)',
           zIndex: isDragging ? 1000 : event.stackIndex + 1,
           transform,
           boxShadow: isDragging

--- a/src/components/Timeline/TimelineEvent.tsx
+++ b/src/components/Timeline/TimelineEvent.tsx
@@ -153,17 +153,20 @@ export const TimelineEvent = memo(function TimelineEvent({
 
   // Build the transform/transition for the main element. Drag takes priority
   // over the stack-reflow transition (the dragged event animates separately).
+  // The default `height ...` transition smooths vertical-scale changes; the
+  // 'jumping' phase explicitly clears it for one frame so the FLIP layout
+  // snap can happen without interpolation.
   let transform: string | undefined;
-  let transition: string | undefined;
+  let transition: string | undefined = `height ${STACK_TRANSITION_MS}ms ease`;
   if (isDragging) {
     transform = `translateX(${dragDeltaPixels}px) scale(1.04)`;
-    transition = 'box-shadow 150ms ease, opacity 150ms ease';
+    transition = `box-shadow 150ms ease, opacity 150ms ease, height ${STACK_TRANSITION_MS}ms ease`;
   } else if (animPhase === 'jumping') {
     transform = `translateY(${animOffset}px)`;
     transition = 'none';
   } else if (animPhase === 'animating') {
     transform = 'translateY(0px)';
-    transition = `transform ${STACK_TRANSITION_MS}ms ease`;
+    transition = `transform ${STACK_TRANSITION_MS}ms ease, height ${STACK_TRANSITION_MS}ms ease`;
   }
 
   return (

--- a/src/components/TimelineViewer/TimelineViewer.tsx
+++ b/src/components/TimelineViewer/TimelineViewer.tsx
@@ -5,6 +5,7 @@ import { Timeline } from '../Timeline/Timeline';
 import { TimelineTitle } from '../TimelineTitle/TimelineTitle';
 import { EventDetailPanel } from '../EventDetailPanel/EventDetailPanel';
 import { SCALES } from '../../constants/scales';
+import { VERTICAL_SCALES } from '../../constants/verticalScales';
 import { DEFAULT_CATEGORIES } from '../../constants/categories';
 import { TimelineEvent, CategoryConfig } from '../../types/event';
 import { getDraft } from '../../utils/draftStorage';
@@ -19,6 +20,7 @@ interface TimelineData {
   events: TimelineEvent[];
   categories: CategoryConfig[];
   scale: 'large' | 'medium' | 'small';
+  verticalScale: 'small' | 'medium';
   groupByCategory: boolean;
 }
 
@@ -58,6 +60,7 @@ export function TimelineViewer() {
             events: draft.events || [],
             categories,
             scale: draft.scale || 'medium',
+            verticalScale: draft.verticalScale ?? 'small',
             groupByCategory: draft.groupByCategory ?? false
           });
         } catch {
@@ -132,6 +135,7 @@ export function TimelineViewer() {
           events: formattedEvents,
           categories: categories,
           scale: timelineData.scale || 'medium',
+          verticalScale: timelineData.vertical_scale ?? 'small',
           groupByCategory: timelineData.group_by_category ?? false
         });
       } catch (err) {
@@ -194,6 +198,7 @@ export function TimelineViewer() {
           events={timeline.events}
           categories={timeline.categories}
           scale={SCALES[timeline.scale]}
+          verticalScale={VERTICAL_SCALES[timeline.verticalScale]}
           groupByCategory={timeline.groupByCategory}
           mode="view"
           onOpenDetails={(event) => setDetailPanelEvent(event)}

--- a/src/constants/verticalScales.ts
+++ b/src/constants/verticalScales.ts
@@ -1,0 +1,14 @@
+import { TimelineVerticalScale } from '../types/timeline';
+
+export const VERTICAL_SCALES: Record<'small' | 'medium', TimelineVerticalScale> = {
+  small: {
+    value: 'small',
+    eventHeight: 36,
+    eventRowHeight: 38
+  },
+  medium: {
+    value: 'medium',
+    eventHeight: 44,
+    eventRowHeight: 46
+  }
+};

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -12,6 +12,7 @@ interface TimelineData {
   events: TimelineEvent[];
   categories: CategoryConfig[];
   scale: 'large' | 'medium' | 'small';
+  verticalScale: 'small' | 'medium';
   groupByCategory: boolean;
 }
 
@@ -33,6 +34,7 @@ export function useAutosave(timelineData: TimelineData) {
           title: data.title,
           description: data.description,
           scale: data.scale,
+          vertical_scale: data.verticalScale,
           group_by_category: data.groupByCategory,
           updated_at: new Date().toISOString()
         })

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -41,6 +41,7 @@ interface TimelineData {
   events: TimelineEvent[];
   categories?: CategoryConfig[];
   scale?: 'large' | 'medium' | 'small';
+  verticalScale?: 'small' | 'medium';
   groupByCategory?: boolean;
 }
 
@@ -118,6 +119,7 @@ export function useTimeline() {
           events: [],
           categories: undefined, // Will use default categories
           scale: 'medium',
+          verticalScale: 'small',
           groupByCategory: false
         };
       }
@@ -163,6 +165,7 @@ export function useTimeline() {
         })),
         categories: categories || undefined,
         scale: timeline.scale || 'medium',
+        verticalScale: timeline.vertical_scale || 'small',
         groupByCategory: timeline.group_by_category ?? false
       };
     } catch (error) {
@@ -172,7 +175,12 @@ export function useTimeline() {
     }
   }, [user, timelineId]);
 
-  const saveTimeline = useCallback(async (title: string, events: TimelineEvent[], scale: 'large' | 'medium' | 'small' = 'medium') => {
+  const saveTimeline = useCallback(async (
+    title: string,
+    events: TimelineEvent[],
+    scale: 'large' | 'medium' | 'small' = 'medium',
+    verticalScale: 'small' | 'medium' = 'small',
+  ) => {
     if (!user) throw new Error('Must be signed in to save');
 
     try {
@@ -182,7 +190,7 @@ export function useTimeline() {
         // Create new timeline
         const { data: timeline, error: timelineError } = await supabase
           .from('timelines')
-          .insert({ title, user_id: user.id, scale })
+          .insert({ title, user_id: user.id, scale, vertical_scale: verticalScale })
           .select('id')
           .single();
 
@@ -210,10 +218,11 @@ export function useTimeline() {
         // Update existing timeline
         const { error: timelineError } = await supabase
           .from('timelines')
-          .update({ 
-            title, 
+          .update({
+            title,
             updated_at: new Date().toISOString(),
-            scale 
+            scale,
+            vertical_scale: verticalScale
           })
           .eq('id', timelineId);
 

--- a/src/hooks/useTimelineState.ts
+++ b/src/hooks/useTimelineState.ts
@@ -2,6 +2,7 @@ import { useEvents } from './useEvents'
 import { useTimelineTitle } from './useTimelineTitle'
 import { useCategories } from './useCategories'
 import { useTimelineScale } from './useTimelineScale'
+import { useTimelineVerticalScale } from './useTimelineVerticalScale'
 import { useGroupByCategory } from './useGroupByCategory'
 
 export function useTimelineState() {
@@ -9,11 +10,12 @@ export function useTimelineState() {
   const { title, description, setTitle, setDescription, resetTitle } = useTimelineTitle()
   const { categories, updateCategories, resetCategories } = useCategories()
   const { scale, currentScale, handleScaleChange } = useTimelineScale()
+  const { verticalScale, currentVerticalScale, handleVerticalScaleChange } = useTimelineVerticalScale()
   const { groupByCategory, handleGroupByCategoryChange } = useGroupByCategory()
 
   return {
     // State
-    events, title, description, categories, scale, currentScale, groupByCategory,
+    events, title, description, categories, scale, currentScale, verticalScale, currentVerticalScale, groupByCategory,
     // Event actions
     addEvent, addEvents, clearEvents, setEvents, updateEvent,
     // Title actions
@@ -22,6 +24,7 @@ export function useTimelineState() {
     updateCategories, resetCategories,
     // Scale actions
     handleScaleChange,
+    handleVerticalScaleChange,
     // Layout actions
     handleGroupByCategoryChange,
   }

--- a/src/hooks/useTimelineVerticalScale.ts
+++ b/src/hooks/useTimelineVerticalScale.ts
@@ -1,0 +1,19 @@
+import { useState, useCallback } from 'react';
+import { VERTICAL_SCALES } from '../constants/verticalScales';
+import { TimelineVerticalScale } from '../types/timeline';
+
+export function useTimelineVerticalScale(initialScale: 'small' | 'medium' = 'small') {
+  const [verticalScale, setVerticalScale] = useState<'small' | 'medium'>(initialScale);
+
+  const handleVerticalScaleChange = useCallback((newScale: 'small' | 'medium') => {
+    setVerticalScale(newScale);
+  }, []);
+
+  const currentVerticalScale: TimelineVerticalScale = VERTICAL_SCALES[verticalScale];
+
+  return {
+    verticalScale,
+    currentVerticalScale,
+    handleVerticalScaleChange
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,14 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Registered so transitions can interpolate the row height as a length and
+   smoothly relayout `gridAutoRows` + each event's `height` together. */
+@property --event-row-height {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 38px;
+}
+
 @layer base {
   :root {
     --background: 0 0% 0%;

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -9,10 +9,17 @@ export interface Timeline {
   updated_at: string | null;
   user_id: string;
   scale: 'large' | 'medium' | 'small';
+  verticalScale: 'small' | 'medium';
 }
 
 export interface TimelineScale {
   value: 'large' | 'medium' | 'small';
   monthWidth: number;
   quarterWidth: number;
+}
+
+export interface TimelineVerticalScale {
+  value: 'small' | 'medium';
+  eventHeight: number;
+  eventRowHeight: number;
 }

--- a/src/utils/draftStorage.ts
+++ b/src/utils/draftStorage.ts
@@ -10,6 +10,7 @@ export interface LocalDraft {
   events: TimelineEvent[]
   categories: CategoryConfig[]
   scale: 'large' | 'medium' | 'small'
+  verticalScale?: 'small' | 'medium'
   groupByCategory?: boolean
   savedAt: string
 }
@@ -82,6 +83,7 @@ export function createDraft(): LocalDraft | null {
     events: [],
     categories: [...DEFAULT_CATEGORIES],
     scale: 'medium',
+    verticalScale: 'small',
     groupByCategory: false,
     savedAt: new Date().toISOString(),
   }

--- a/supabase/migrations/20260504000000_add_vertical_scale.sql
+++ b/supabase/migrations/20260504000000_add_vertical_scale.sql
@@ -1,0 +1,24 @@
+/*
+  # Add vertical_scale column to timelines table
+
+  1. Changes
+    - Add `vertical_scale` text column to `timelines` with default 'small'
+    - CHECK constraint allowing ('small', 'medium')
+    - Idempotent: only adds the column if it does not already exist
+
+  Default 'small' preserves the current visual behavior for every existing
+  timeline (event row height stays at 36/38px).
+*/
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'timelines'
+    AND column_name = 'vertical_scale'
+  ) THEN
+    ALTER TABLE timelines
+    ADD COLUMN vertical_scale text NOT NULL DEFAULT 'small'
+    CHECK (vertical_scale IN ('small', 'medium'));
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

Mirrors the existing horizontal scale system with a new vertical scale that controls event row height.

- Today's hard-coded `EVENT_HEIGHT = 36` / `EVENT_ROW_HEIGHT = 38` becomes the **Small** preset.
- New **Medium** preset at **44 / 46 px** gives stacked events more breathing room (~10px above/below the 16px Avenir title vs. ~6px today).
- Setting is persisted per timeline (`timelines.vertical_scale` in Supabase + `LocalDraft.verticalScale` for logged-out drafts) and changed via a new "Event height" row in the Timeline Settings side panel, just below the existing horizontal scale row.
- Default is `'small'`, so every existing timeline (and every existing local draft) renders identically.
- DB column type leaves room to add `'large'` later without further migration body changes.

## Implementation notes

- New constant map `VERTICAL_SCALES` (`src/constants/verticalScales.ts`) and matching `TimelineVerticalScale` type.
- New `useTimelineVerticalScale` hook composed into `useTimelineState`, mirroring `useTimelineScale`.
- `Timeline.tsx` now consumes `verticalScale: TimelineVerticalScale` instead of importing `EVENT_HEIGHT` / `EVENT_ROW_HEIGHT` constants directly. The constants remain exported as the `TimelineEvent.rowHeight` default fallback.
- `TimelineEvent.tsx` event/ghost-placeholder heights use the runtime `rowHeight` prop instead of the constant — the FLIP stack-reflow animation already used `rowHeight` so it scales for free.
- Idempotent migration `supabase/migrations/20260504000000_add_vertical_scale.sql` adds `vertical_scale text NOT NULL DEFAULT 'small'` with a `CHECK (vertical_scale IN ('small','medium'))` constraint.
- AI mode and `useTimelines` (list view, `select('*')`) need no edits — defaults flow through.

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] Existing timeline opens at Small (36/38) by default; visually unchanged
- [ ] Switch "Event height" to Medium → events grow to 44/46; band height grows; FLIP stack animation still smooth on add/delete
- [ ] Refresh page → Medium persists (`SELECT vertical_scale FROM timelines WHERE id=...` returns `'medium'`)
- [ ] Logged-out draft: change to Medium, refresh → persists from localStorage
- [ ] Sign in → draft migrates to Supabase with `vertical_scale = 'medium'`
- [ ] `/view/:id` viewer reflects the timeline's persisted vertical scale
- [ ] Group-by-category mode at Medium → category band heights recompute correctly using the new event height
- [ ] Drag an event at Medium scale → ghost placeholder, drag visuals, and FLIP animation all work at the 46px row pitch

https://claude.ai/code/session_01QnA8tmPMHXhBDTUyCGLCN7

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnA8tmPMHXhBDTUyCGLCN7)_