### PR TITLE
Fix CORS preflight for cached builds and deploy previews

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,6 +1,6 @@
-// CORS is pinned to the production app origin(s) instead of "*" so third-party
-// sites can't drive these functions from their visitors' browsers. Override
-// with a comma-separated ALLOWED_ORIGINS env var (e.g. to add a preview URL).
+// CORS is pinned to the app's own origins instead of "*" so third-party sites
+// can't drive these functions from their visitors' browsers. Override the exact
+// list with a comma-separated ALLOWED_ORIGINS env var.
 const DEFAULT_ALLOWED_ORIGINS = [
   "https://app.timeline.academy", // production app
   "https://timeline.academy",
@@ -9,6 +9,11 @@ const DEFAULT_ALLOWED_ORIGINS = [
   "http://localhost:5173", // vite dev server
 ];
 
+// Netlify deploy previews get a generated hostname per PR/branch, e.g.
+// https://deploy-preview-84--timelineacademy.netlify.app. They're our own
+// builds of this site, so match them by suffix rather than pinning each one.
+const ALLOWED_ORIGIN_SUFFIX = "--timelineacademy.netlify.app";
+
 function allowedOrigins(): string[] {
   const fromEnv = Deno.env.get("ALLOWED_ORIGINS");
   if (!fromEnv) return DEFAULT_ALLOWED_ORIGINS;
@@ -16,11 +21,16 @@ function allowedOrigins(): string[] {
   return parsed.length > 0 ? parsed : DEFAULT_ALLOWED_ORIGINS;
 }
 
+function isAllowed(origin: string, origins: string[]): boolean {
+  if (origins.includes(origin)) return true;
+  return origin.startsWith("https://") && origin.endsWith(ALLOWED_ORIGIN_SUFFIX);
+}
+
 export function corsHeadersFor(req: Request): Record<string, string> {
   const origins = allowedOrigins();
   const origin = req.headers.get("origin") ?? "";
   return {
-    "Access-Control-Allow-Origin": origins.includes(origin) ? origin : origins[0],
+    "Access-Control-Allow-Origin": isAllowed(origin, origins) ? origin : origins[0],
     Vary: "Origin",
     "Access-Control-Allow-Methods": "POST, OPTIONS",
     "Access-Control-Allow-Headers":

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -33,7 +33,10 @@ export function corsHeadersFor(req: Request): Record<string, string> {
     "Access-Control-Allow-Origin": isAllowed(origin, origins) ? origin : origins[0],
     Vary: "Origin",
     "Access-Control-Allow-Methods": "POST, OPTIONS",
+    // x-session-token is no longer read by any function, but older cached
+    // builds of the app still send it. Listing it keeps their preflight from
+    // failing, which would block the request before it was ever sent.
     "Access-Control-Allow-Headers":
-      "authorization, x-client-info, apikey, content-type",
+      "authorization, x-client-info, apikey, content-type, x-session-token",
   };
 }


### PR DESCRIPTION
Two follow-up commits to #84 that were pushed after it merged and so never landed. Both touch only `supabase/functions/_shared/cors.ts`.

## `x-session-token` back in `Allow-Headers`

#84 tightened `Access-Control-Allow-Headers` from `"*"` to an explicit list, which dropped `x-session-token`. The pre-#84 build of the app sent that header on **every** generation request, so a browser still running a cached copy of the old bundle fails its CORS preflight and the request never leaves the browser — surfacing as *"Failed to send a request to the Edge Function."*

This was hit on production right after the merge. The header is no longer read by any function; listing it just stops the preflight from failing while old bundles age out of caches.

The underlying mistake was pinning the header list to only what the new client sends, which makes the deploy order load-bearing. A rollout has to accept both the old and new client for as long as cached copies exist.

## Netlify deploy-preview origins

Preview builds get a generated hostname per PR (`deploy-preview-84--timelineacademy.netlify.app`), so the pinned origin list blocked the app's own previews from calling the edge functions. Matched by suffix, since these are our own builds of this site.

## Deploying

`cors.ts` reaches production by hand through the Supabase dashboard, so **merging this does not deploy it**. Each function keeps its own copy and needs the file pasted in separately:

- `generate-timeline` — the only one that fixes the live bug; the old client never sent that header to the others
- `enrich-event`, `set-byok-flag`, `delete-account` — same file, for consistency

## Verification

Generate a timeline on `app.timeline.academy` from a browser session that has *not* hard-refreshed since the #84 deploy — it should succeed rather than failing at preflight. A hard refresh already works today, since the current bundle doesn't send the header at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xdcnLgwEaAaiV7SUaZFyo

---
_Generated by [Claude Code](https://claude.ai/code/session_014xdcnLgwEaAaiV7SUaZFyo)_