### PR TITLE
Disable verify_jwt — it blocks the CORS preflight and breaks all browser calls

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -7,18 +7,29 @@
 # project by default.
 project_id = "ltudgurcouffxyuxvpmw"
 
-# Each function verifies the caller's JWT itself via auth.getUser() and rejects
-# anonymous requests; verify_jwt adds gateway-level rejection of requests
-# carrying no valid JWT at all, as defense in depth.
+# verify_jwt MUST stay false for anything a browser calls.
+#
+# Browsers send a CORS preflight (OPTIONS) before a cross-origin POST, and by
+# specification that preflight carries no Authorization header. With
+# verify_jwt = true the gateway rejects it before the function runs and answers
+# with its own minimal CORS headers — which omit content-type. The browser then
+# refuses to send the real request, surfacing as "Failed to send a request to
+# the Edge Function". No amount of CORS handling inside the function can fix
+# this, because the function is never reached.
+#
+# Nothing is lost by disabling it: every function below authenticates the
+# caller itself with supabase.auth.getUser() and returns 401 to anonymous
+# requests. The gateway check was redundant with that, and incompatible with
+# browser clients.
 
 [functions.generate-timeline]
-verify_jwt = true
+verify_jwt = false
 
 [functions.enrich-event]
-verify_jwt = true
+verify_jwt = false
 
 [functions.set-byok-flag]
-verify_jwt = true
+verify_jwt = false
 
 [functions.delete-account]
-verify_jwt = true
+verify_jwt = false


### PR DESCRIPTION
Root cause of the generation outage, confirmed from a gateway response rather than inferred.

## The mechanism

Browsers send a CORS preflight (`OPTIONS`) before any cross-origin POST, and **by specification that preflight carries no `Authorization` header**. With `verify_jwt = true`, Supabase's gateway rejects the preflight before the function runs, and answers with its own minimal CORS headers:

```
sb-error-code: UNAUTHORIZED_INVALID_JWT_FORMAT
access-control-allow-headers: authorization, x-client-info, apikey
```

No `content-type`. The app posts JSON, so the browser asks permission to send `content-type`, doesn't get it, and refuses to send the real request — surfacing as *"Failed to send a request to the Edge Function."*

**This is why the outage survived an atomic redeploy.** The function was never reached, so nothing in its code could have fixed it. The earlier theories — mismatched `_shared` files, the `x-session-token` allow-list, pinned origins — were all wrong. `curl` reached the gateway with a header a browser would never send, which is what finally separated the two layers.

`verify_jwt` was introduced by `supabase/config.toml` in #86. The dashboard ignores that file, which is why the setting only took effect once deploys moved to CI.

## Why disabling it costs nothing

Every function authenticates the caller itself with `supabase.auth.getUser()` and returns 401 to anonymous requests — `generate-timeline`, `enrich-event`, `set-byok-flag` and `delete-account` all do this in their own code. The gateway check was redundant defense-in-depth, and it is incompatible with browser clients.

## Deployment

Merging deploys automatically: `supabase/config.toml` is in the workflow's trigger paths. No manual steps.

## Verification

After the workflow goes green, with **both** placeholders replaced this time:

```bash
curl -i -X POST \
  'https://ltudgurcouffxyuxvpmw.supabase.co/functions/v1/generate-timeline' \
  -H 'Content-Type: application/json' \
  -H "apikey: $ANON_KEY" -H "Authorization: Bearer $ANON_KEY" \
  -d '{"subject":"Ada Lovelace","mode":"classify"}'
```

Expect `401` with `{"error":"Sign in to generate timelines."}` — the function's own message, proving requests now reach it. Then hard-refresh `app.timeline.academy`, sign in, and generate a timeline.

#87 remains open as the rollback if this doesn't hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xdcnLgwEaAaiV7SUaZFyo

---
_Generated by [Claude Code](https://claude.ai/code/session_014xdcnLgwEaAaiV7SUaZFyo)_