### PR TITLE
Document the security review, and correct CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Timeline Academy — an interactive timeline builder that lets users create, edit, and visualize timelines of people's lives or events. Built with React, TypeScript, Vite, and Supabase.
+Timeline Academy — an interactive timeline builder that lets users search for a person or era and get a full, detailed timeline they can scroll through and interact with. The product is informational and educational in intent; keep that spirit in feature work. Built with React, TypeScript, Vite, and Supabase.
 
 ## Commands
 
@@ -13,51 +13,103 @@ npm run lint      # ESLint on .ts/.tsx files
 npm run preview   # Preview production build locally
 ```
 
-No test framework is configured.
+No test framework is configured — every check is manual. This is the direct reason a five-month drift between this repo and the live project went unnoticed, along with three features that were silently broken in production for months (see `docs/2026-08-05-security-review-handoff.md`).
 
 ## Architecture
 
 ```
 src/
 ├── components/       # Feature-folder organized React components
+│   ├── Legal/        # /privacy and /terms pages
 │   └── ui/           # shadcn/ui primitives
-├── hooks/            # Custom React hooks (useTimeline, useEvents, useAutosave, etc.)
-├── contexts/         # React Context providers (AuthContext)
-├── services/         # Business logic (AI timeline generation, session tokens)
-├── utils/            # Helpers (CSV/Excel parsing, date utils, event stacking, etc.)
+├── hooks/            # Custom React hooks (useTimeline, useEvents, useAutosave, useAIMode, etc.)
+├── contexts/         # React Context providers (AuthContext, SidePanelContext)
+├── services/         # AI generation + external APIs:
+│                     #   aiTimeline, anthropicDirect (BYOK), eventEnrichment,
+│                     #   llmPrompts, userApiKey, viewerEventCache,
+│                     #   wikipediaSearch, wikipediaImage
+├── utils/            # Helpers (csvParser, excelSheet/excelExport, dateUtils,
+│                     #   eventStacking, draftStorage, saveEvents, etc.)
 ├── types/            # TypeScript type definitions (event.ts, timeline.ts)
-├── constants/        # App constants (categories, defaults, scales)
-├── lib/              # Supabase client setup and shared utilities
+├── constants/        # App constants (categories, defaults, scales, plans)
+├── lib/              # Supabase client setup, plan limits
 ├── App.tsx           # Timeline editor page (/editor)
-├── Router.tsx        # Routes: / → AIModePage, /editor → App, /view/:id → TimelineViewer
+├── Router.tsx        # Routes: / → AIModePage, /editor → App,
+│                     #   /view/:id → TimelineViewer, /privacy, /terms
 └── main.tsx          # Entry point
 supabase/
-├── functions/        # Edge Functions
-└── migrations/       # Database migrations
+├── config.toml       # Per-function settings (verify_jwt) + project_id
+├── functions/        # Edge Functions: generate-timeline, enrich-event,
+│                     #   set-byok-flag, delete-account, and _shared/
+└── migrations/       # Database migrations (applied BY HAND — see below)
+.github/workflows/
+└── deploy-functions.yml   # Deploys all edge functions on merge to main
 ```
 
 ## Code Style & Conventions
 
 - **TypeScript** strict mode enabled. No unused locals or parameters. Target ES2020.
 - **Path alias**: `@/` maps to `src/` — use for all imports.
-- **Tailwind CSS** for styling. Dark mode via `class` strategy. Custom fonts: Avenir, IBM Plex Mono.
+- **Tailwind CSS** for styling. Dark mode via `class` strategy.
+- **Fonts**: Aleo, IBM Plex Mono and JetBrains Mono load from Google Fonts (`src/index.css:1`). `Avenir` is declared and referenced throughout, but **has never actually loaded** — `index.css:81` points a `@font-face src` at a stylesheet URL rather than a font file, so everything specifying Avenir falls back to a system sans-serif. Known and deliberately deferred; fixing it changes the look of the whole interface.
 - **shadcn/ui** — Custom preset, Base UI library, Vega style, Neutral base/theme color, Lucide icons, Inter font, Medium radius, Default menu color, Subtle menu accent.
 - **Component organization**: Feature folders under `src/components/` (e.g., `Auth/`, `Timeline/`, `Navigation/`, `AIMode/`).
-- **State management**: Custom hooks for feature logic; React Context for global state (auth).
+- **State management**: Custom hooks for feature logic; React Context for global state (auth, side panel).
 - **ESLint** flat config with TypeScript ESLint and React Hooks plugins. No Prettier.
 - **No semicolons or formatting tool** — follow existing code style in each file.
+- **Spreadsheets** use `exceljs` via the shared helper in `src/utils/excelSheet.ts`, lazy-loaded into its own chunk. The `xlsx` package was removed (frozen on npm at 0.18.5 with prototype-pollution and ReDoS advisories, while parsing untrusted uploads). Don't reintroduce it.
 
 ## Environment
 
-Copy `.env.example` to `.env` and set:
+**Client** — copy `.env.example` to `.env`:
 
 ```
 VITE_SUPABASE_URL=<your-supabase-url>
 VITE_SUPABASE_ANON_KEY=<your-anon-key>
 ```
 
-All client-exposed env vars use the `VITE_` prefix.
+All client-exposed env vars use the `VITE_` prefix. In production these live in Netlify's environment variables.
+
+**Server (edge functions)** — set in Supabase → Edge Functions → Secrets, not in any file. They survive deploys:
+
+- `ANTHROPIC_API_KEY`, `OPENAI_API_KEY` — LLM providers
+- `DEFAULT_LLM_PROVIDER` — `claude` (default) or `openai`
+- `ALLOWED_ORIGINS` — optional comma-separated override of the CORS allow-list
+- `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY` — injected automatically
+
+**CI** — GitHub repository secrets: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`.
 
 ## Deployment
 
-Deployed via **Netlify**. SPA redirect configured in `netlify.toml` (all routes → `/index.html`).
+Three independent paths. Understanding that they are separate — and finish at different moments — matters more than any other operational detail here.
+
+1. **Site → Netlify**, automatically on merge to `main`. `netlify.toml` also serves the CSP and security headers.
+2. **Edge functions → GitHub Actions** (`.github/workflows/deploy-functions.yml`), which runs `supabase functions deploy` on pushes to `main` touching `supabase/functions/**` or `supabase/config.toml`. Also triggerable manually from the Actions tab. Production project ref: `ltudgurcouffxyuxvpmw`.
+3. **Migrations → by hand**, pasted into the Supabase SQL editor. Nothing enforces or verifies this.
+
+## Critical operational rules
+
+Each of these was learned the expensive way. See `docs/2026-08-05-security-review-handoff.md` for the incidents behind them.
+
+- **Never paste function code into the Supabase dashboard.** A function's `index.ts` and its `_shared/` imports must ship together; hand-copying them separately leaves the function broken. Let CI deploy.
+- **Never assume a migration in `supabase/migrations/` has been applied.** Verify against `information_schema.columns` first. An unapplied April–May 2026 batch silently broke autosave, event descriptions and sharing for three months while the code that depended on it shipped normally.
+- **`verify_jwt` must stay `false`** in `supabase/config.toml`. With it `true`, Supabase's gateway rejects the CORS preflight — which by specification carries no `Authorization` header — and answers with headers omitting `content-type`, so browsers can never POST JSON. Every function authenticates its own caller with `supabase.auth.getUser()`, so the gateway check adds nothing.
+- **Do not "tighten" `_shared/cors.ts`.** It deliberately reflects `Access-Control-Request-Headers` back. A hand-written allow-list turns the client library's exact header set into a deploy-time dependency, and the failure is invisible to `curl` — because `curl` only asks permission for headers you already thought of.
+- **A function must accept both the current site and the previous one.** The two pipelines finish at different times and cached bundles persist for longer still. Keep old headers permitted and old request shapes tolerated.
+- **Debug with `curl` before the browser.** CORS is a browser-only mechanism, so `curl` separates "the server is broken" from "the browser refused to send" — a distinction that once cost hours.
+
+## Access & data model
+
+- **Server-funded AI requires sign-in.** Anonymous visitors hitting Generate get a gate offering email sign-in or their own Anthropic key. BYOK runs browser-direct (`services/anthropicDirect.ts`) and never touches our servers.
+- **Identity is email-only** — passwordless OTP, 6-digit codes, custom SMTP via Resend from `timeline.academy`. Supabase's Email OTP Length setting must stay at 6 to match the UI.
+- **Timelines are private by default.** Sharing sets `timelines.is_public`; public reads go through the `get_public_timeline` RPC, which requires the timeline's UUID and never returns `user_id`. Table policies remain owner-only.
+- **Plan limits** live in `src/constants/plans.ts` and must stay in sync with `get_plan_limits` in SQL. The `byok_enabled` flag lives in `app_metadata` (service-role writable only) — never move it back to `user_metadata`, which users can edit themselves.
+- **Rate limits**: 5 generations/day, 30 event enrichments/day, 30 classifications/day, per signed-in user. Enrichment is higher because descriptions auto-generate when an event is opened.
+- **No analytics, tracking, or third-party scripts.** This is deliberate and is the product's strongest privacy property. Keep it that way.
+
+## Known issues
+
+- `Avenir` never loads (see Code Style above).
+- Migrations are not automated — the other half of the drift problem.
+- `/privacy` and `/terms` are engineering drafts describing the real data flows accurately, but they have not had a legal review.
+- Several paths shipped in August 2026 are deployed but never exercised, including **account deletion, which is destructive**. See the handoff doc's verified/unverified section before trusting them.

--- a/docs/2026-08-05-security-review-handoff.md
+++ b/docs/2026-08-05-security-review-handoff.md
@@ -1,0 +1,169 @@
+# Privacy & security review — session record, 5 August 2026
+
+Context handoff for whoever picks this up next. Covers PRs #84–#89 and eleven database migrations applied by hand.
+
+---
+
+## 1. Summary
+
+What began as "check the codebase for privacy red flags" found one genuine security exposure, three product features that had been silently broken in production for months, and a deployment process that had let this repo drift five months ahead of the live Supabase project without anyone noticing.
+
+All of it is fixed and deployed. Fixing it also caused a multi-hour outage of timeline generation, which was diagnosed wrongly four times before being resolved — that post-mortem is section 5, and it's the most useful part of this document.
+
+**Current state:** timeline generation confirmed working. Most other changes are deployed but never exercised — see section 6 before trusting anything.
+
+---
+
+## 2. Security findings
+
+### The one real exposure: `ai_rate_limits`
+
+The table was created without row-level security in the `public` schema. Supabase exposes every `public` table through PostgREST with default grants to `anon` and `authenticated`, so RLS is the only thing standing between the public anon key — which ships inside the browser bundle by design — and the table contents.
+
+The original migration said, in a comment: *"Accessed only by Supabase Edge Functions via service role key — no RLS needed."* That describes who *does* access it, not who *can*.
+
+Anyone who opened the site, copied the anon key from devtools, and made three requests could:
+
+- **Read the whole table** — every row is `session_key` + timestamp, where `session_key` is either `user:<uuid>` or an anonymous device token. A user-ID enumeration plus a behavioural log of when each person used AI features.
+- **Delete their own rows** — resetting their rate limit, giving unlimited generation on the project's Anthropic key.
+- **Insert rows under someone else's key** — locking a victim out of AI features for 24 hours.
+
+**Closed by** `20260803000000_lock_down_ai_rate_limits.sql`: RLS enabled with no policies (edge functions use the service role, which bypasses RLS), default grants revoked, and a 24-hour retention cleanup so the table stops accumulating a permanent per-user usage log.
+
+### What the audit cleared
+
+A full policy audit (`pg_policies` across the `public` schema) returned 12 rows, all `{authenticated}` and owner-scoped — `auth.uid() = user_id` on `timelines`, ownership-by-lookup on `events` and `timeline_categories`. **No policy granted anything to `anon`, and no policy used `USING (true)`.**
+
+**No user data was ever exposed.** The worst-case scenario from the initial review — every timeline readable by anyone holding the anon key — did not happen.
+
+### Other hardening
+
+- **Plan tier trusted client-writable metadata.** `get_user_plan()` read `byok_enabled` from `raw_user_meta_data`, which any user can set from the browser console via `supabase.auth.updateUser()` — a self-service jump from free limits (300 events / 10 timelines) to BYOK limits (1200 / 25). Moved to `app_metadata`, writable only through the service-role `set-byok-flag` function.
+- **`generate-timeline`'s classify mode had no auth and no rate limit** — unbounded, unattributed LLM spend for anyone on the internet. Now gated, with its own 30/day budget.
+- **Rate limiting was forgeable and failed open.** The session key came from a client-supplied `x-session-token` header (rotate the UUID, bypass the limit), and if the counting query errored the request was allowed. Now keyed to the authenticated user only, and fails closed.
+- **`fetch-event-image` was unauthenticated and unmetered.** Deleted — image lookup now runs browser-direct to Wikipedia, the same pattern the autocomplete already used.
+- **Provider error bodies were relayed to callers** verbatim, potentially including account details. Now logged server-side only.
+- **`xlsx@0.18.5`** (frozen on npm; prototype pollution CVE-2023-30533, ReDoS CVE-2024-22363) was parsing untrusted uploads in the origin holding the session token and BYOK key. Replaced with lazy-loaded `exceljs`.
+- **Two `SECURITY DEFINER` functions** were missing `SET search_path`.
+
+---
+
+## 3. Three silently broken features
+
+All three trace to one root cause: **the April–May 2026 migrations and two edge functions were never applied to the live project, while the frontend depending on them shipped normally.**
+
+### Autosave — three months of silent data loss
+
+A commit on **4 May** made the app write `vertical_scale` and `group_by_category` on every save (`useAutosave.ts:33-40`). Neither column existed in production. Every autosave was rejected by the database, the error was caught and logged to the console, and because the save-status indicator is disabled (`GlobalNav.tsx`, `SHOW_SAVE_STATUS = false`) nothing on screen told the user.
+
+Nothing saved — not titles, not descriptions, not events, since the code stops at the first error before reaching the event save. **Signed-in users' work had not been persisting for three months.**
+
+### AI event descriptions — broken since April
+
+`enrich-event` was written on 30 April but never deployed; the last function deploy was 31 March. Opening an event auto-triggers description generation, which hit a 404 and rendered "Couldn't generate details." Every time, for every user without their own API key. The user confirmed this was a regular complaint. The columns to store results (`events.description`, `image_url`, `image_attribution`, `sources`) were also missing.
+
+### Sharing — never worked at all
+
+The Share button minted `/view/:id` links client-side, but **no policy ever permitted non-owner reads**. Every recipient saw "Timeline not found." Not a regression — it had never worked since the feature shipped.
+
+Now implemented explicitly: `timelines.is_public` (default false) plus a `get_public_timeline` RPC that requires the timeline's UUID, returns no `user_id`, and leaves table policies owner-only. Unshare revokes it.
+
+---
+
+## 4. Everything shipped
+
+**Security** — `ai_rate_limits` locked down; sign-in required for all server-funded AI; classify mode gated; rate limiter fails closed and is keyed to the user; CORS pinned to real origins; provider errors sanitised; `fetch-event-image` removed; plan flag moved to `app_metadata`; `search_path` pinned on `SECURITY DEFINER` functions; `xlsx` replaced.
+
+**Privacy & compliance** — `/privacy` and `/terms` pages describing the real data flows and sub-processors (Supabase, Netlify, Anthropic, OpenAI fallback, Wikimedia), linked from the footer and the sign-in modal; account deletion via a service-role function; viewer enrichment cache now evicts at 200 entries and clears on sign-out; security headers in `netlify.toml` (CSP, Referrer-Policy, frame-ancestors, nosniff, HSTS); `no-referrer` on Wikimedia images so `/view/<uuid>` capability URLs stop leaking.
+
+**Bug fixes found along the way** — the three above, plus: verification codes rejected as expired (the OTP input fired an attempt on every keystroke once six boxes were filled and never cleared them after a failure, so typing a fresh code over stale digits submitted five garbled ones first); Supabase's Email OTP Length was set to 8 while the UI accepts 6, meaning **nobody could sign in at all**; CSP blocked the app's own webfonts; CSV import silently dropped the first data row of non-template files (`slice(2)` on the header rows); the AIMode importer dropped malformed rows without reporting them.
+
+**Infrastructure** — edge functions now deploy from GitHub Actions; `supabase/config.toml` checked in; custom SMTP via Resend replacing Supabase's rate-limited built-in sender; 11 migrations applied (7 catching production up to the repo, 4 new).
+
+**Product decisions** — guest AI model changed to "sign-in + BYOK side door"; default timeline scale changed to `large`; enrichment budget raised from 5 to 30/day because descriptions auto-generate on opening an event.
+
+---
+
+## 5. The outage — post-mortem
+
+Deploying the hardened `generate-timeline` broke timeline generation for several hours. The browser reported *"Failed to send a request to the Edge Function"* — a fetch that never left the browser. It was diagnosed wrongly four times.
+
+| # | Theory | Why it was plausible | What disproved it |
+|---|---|---|---|
+| 1 | Mismatched `index.ts` / `_shared` files | The dashboard workflow makes partial updates easy, and the old `index.ts` imports `corsHeaders` while the new `cors.ts` exports only `corsHeadersFor` — a real incompatibility | An atomic CI deploy (#86) failed identically |
+| 2 | `x-session-token` missing from the allow-list | The pre-merge site sent that header on every request; tightening `Allow-Headers` had dropped it | Added in #85; still failed |
+| 3 | `verify_jwt` blocking the preflight | Genuinely true and worth fixing — the gateway rejects preflights, which carry no `Authorization` header, and replies without `content-type` | Disabled in #88; still failed |
+| 4 | Function crashing or unreachable | Logs showed `EarlyDrop` shutdown events | Preflight probe returned a clean `200` |
+
+**The actual cause:** the pre-review `cors.ts` used `Access-Control-Allow-Headers: "*"` and had worked for months. The rewrite replaced it with a hand-written list of five headers. supabase-js sends a header that wasn't on it, so the browser's preflight was refused and the request dropped before being sent.
+
+**Why it took so long:** the `curl` probe used to "prove" the preflight was healthy requested permission for exactly the five headers the code allowed. It proved the list matched itself. A hand-written `curl` can never reproduce this class of bug, because it only asks for headers you already thought of.
+
+**Fixed in #89** by reflecting `Access-Control-Request-Headers` back rather than maintaining a list of predictions.
+
+### Lessons
+
+1. **Don't tighten a request-side allow-list to match only what today's client sends.** Headers, origins, body fields — where the value isn't a real security control, prefer permissive or reflected values. A hand-written list makes the client's exact behaviour a deploy-time dependency, and the failure is invisible to server-side testing.
+2. **`curl` before the browser.** CORS is browser-only, so `curl` separates "the server is broken" from "the browser refused to send." Reaching for it earlier would have saved hours — but design the probe so it *can* fail, or it proves nothing.
+3. **Deploy server changes as one unit.** Hand-copying files across two systems in a particular order is not a deployment process.
+4. **Two pipelines finish at different moments.** Automation makes each side reliable, not simultaneous. Backwards compatibility has to come from the code.
+
+---
+
+## 6. Verified vs. unverified
+
+The verification pass was never completed — the outage consumed it. **Do not assume anything below the first list works.**
+
+**Confirmed working**
+- Timeline generation
+- Sign-in end to end (6-digit code, Resend, from `login@timeline.academy`)
+- CI function deploys (three green runs)
+- All 11 migrations applied without error
+- The CORS preflight (via `curl`)
+
+**Deployed but never exercised**
+- Sharing and unsharing end to end
+- Autosave persistence after the schema catch-up — *believed* fixed, never observed
+- AI event descriptions in the browser
+- The anonymous sign-in-or-BYOK gate
+- `/privacy` and `/terms` rendering
+- `set-byok-flag`
+- Security headers actually serving on production responses
+- The unfiltered `events` realtime subscription in `useEventUsage.ts` — a code comment asserts Supabase Realtime enforces RLS on `postgres_changes`; plausible, unverified
+
+**⚠️ `delete-account` — untested and destructive**
+
+It purges the user's timelines (events and categories cascade), then rate-limit rows, then the auth record via the admin API. If any step is wrong, a user gets a partial deletion — orphaned data, or an account that half-exists. This is the one untested path where being wrong is unrecoverable.
+
+**Test with a throwaway account before anyone can reach that button.** Afterwards confirm no rows survive in `timelines`, `events`, `timeline_categories`, `ai_rate_limits`, or `auth.users`.
+
+---
+
+## 7. Open items
+
+**Operational, with dates attached**
+
+- **Supabase access token expiry.** If a 30- or 90-day expiry was chosen when generating `SUPABASE_ACCESS_TOKEN`, CI stops deploying on that date with an opaque auth error — precisely the silent-drift failure this work exists to prevent. Record the expiry and diarise rotation.
+- **Second Supabase project.** Custom SMTP was configured there by mistake during setup and may still be able to send as `timeline.academy`. Disable it.
+- **Five unused Resend API keys**, three with full access, none ever used. Delete them.
+
+**Engineering**
+
+- **Migrations in CI** — the other half of the root cause. `supabase db push` would close it, but it needs the database password in secrets and a bad migration is far harder to undo than a bad function. Deserves its own careful sitting.
+- **No test framework.** Every check is manual, which is why the drift and the three broken features persisted. Worth weighing against the cost of the incidents above.
+- **Avenir never loads** — `index.css:81` points a `@font-face src` at a stylesheet URL. Fixing it changes typography across the whole interface, so it was deliberately deferred.
+
+**Non-engineering**
+
+- **Legal review of `/privacy` and `/terms`.** They describe the real data flows and sub-processors accurately, but they are engineering drafts.
+
+---
+
+## 8. Decisions worth not re-litigating
+
+- **Sign-in required for server-funded AI, with BYOK as the anonymous side door.** A pure-BYOK model was considered and rejected: it fails the mainstream educational audience (pasting an API key is a developer flow, not a student one) and would kill sharing and persistence entirely.
+- **Sharing is private by default.** Existing timelines were not grandfathered public — there was no record of which had ever been shared, and grandfathering would have meant exposing everything.
+- **Enrichment at 30/day**, not 5. Descriptions auto-generate when an event is opened, so a low budget makes the feature feel broken; each result is persisted, so it's a one-time cost per event.
+- **Default timeline scale `large`**, set across five places plus the column default.
+- **BYOK keys stay in localStorage**, disclosed in the UI. CSP is the mitigation, not re-architecture.
+- **No analytics, ever.** The absence of any tracking is the product's strongest privacy property.


### PR DESCRIPTION
Documentation only — no code touched, so the deploy workflow won't fire.

## `CLAUDE.md` — corrected and expanded

It had gone stale in ways that would actively mislead a new session:

| Was | Now |
|---|---|
| `services/` includes "session tokens" | `sessionToken.ts` was deleted with anonymous server-funded AI; lists the 8 real files incl. `wikipediaImage.ts` |
| 3 routes | Adds `/privacy` and `/terms` |
| No `Legal/` component folder | Added |
| `supabase/` = functions + migrations | Adds `config.toml`; names the 4 functions (`fetch-event-image` deleted) |
| "Custom fonts: Avenir, IBM Plex Mono" | Aleo / IBM Plex Mono / JetBrains Mono load from Google Fonts; **Avenir has never loaded** — `index.css:81` points a `@font-face src` at a stylesheet URL |
| "Netlify. SPA redirect." | Three independent deploy paths: site (Netlify), functions (GitHub Actions), migrations (**by hand**) |
| — | `exceljs` replaced `xlsx`; don't reintroduce it |

New sections: **Deployment**, **Critical operational rules**, **Access & data model**, **Known issues**, and server-side secrets in **Environment** (they live in Supabase, not in any file, and nothing in the repo said so).

The operational rules are the ones that cost a night: never hand-copy functions into the dashboard, never assume a migration was applied, keep `verify_jwt` false, don't "tighten" `_shared/cors.ts`, functions must accept both the current site and the previous one, and reach for `curl` before the browser.

## `docs/2026-08-05-security-review-handoff.md` — new

The full record: the `ai_rate_limits` exposure and what closed it (plus the audit confirming **no user data was ever exposed**); the three features silently broken in production for months and their shared root cause; everything shipped across #84–#89; and a post-mortem of the four wrong diagnoses during the generation outage — including why the `curl` probe that "proved" the preflight healthy was circular.

It also states plainly **which changes are verified and which are only deployed**. Most are the latter, because the outage consumed the verification pass. `delete-account` is untested and destructive; that's called out with a test procedure.

Section 7 lists open items with dates attached — the Supabase access token expiry that will silently stop CI, a second Supabase project that may still send email as this domain, and unused Resend keys.

## Verification

`npm run lint` and `npm run build` pass. Every path claimed in the Architecture block was checked against the filesystem, and both deleted files confirmed absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xdcnLgwEaAaiV7SUaZFyo

---
_Generated by [Claude Code](https://claude.ai/code/session_014xdcnLgwEaAaiV7SUaZFyo)_