### PR TITLE
ROLLBACK: restore the pre-review generate-timeline (merge only if generation breaks)

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,3 +1,12 @@
+// Legacy permissive headers, kept only for the rolled-back generate-timeline
+// on this branch. Every other function uses corsHeadersFor() below, which
+// pins the origin. Remove this together with the rollback.
+export const corsHeaders: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "*",
+};
+
 // CORS is pinned to the app's own origins instead of "*" so third-party sites
 // can't drive these functions from their visitors' browsers. Override the exact
 // list with a comma-separated ALLOWED_ORIGINS env var.

--- a/supabase/functions/generate-timeline/index.ts
+++ b/supabase/functions/generate-timeline/index.ts
@@ -1,41 +1,11 @@
 import { createClient } from "jsr:@supabase/supabase-js@2";
-import { corsHeadersFor } from "../_shared/cors.ts";
+import { corsHeaders } from "../_shared/cors.ts";
 import { createLLMClient } from "../_shared/llm-client.ts";
 import { checkRateLimit, recordUsage } from "../_shared/rate-limiter.ts";
 import { classifySubject } from "../_shared/classify.ts";
 import type { CategoryDefinition } from "../_shared/prompts.ts";
 
-const MAX_SUBJECT_LENGTH = 200;
-// Classification is a cheap Haiku call made once before each generation, so it
-// gets its own, larger budget instead of consuming the generation quota.
-const CLASSIFY_RATE_LIMIT = 30;
-
-async function authenticateUser(req: Request): Promise<string | null> {
-  const authHeader = req.headers.get("authorization");
-  if (!authHeader) return null;
-  try {
-    const supabase = createClient(
-      Deno.env.get("SUPABASE_URL")!,
-      Deno.env.get("SUPABASE_ANON_KEY")!,
-      { global: { headers: { Authorization: authHeader } } }
-    );
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    return user?.id ?? null;
-  } catch {
-    return null;
-  }
-}
-
 Deno.serve(async (req: Request) => {
-  const corsHeaders = corsHeadersFor(req);
-  const json = (body: unknown, status: number, extra: Record<string, string> = {}) =>
-    new Response(JSON.stringify(body), {
-      status,
-      headers: { ...corsHeaders, "Content-Type": "application/json", ...extra },
-    });
-
   // Handle CORS preflight
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
@@ -43,60 +13,95 @@ Deno.serve(async (req: Request) => {
 
   try {
     // 1. Parse request body
-    const { subject, categories, mode } = await req.json();
+    const { subject, provider, categories, mode } = await req.json();
 
     if (!subject || typeof subject !== "string" || !subject.trim()) {
-      return json({ error: "Missing or empty 'subject' field" }, 400);
-    }
-    if (subject.length > MAX_SUBJECT_LENGTH) {
-      return json({ error: "Subject is too long." }, 400);
-    }
-
-    // 2. Every server-funded AI call requires a signed-in user. Anonymous
-    //    visitors use their own Anthropic key browser-direct instead.
-    const userId = await authenticateUser(req);
-    if (!userId) {
-      return json({ error: "Sign in to generate timelines." }, 401);
-    }
-
-    // 3. Classification mode — cheap, but still authenticated and metered
-    //    (on its own budget so it doesn't consume the generation quota).
-    if (mode === "classify") {
-      const { allowed } = await checkRateLimit(
-        `classify:user:${userId}`,
-        CLASSIFY_RATE_LIMIT
+      return new Response(
+        JSON.stringify({ error: "Missing or empty 'subject' field" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
       );
-      if (!allowed) {
-        return json({ type: "topic" }, 200);
-      }
+    }
+
+    // 1b. Classification mode — cheap, fast, no auth/rate-limit needed
+    if (mode === "classify") {
       try {
         const type = await classifySubject(subject.trim());
-        await recordUsage(`classify:user:${userId}`);
-        return json({ type }, 200);
+        return new Response(JSON.stringify({ type }), {
+          status: 200,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
       } catch (classifyErr) {
         console.error("Classification failed, falling back to topic:", classifyErr);
-        return json({ type: "topic" }, 200);
+        return new Response(JSON.stringify({ type: "topic" }), {
+          status: 200,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
       }
     }
 
-    // 4. Check the generation rate limit
-    const sessionKey = `user:${userId}`;
+    // 2. Determine session key for rate limiting
+    //    Prefer user ID from auth JWT; fall back to x-session-token header
+    let sessionKey: string | null = null;
+
+    const authHeader = req.headers.get("authorization");
+    if (authHeader) {
+      try {
+        const supabase = createClient(
+          Deno.env.get("SUPABASE_URL")!,
+          Deno.env.get("SUPABASE_ANON_KEY")!,
+          { global: { headers: { Authorization: authHeader } } }
+        );
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (user) {
+          sessionKey = `user:${user.id}`;
+        }
+      } catch {
+        // Auth extraction failed — fall through to session token
+      }
+    }
+
+    if (!sessionKey) {
+      sessionKey = req.headers.get("x-session-token");
+    }
+
+    if (!sessionKey) {
+      return new Response(
+        JSON.stringify({
+          error: "Authentication required. Please sign in or try again.",
+        }),
+        {
+          status: 401,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // 3. Check rate limit
     const { allowed, remaining } = await checkRateLimit(sessionKey);
     if (!allowed) {
-      return json(
-        {
+      return new Response(
+        JSON.stringify({
           error:
             "You've reached the daily limit for AI timeline generation. Please try again tomorrow.",
           remaining: 0,
-        },
-        429
+        }),
+        {
+          status: 429,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
       );
     }
 
-    // 5. Create LLM client and generate timeline. The provider is a server
-    //    decision — never taken from the request body.
+    // 4. Create LLM client and generate timeline
     const selectedProvider =
-      (Deno.env.get("DEFAULT_LLM_PROVIDER") as "openai" | "claude") || "claude";
+      (provider as "openai" | "claude") ||
+      (Deno.env.get("DEFAULT_LLM_PROVIDER") as "openai" | "claude") ||
+      "claude";
 
     const client = createLLMClient(selectedProvider);
 
@@ -106,17 +111,30 @@ Deno.serve(async (req: Request) => {
         ? categories
         : undefined;
 
-    const result = await client.generateTimeline(subject.trim(), categoryDefs);
+    const result = await client.generateTimeline(
+      subject.trim(),
+      categoryDefs
+    );
 
-    // 6. Record usage
+    // 5. Record usage
     await recordUsage(sessionKey);
 
-    // 7. Return result
-    return json(result, 200, { "X-RateLimit-Remaining": String(remaining - 1) });
+    // 6. Return result
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: {
+        ...corsHeaders,
+        "Content-Type": "application/json",
+        "X-RateLimit-Remaining": String(remaining - 1),
+      },
+    });
   } catch (err) {
-    // Upstream provider errors can carry account details in their bodies —
-    // log the specifics server-side, return only a generic message.
     console.error("generate-timeline error:", err);
-    return json({ error: "Timeline generation failed. Please try again." }, 500);
+    const message =
+      err instanceof Error ? err.message : "Internal server error";
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
   }
 });


### PR DESCRIPTION
**Do not merge unless timeline generation is broken.** This is a prepared escape hatch, written in advance so recovery is a single click rather than an improvised debugging session.

## When to merge this

If the first CI deploy (#86) — or any later one — leaves generation failing on `app.timeline.academy`. Merging redeploys the version running in production today, through CI, in about two minutes.

## What it does

- Restores `supabase/functions/generate-timeline/index.ts` verbatim from `1b49edd`, the last known-good version.
- Re-exports the permissive `corsHeaders` constant that file imports, which was removed when CORS was pinned to specific origins.

Other functions are untouched — they call `corsHeadersFor()`, which still pins the origin. `enrich-event` keeps its hardening and its working AI descriptions.

## What merging gives up

On `generate-timeline` only: the sign-in requirement, the classify-mode rate limit, fail-closed rate limiting, pinned CORS, and error-message sanitising.

That's **cost-control hardening, not a data-exposure fix** — no user data is reachable through it, and it's the same posture the endpoint had before this work started. The website still shows anonymous visitors the sign-in-or-BYOK gate, so ordinary users can't generate for free; the gap is that someone technical could call the endpoint directly.

The genuine security fix from the review — the `ai_rate_limits` lockdown — lives in the database and is unaffected by this.

## After merging

Verify generation works, then close this PR. When the hardening is reattempted, delete the legacy `corsHeaders` export along with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xdcnLgwEaAaiV7SUaZFyo

---
_Generated by [Claude Code](https://claude.ai/code/session_014xdcnLgwEaAaiV7SUaZFyo)_