### PR TITLE
Simplify settings panel and update default scales

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,7 +124,7 @@ export function App() {
         setEvents(imported);
         updateCategories(newDraft.categories);
         handleScaleChange(newDraft.scale);
-        handleVerticalScaleChange(newDraft.verticalScale ?? 'small');
+        handleVerticalScaleChange(newDraft.verticalScale ?? 'medium');
         if (imported.length > 0) {
           const earliest = imported.reduce((a, b) => a.startDate < b.startDate ? a : b);
           setPendingScrollDate(earliest.startDate);
@@ -146,7 +146,7 @@ export function App() {
         setEvents(aiEvents);
         updateCategories(aiCategories);
         handleScaleChange(newDraft.scale);
-        handleVerticalScaleChange(newDraft.verticalScale ?? 'small');
+        handleVerticalScaleChange(newDraft.verticalScale ?? 'medium');
         if (aiEvents.length > 0) {
           const earliest = aiEvents.reduce((a, b) => a.startDate < b.startDate ? a : b);
           setPendingScrollDate(earliest.startDate);
@@ -166,7 +166,7 @@ export function App() {
         setEvents(newDraft.events);
         updateCategories(newDraft.categories);
         handleScaleChange(newDraft.scale);
-        handleVerticalScaleChange(newDraft.verticalScale ?? 'small');
+        handleVerticalScaleChange(newDraft.verticalScale ?? 'medium');
       } else if (routeState?.draftId) {
         // Resuming a local draft (e.g. from the side panel)
         const draft = loadDraft(routeState.draftId);
@@ -177,7 +177,7 @@ export function App() {
           setEvents(draft.events);
           updateCategories(draft.categories);
           handleScaleChange(draft.scale);
-          handleVerticalScaleChange(draft.verticalScale ?? 'small');
+          handleVerticalScaleChange(draft.verticalScale ?? 'medium');
           handleGroupByCategoryChange(draft.groupByCategory ?? false);
         } else {
           routerNavigate('/', { replace: true });
@@ -195,7 +195,7 @@ export function App() {
           setEvents(mostRecent.events);
           updateCategories(mostRecent.categories);
           handleScaleChange(mostRecent.scale);
-          handleVerticalScaleChange(mostRecent.verticalScale ?? 'small');
+          handleVerticalScaleChange(mostRecent.verticalScale ?? 'medium');
           handleGroupByCategoryChange(mostRecent.groupByCategory ?? false);
         } else {
           routerNavigate('/', { replace: true });
@@ -239,7 +239,7 @@ export function App() {
       (async () => {
         for (const draft of draftsWithEvents) {
           try {
-            await saveTimeline(draft.title, draft.events, draft.scale, draft.verticalScale ?? 'small');
+            await saveTimeline(draft.title, draft.events, draft.scale, draft.verticalScale ?? 'medium');
           } catch (err: unknown) {
             if (err instanceof LimitReachedError) {
               alert(
@@ -392,7 +392,7 @@ export function App() {
     setEvents(draft.events);
     updateCategories(draft.categories);
     handleScaleChange(draft.scale);
-    handleVerticalScaleChange(draft.verticalScale ?? 'small');
+    handleVerticalScaleChange(draft.verticalScale ?? 'medium');
     handleGroupByCategoryChange(draft.groupByCategory ?? false);
   };
 
@@ -547,7 +547,6 @@ export function App() {
       <Header
         title={title}
         description={description}
-        onTitleChange={setTitle}
         onDescriptionChange={setDescription}
         onAddEvent={addEvent}
         onImportEvents={addEvents}

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -14,7 +14,6 @@ import type { AddEventsResult } from '../../hooks/useEvents';
 interface HeaderProps {
   title: string;
   description: string;
-  onTitleChange: (title: string) => void;
   onDescriptionChange: (description: string) => void;
   onAddEvent: (event: Omit<TimelineEvent, 'id'>) => void;
   onImportEvents: (events: Omit<TimelineEvent, 'id'>[]) => AddEventsResult;
@@ -41,7 +40,6 @@ interface HeaderProps {
 export function Header({
   title,
   description,
-  onTitleChange,
   onDescriptionChange,
   onAddEvent,
   onImportEvents,
@@ -107,7 +105,6 @@ export function Header({
         timelineDescription={description}
         onImportEvents={onImportEvents}
         onClearTimeline={onClearTimeline}
-        onTitleChange={onTitleChange}
         onDescriptionChange={onDescriptionChange}
         categories={categories}
         onCategoriesChange={onCategoriesChange}

--- a/src/components/Settings/TimelineSettingsPanel.tsx
+++ b/src/components/Settings/TimelineSettingsPanel.tsx
@@ -27,7 +27,6 @@ interface TimelineSettingsPanelProps {
   timelineDescription: string;
   onImportEvents: (events: Omit<TimelineEvent, 'id'>[]) => AddEventsResult;
   onClearTimeline: () => void;
-  onTitleChange: (title: string) => void;
   onDescriptionChange: (description: string) => void;
   scale: 'large' | 'medium' | 'small';
   onScaleChange: (scale: 'large' | 'medium' | 'small') => void;
@@ -47,7 +46,6 @@ export function TimelineSettingsPanel({
   timelineTitle,
   timelineDescription,
   onImportEvents,
-  onTitleChange,
   onDescriptionChange,
   scale,
   onScaleChange,
@@ -76,10 +74,6 @@ export function TimelineSettingsPanel({
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
   }, [isOpen, onClose]);
-
-  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onTitleChange(e.target.value);
-  };
 
   const handleDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newDescription = e.target.value;
@@ -197,20 +191,6 @@ export function TimelineSettingsPanel({
               {/* Body */}
               <div className="flex-1 min-h-0 overflow-y-auto">
                 <div className="flex flex-col px-5 pt-6 pb-2 gap-8 min-h-full">
-                  {/* Title */}
-                  <div>
-                    <label htmlFor="timelineTitle" className="label-m-type2 text-[#9B9EA3] mb-1 block">
-                      Title
-                    </label>
-                    <input
-                      type="text"
-                      id="timelineTitle"
-                      value={timelineTitle}
-                      onChange={handleTitleChange}
-                      className="w-full h-9 bg-[#242526] border border-[#262626] rounded-[8px] px-3 py-[7.5px] body-m text-[#DADEE5] outline-none focus:border-[#404040]"
-                    />
-                  </div>
-
                   {/* Description */}
                   <div>
                     <label htmlFor="timelineDescription" className="label-m-type2 text-[#9B9EA3] mb-1 block">
@@ -232,7 +212,7 @@ export function TimelineSettingsPanel({
 
                     {/* Timeline scale row */}
                     <div className="flex flex-row items-center justify-between h-10">
-                      <span className="label-m-type2 text-[#9B9EA3]">Timeline scale</span>
+                      <span className="label-m-type2 text-[#9B9EA3]">Scale</span>
                       <ScaleSelector value={scale} onChange={onScaleChange} />
                     </div>
 
@@ -240,7 +220,7 @@ export function TimelineSettingsPanel({
 
                     {/* Event height row */}
                     <div className="flex flex-row items-center justify-between h-10">
-                      <span className="label-m-type2 text-[#9B9EA3]">Event height</span>
+                      <span className="label-m-type2 text-[#9B9EA3]">Row height</span>
                       <VerticalScaleSelector value={verticalScale} onChange={onVerticalScaleChange} />
                     </div>
 

--- a/src/components/TimelineViewer/TimelineViewer.tsx
+++ b/src/components/TimelineViewer/TimelineViewer.tsx
@@ -59,8 +59,8 @@ export function TimelineViewer() {
             description: draft.description || '',
             events: draft.events || [],
             categories,
-            scale: draft.scale || 'medium',
-            verticalScale: draft.verticalScale ?? 'small',
+            scale: draft.scale || 'small',
+            verticalScale: draft.verticalScale ?? 'medium',
             groupByCategory: draft.groupByCategory ?? false
           });
         } catch {
@@ -134,8 +134,8 @@ export function TimelineViewer() {
           description: timelineData.description || '',
           events: formattedEvents,
           categories: categories,
-          scale: timelineData.scale || 'medium',
-          verticalScale: timelineData.vertical_scale ?? 'small',
+          scale: timelineData.scale || 'small',
+          verticalScale: timelineData.vertical_scale ?? 'medium',
           groupByCategory: timelineData.group_by_category ?? false
         });
       } catch (err) {

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -118,8 +118,8 @@ export function useTimeline() {
           description: '',
           events: [],
           categories: undefined, // Will use default categories
-          scale: 'medium',
-          verticalScale: 'small',
+          scale: 'small',
+          verticalScale: 'medium',
           groupByCategory: false
         };
       }
@@ -164,8 +164,8 @@ export function useTimeline() {
           sources: event.sources ?? null,
         })),
         categories: categories || undefined,
-        scale: timeline.scale || 'medium',
-        verticalScale: timeline.vertical_scale || 'small',
+        scale: timeline.scale || 'small',
+        verticalScale: timeline.vertical_scale || 'medium',
         groupByCategory: timeline.group_by_category ?? false
       };
     } catch (error) {
@@ -178,8 +178,8 @@ export function useTimeline() {
   const saveTimeline = useCallback(async (
     title: string,
     events: TimelineEvent[],
-    scale: 'large' | 'medium' | 'small' = 'medium',
-    verticalScale: 'small' | 'medium' = 'small',
+    scale: 'large' | 'medium' | 'small' = 'small',
+    verticalScale: 'small' | 'medium' = 'medium',
   ) => {
     if (!user) throw new Error('Must be signed in to save');
 

--- a/src/hooks/useTimelineScale.ts
+++ b/src/hooks/useTimelineScale.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { SCALES } from '../constants/scales';
 import { TimelineScale } from '../types/timeline';
 
-export function useTimelineScale(initialScale: 'large' | 'medium' | 'small' = 'medium') {
+export function useTimelineScale(initialScale: 'large' | 'medium' | 'small' = 'small') {
   const [scale, setScale] = useState<'large' | 'medium' | 'small'>(initialScale);
 
   const handleScaleChange = useCallback((newScale: 'large' | 'medium' | 'small') => {

--- a/src/hooks/useTimelineVerticalScale.ts
+++ b/src/hooks/useTimelineVerticalScale.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { VERTICAL_SCALES } from '../constants/verticalScales';
 import { TimelineVerticalScale } from '../types/timeline';
 
-export function useTimelineVerticalScale(initialScale: 'small' | 'medium' = 'small') {
+export function useTimelineVerticalScale(initialScale: 'small' | 'medium' = 'medium') {
   const [verticalScale, setVerticalScale] = useState<'small' | 'medium'>(initialScale);
 
   const handleVerticalScaleChange = useCallback((newScale: 'small' | 'medium') => {

--- a/src/utils/draftStorage.ts
+++ b/src/utils/draftStorage.ts
@@ -84,8 +84,8 @@ export function createDraft(): LocalDraft | null {
     description: '',
     events: [],
     categories: [...DEFAULT_CATEGORIES],
-    scale: 'medium',
-    verticalScale: 'small',
+    scale: 'small',
+    verticalScale: 'medium',
     groupByCategory: false,
     savedAt: new Date().toISOString(),
   }


### PR DESCRIPTION
## Summary
- Remove the Title input from the settings side panel (title is still editable from the global nav).
- Rename "Timeline scale" to "Scale" and "Event height" to "Row height".
- New timelines and drafts now default to **Scale: small** and **Row height: medium**. Loader fallbacks for legacy rows missing these fields are flipped to match.

## Changes
- `src/components/Settings/TimelineSettingsPanel.tsx`: dropped the title input, label, handler, and `onTitleChange` prop; updated the two label strings.
- `src/components/Layout/Header.tsx` + `src/App.tsx`: removed the now-unused `onTitleChange` plumbing.
- Defaults flipped in `src/hooks/useTimelineScale.ts`, `src/hooks/useTimelineVerticalScale.ts`, `src/hooks/useTimeline.ts` (new-timeline init, loader fallbacks, `saveTimeline` defaults), `src/utils/draftStorage.ts`, `src/components/TimelineViewer/TimelineViewer.tsx`, and all `?? 'small'` fallbacks in `src/App.tsx`.

## Test plan
- [ ] `npm run lint` and `npm run build` are clean (verified locally).
- [ ] Open the settings panel — no Title field; labels read "Scale" and "Row height".
- [ ] Create a new timeline — Scale starts on Small, Row height on Medium.
- [ ] Edit title from the global nav still works.
- [ ] Loading a legacy timeline with missing scale fields renders with the new defaults.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMFK7byJs2KX9R5HCGsUSu)_