### PR TITLE
Echo the browser's requested CORS headers instead of guessing them

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -29,14 +29,25 @@ function isAllowed(origin: string, origins: string[]): boolean {
 export function corsHeadersFor(req: Request): Record<string, string> {
   const origins = allowedOrigins();
   const origin = req.headers.get("origin") ?? "";
+
+  // Echo back whatever headers the browser asked permission for, rather than
+  // maintaining a hand-written list. A list has to predict every header the
+  // client library sends; miss one and the preflight is refused, so the real
+  // request never leaves the browser — and no curl reproduces it, because a
+  // curl only asks for headers you already thought of. The pre-review version
+  // of this file allowed "*" for the same reason.
+  //
+  // This is not a weakening: Access-Control-Allow-Origin above decides *who*
+  // may call these functions, and each function authenticates the caller with
+  // supabase.auth.getUser(). Which header names a permitted origin may send
+  // was never a security control.
+  const requestedHeaders = req.headers.get("access-control-request-headers");
+
   return {
     "Access-Control-Allow-Origin": isAllowed(origin, origins) ? origin : origins[0],
-    Vary: "Origin",
+    Vary: "Origin, Access-Control-Request-Headers",
     "Access-Control-Allow-Methods": "POST, OPTIONS",
-    // x-session-token is no longer read by any function, but older cached
-    // builds of the app still send it. Listing it keeps their preflight from
-    // failing, which would block the request before it was ever sent.
     "Access-Control-Allow-Headers":
-      "authorization, x-client-info, apikey, content-type, x-session-token",
+      requestedHeaders ?? "authorization, x-client-info, apikey, content-type",
   };
 }


### PR DESCRIPTION
Generation has been broken on `app.timeline.academy` since `_shared/cors.ts` was rewritten. The browser reports *"Failed to send a request to the Edge Function"* — a fetch that never leaves the browser.

## Why the previous four attempts missed it

| Theory | Disproved by |
|---|---|
| Mismatched `index.ts` / `_shared` files | Atomic CI deploy (#86) failed identically |
| Missing `x-session-token` in the allow-list | Added in #85; still failed |
| `verify_jwt` blocking the preflight | Disabled in #88; still failed |
| Function crashing or unreachable | Preflight returns a clean `200` |

The preflight probe returning `200` looked like exoneration. It wasn't — **the probe was circular.** It requested permission for exactly the five headers the code allows, so approval was guaranteed. It proved the list matches itself, not that it matches what supabase-js sends.

## Root cause

The pre-review file used `Access-Control-Allow-Headers: "*"` and worked for months. The rewrite replaced it with a fixed five-header list. Any header the client library sends that isn't on that list causes the browser to refuse the preflight and drop the request before sending it. A hand-written `curl` can never reproduce this, because it only asks for headers you already thought of.

## The fix

Reflect `Access-Control-Request-Headers` back rather than maintaining a list of predictions. This removes the failure class instead of guessing which header was missing.

Not a weakening: `Access-Control-Allow-Origin` still decides *who* may call these functions, and each function authenticates the caller with `supabase.auth.getUser()`. Which header names a permitted origin may send was never a security control — which is why the original allowed `*`.

`Vary` now includes `Access-Control-Request-Headers` so caches key on it correctly.

Shared by all four functions.

## Verification

Non-circular this time — request a header the old list would have rejected:

```bash
curl -i -X OPTIONS 'https://ltudgurcouffxyuxvpmw.supabase.co/functions/v1/generate-timeline' \
  -H 'Origin: https://app.timeline.academy' \
  -H 'Access-Control-Request-Method: POST' \
  -H 'Access-Control-Request-Headers: content-type,authorization,x-made-up-header'
```

`access-control-allow-headers` must come back including `x-made-up-header`. Then hard-refresh the site, sign in, generate a timeline, and open an event without a description to confirm enrichment still streams.

Merging deploys automatically. #87 remains open as the rollback.

## Takeaway

Tightening a request-side allow-list to match only what the current client sends makes the client's exact behaviour a deploy-time dependency, and the failure is invisible to server-side testing. Where the value isn't a real security control, prefer permissive or reflected values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xdcnLgwEaAaiV7SUaZFyo

---
_Generated by [Claude Code](https://claude.ai/code/session_014xdcnLgwEaAaiV7SUaZFyo)_