### PR TITLE
Shorten scale and row height toggle labels to S/M/L

### DIFF
--- a/src/components/Settings/ScaleSelector.tsx
+++ b/src/components/Settings/ScaleSelector.tsx
@@ -11,34 +11,34 @@ export function ScaleSelector({ value, onChange }: ScaleSelectorProps) {
   };
 
   const tabClass = (active: boolean) =>
-    `flex items-center justify-center w-[60px] min-w-[60px] h-8 px-3 py-1.5 rounded-[6px] transition-colors body-m ${
+    `flex items-center justify-center w-[64px] min-w-[64px] h-8 px-3 py-1.5 rounded-[6px] transition-colors body-m ${
       active
         ? 'bg-[#262626] text-text-secondary'
         : 'bg-transparent text-text-tertiary hover:text-text-secondary'
     }`;
 
   return (
-    <div className="flex flex-row items-start p-1 w-[188px] h-10 bg-surface-secondary border border-[#262626] rounded-[10px]">
+    <div className="flex flex-row items-start p-1 w-[200px] h-10 bg-surface-secondary border border-[#262626] rounded-[10px]">
       <button
         type="button"
         onClick={() => handleScaleChange('small')}
         className={tabClass(value === 'small')}
       >
-        Small
+        S
       </button>
       <button
         type="button"
         onClick={() => handleScaleChange('medium')}
         className={tabClass(value === 'medium')}
       >
-        Medium
+        M
       </button>
       <button
         type="button"
         onClick={() => handleScaleChange('large')}
         className={tabClass(value === 'large')}
       >
-        Large
+        L
       </button>
     </div>
   );

--- a/src/components/Settings/VerticalScaleSelector.tsx
+++ b/src/components/Settings/VerticalScaleSelector.tsx
@@ -11,7 +11,7 @@ export function VerticalScaleSelector({ value, onChange }: VerticalScaleSelector
   };
 
   const tabClass = (active: boolean) =>
-    `flex items-center justify-center w-[60px] min-w-[60px] h-8 px-3 py-1.5 rounded-[6px] transition-colors body-m ${
+    `flex items-center justify-center w-[64px] min-w-[64px] h-8 px-3 py-1.5 rounded-[6px] transition-colors body-m ${
       active
         ? 'bg-[#262626] text-text-secondary'
         : 'bg-transparent text-text-tertiary hover:text-text-secondary'
@@ -24,14 +24,14 @@ export function VerticalScaleSelector({ value, onChange }: VerticalScaleSelector
         onClick={() => handleChange('small')}
         className={tabClass(value === 'small')}
       >
-        Small
+        S
       </button>
       <button
         type="button"
         onClick={() => handleChange('medium')}
         className={tabClass(value === 'medium')}
       >
-        Medium
+        M
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace the full **Small / Medium / Large** labels in the settings side panel's **Scale** control with **S / M / L**, and the **Row height** control's labels with **S / M**, to consolidate the wide text into smaller areas.
- Widen each toggle option from 60px to 64px (Scale container `188px → 200px`; Row height container stays `136px` since two 64px buttons + padding already fit).
- No functional change — the underlying stored values (`'small' | 'medium' | 'large'`) and `onChange` selection behavior are unchanged.

## Changes
- `src/components/Settings/ScaleSelector.tsx`
- `src/components/Settings/VerticalScaleSelector.tsx`

## Test plan
- [ ] Open the editor (`/editor`) and open the settings side panel
- [ ] Confirm **Scale** shows S / M / L and **Row height** shows S / M
- [ ] Click each option and confirm scale / row height still change as before (active highlight follows selection)
- [ ] Confirm each option button is at least 64px wide with centered, unclipped labels
- [ ] `npm run build` and `npm run lint` pass (verified locally)

https://claude.ai/code/session_01WiYPtbqJQ2NbZeDsxEybpe

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiYPtbqJQ2NbZeDsxEybpe)_