### PR TITLE
Rename primary side panel creation buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -152,7 +152,7 @@ export function App() {
           setPendingScrollDate(earliest.startDate);
         }
       } else if (routeState?.newTimeline && routeState.skipCreationScreen) {
-        // "Build from Scratch" — create draft immediately
+        // "Create a Timeline" — create draft immediately
         const newDraft = createDraft();
         if (!newDraft) {
           alert(limitReachedMessage('timeline'));

--- a/src/components/SidePanel/SidePanelBody.tsx
+++ b/src/components/SidePanel/SidePanelBody.tsx
@@ -1,16 +1,16 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
-  Balloon,
+  CirclePlus,
   Copy,
   Download,
   FileDown,
   FileSpreadsheet,
-  Flower,
   LogOut,
   MoreVertical,
   PanelLeft,
   Share2,
+  Telescope,
   Trash2,
 } from 'lucide-react'
 import { utils, writeFile } from 'xlsx'
@@ -435,8 +435,8 @@ export function SidePanelBody() {
 
       {/* Creation actions */}
       <div className="flex flex-col p-3 shrink-0">
-        <SidePanelActionButton icon={Flower} label="Build with AI" onClick={handleBuildWithAI} />
-        <SidePanelActionButton icon={Balloon} label="Build from Scratch" onClick={handleBuildFromScratch} />
+        <SidePanelActionButton icon={Telescope} label="Discover a Timeline" onClick={handleBuildWithAI} />
+        <SidePanelActionButton icon={CirclePlus} label="Create a Timeline" onClick={handleBuildFromScratch} />
         <SidePanelActionButton icon={FileSpreadsheet} label="Import Data" onClick={handleImportData} />
         <SidePanelActionButton icon={Download} label="Download Template" onClick={handleDownloadTemplate} />
       </div>


### PR DESCRIPTION
## Summary
- Rename the first two buttons in the primary side panel (timelines list panel):
  - **"Build with AI"** → **"Discover a Timeline"** (icon: `Flower` → `Telescope`)
  - **"Build from Scratch"** → **"Create a Timeline"** (icon: `Balloon` → `CirclePlus`)
- Update a stale code comment in `src/App.tsx` that referenced the old "Build from Scratch" label.
- No behavior changes — `onClick` handlers and route state are unchanged. Icon size and stroke weight are owned by `SidePanelActionButton` (`size={16}`, `strokeWidth={1.25}`), so the new icons automatically match the existing `Import Data` and `Download Template` icons in the same panel.

## Files changed
- `src/components/SidePanel/SidePanelBody.tsx` — swap lucide-react imports (drop `Flower`/`Balloon`, add `Telescope`/`CirclePlus`) and update the two button callsites.
- `src/App.tsx` — update one comment from `"Build from Scratch"` to `"Create a Timeline"`.

## Test plan
- [ ] `grep -rn "Build with AI" src/` returns 0 matches
- [ ] `grep -rn "Build from Scratch" src/` returns 0 matches
- [ ] `grep -rn "Discover a Timeline" src/` returns 1 match (`SidePanelBody.tsx`)
- [ ] `grep -rn "Create a Timeline" src/` returns matches in `SidePanelBody.tsx` and the updated `App.tsx` comment
- [ ] `grep -rn "Flower\|Balloon" src/` returns 0 matches
- [ ] `npm run lint` passes (no unused imports)
- [ ] `npm run dev` → open the timelines side panel; confirm the top two buttons read "Discover a Timeline" (telescope) and "Create a Timeline" (circle-plus), and that icon size/stroke weight match `Import Data`/`Download Template` below them
- [ ] Click each button — button 1 still routes to AI mode; button 2 still creates a draft immediately


---
_Generated by [Claude Code](https://claude.ai/code/session_01KcqEBFrto91kfhm5h5XdcA)_