### PR TITLE
Remove guest sign-in CTA banner from editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,6 @@ import { useAuth } from './hooks/useAuth';
 import { useAutosave } from './hooks/useAutosave';
 import { useSidePanel } from './hooks/useSidePanel';
 import { computeDominantCategoryColor } from './utils/dominantCategory';
-import { AuthModal } from './components/Auth/AuthModal';
 import { UnsavedChangesModal } from './components/Modal/UnsavedChangesModal';
 import { EventDetailPanel } from './components/EventDetailPanel/EventDetailPanel';
 import { useLocalDraft } from './hooks/useLocalDraft';
@@ -39,7 +38,6 @@ export function App() {
   const { saveTimeline, timelineId, loadTimeline, error: timelineError, retryInitialLoad } = useTimeline();
   const location = useLocation();
   const routerNavigate = useNavigate();
-  const [showAuthModal, setShowAuthModal] = useState(false);
   const [pendingSwitchTimelineId, setPendingSwitchTimelineId] = useState<string | null>(null);
   const [showUnsavedChangesModal, setShowUnsavedChangesModal] = useState(false);
   const [activePanel, setActivePanel] = useState<'events' | 'settings' | null>(null);
@@ -48,7 +46,6 @@ export function App() {
   const [detailPanelEvent, setDetailPanelEvent] = useState<TimelineEvent | null>(null);
   const [pendingScrollDate, setPendingScrollDate] = useState<string | null>(null);
   const [draftHydrated, setDraftHydrated] = useState(false);
-  const [nudgeDismissed, setNudgeDismissed] = useState(false);
   const [activeDraftId, setActiveDraftId] = useState<string | null>(null);
   const { loadAllDrafts, loadDraft, saveDraft, createDraft, clearAllDrafts, deleteDraft: deleteLocalDraft } = useLocalDraft();
   const handledRouteStateRef = useRef(false);
@@ -573,26 +570,6 @@ export function App() {
         onDeleteTimeline={handleDeleteTimeline}
         mode={mode}
       />
-      {!user && events.length > 0 && !nudgeDismissed && (
-        <div className="mx-4 mt-2 px-4 py-3 bg-blue-900/40 border border-blue-800/50 rounded-lg flex items-center justify-between text-sm shrink-0">
-          <span className="text-blue-200">
-            Your work isn't saved to the cloud yet.{' '}
-            <button
-              onClick={() => setShowAuthModal(true)}
-              className="text-blue-400 underline hover:text-blue-300"
-            >
-              Sign in
-            </button>
-            {' '}to save your timeline and access it from any device.
-          </span>
-          <button
-            onClick={() => setNudgeDismissed(true)}
-            className="text-gray-400 hover:text-white ml-4 shrink-0"
-          >
-            &#10005;
-          </button>
-        </div>
-      )}
       {timelineError ? (
         <div className="flex-1 flex items-center justify-center py-20">
           <div className="bg-gray-800 p-6 rounded-lg shadow-xl max-w-md w-full text-center">
@@ -623,10 +600,6 @@ export function App() {
           />
         </main>
       )}
-      <AuthModal
-        isOpen={showAuthModal}
-        onClose={() => setShowAuthModal(false)}
-      />
       <UnsavedChangesModal
         isOpen={showUnsavedChangesModal}
         onClose={() => {


### PR DESCRIPTION
## Summary
- Removes the blue "Your work isn't saved to the cloud yet" banner shown to logged-out users with at least one event.
- Cleans up the now-orphaned `AuthModal` mount + import and the `showAuthModal` / `nudgeDismissed` state in `src/App.tsx`. The banner was the only in-editor caller of `AuthModal`.
- `src/components/Auth/AuthModal.tsx` is intentionally untouched — still used by other flows.

Guest users will no longer have an in-editor sign-in path. This is intentional per the PRD.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [x] grep verification: `nudgeDismissed`, `showAuthModal`, `AuthModal`, `bg-blue-900/40` all 0 hits in `src/App.tsx`; `"isn't saved to the cloud"` 0 hits project-wide
- [ ] Manual: guest with 0 events → no banner (unchanged)
- [ ] Manual: guest with 1+ events → no banner (the change)
- [ ] Manual: logged-in user → no banner (unchanged)
- [ ] Manual: header / timeline layout unchanged where banner used to sit
- [ ] Manual: no console errors on add/remove events

https://claude.ai/code/session_015L9kTXAj3sT96W1JyKswSh

---
_Generated by [Claude Code](https://claude.ai/code/session_015L9kTXAj3sT96W1JyKswSh)_