### PR TITLE
Animate only year-boundary lines on horizontal scroll

### DIFF
--- a/src/TIMELINE_ARCHITECTURE.md
+++ b/src/TIMELINE_ARCHITECTURE.md
@@ -252,9 +252,9 @@ The displayed year is `months[Math.max(0, Math.floor(visibleRange.start / 4))]?.
 
 `TimelineVerticalLines.tsx` overlays a vertical line at every month boundary plus a trailing edge. The component is `aria-hidden`, `pointer-events-none`, and absolute-positioned to fill its parent.
 
-For each month index `i`, a `<span>` is placed at `left: i * scale.monthWidth` with class `bg-line-year-boundary` if its left-side neighbor is December, else `bg-line-default`. A trailing `<span>` is placed at `left: months.length * scale.monthWidth`.
+For each month index `i`, a `<span>` is placed at `left: i * scale.monthWidth` with class `bg-line-year-boundary` if its left-side neighbor is December, else `bg-line-default`. A trailing `<span>` is placed at `left: months.length * scale.monthWidth`. Year-boundary spans additionally get `timeline-vertical-line-reveal`, which is what opts them into the reveal animation — the same `isYearBoundary` test drives both the color and the animation, so the two can never disagree.
 
-Reveal animation: an `IntersectionObserver` rooted on the scroll container marks each line `data-revealed="true"` the first time it intersects the viewport (the CSS for `.timeline-vertical-line[data-revealed]` handles the reveal). When `window.matchMedia('(prefers-reduced-motion: reduce)').matches`, every line is revealed immediately and the observer is skipped.
+Reveal animation (year-boundary lines only): month lines are full height from first paint and are given no ref, no `data-line-key` and no observer entry. An `IntersectionObserver` rooted on the scroll container marks each year-boundary line `data-revealed="true"` the first time it intersects the viewport; `.timeline-vertical-line-reveal:not([data-revealed="true"])` holds it at `height: 0` until then, and the `height` leg of the base rule's `transition` draws it downward. That transition leg is inert for month lines — their computed height stays the token `100%` and never changes. When `window.matchMedia('(prefers-reduced-motion: reduce)').matches`, every reveal-eligible line is revealed immediately and the observer is skipped.
 
 The observer effect re-runs only when the months range key (`first..last`) or the scroll container ref changes — scale changes are handled by CSS transitions, not a new observer.
 

--- a/src/components/Timeline/TimelineVerticalLines.tsx
+++ b/src/components/Timeline/TimelineVerticalLines.tsx
@@ -99,14 +99,19 @@ export function TimelineVerticalLines({
         // neighbor is December.
         const prev = i > 0 ? months[i - 1] : null;
         const isYearBoundary = prev?.month === 11;
+        // Only year-boundary lines take part in the scroll-in reveal, so only
+        // they need a ref, a data-line-key and an observer entry. Month lines
+        // render at full height and are left alone.
         return (
           <span
             key={key}
-            ref={setSpanRef(key)}
-            data-line-key={key}
-            className={`timeline-vertical-line ${
-              isYearBoundary ? 'bg-line-year-boundary' : 'bg-line-default'
-            }`}
+            ref={isYearBoundary ? setSpanRef(key) : undefined}
+            data-line-key={isYearBoundary ? key : undefined}
+            className={
+              isYearBoundary
+                ? 'timeline-vertical-line timeline-vertical-line-reveal bg-line-year-boundary'
+                : 'timeline-vertical-line bg-line-default'
+            }
             style={{ left: `${i * scale.monthWidth}px` }}
           />
         );
@@ -117,11 +122,13 @@ export function TimelineVerticalLines({
         return (
           <span
             key={TRAILING_EDGE_KEY}
-            ref={setSpanRef(TRAILING_EDGE_KEY)}
-            data-line-key={TRAILING_EDGE_KEY}
-            className={`timeline-vertical-line ${
-              trailingIsYearBoundary ? 'bg-line-year-boundary' : 'bg-line-default'
-            }`}
+            ref={trailingIsYearBoundary ? setSpanRef(TRAILING_EDGE_KEY) : undefined}
+            data-line-key={trailingIsYearBoundary ? TRAILING_EDGE_KEY : undefined}
+            className={
+              trailingIsYearBoundary
+                ? 'timeline-vertical-line timeline-vertical-line-reveal bg-line-year-boundary'
+                : 'timeline-vertical-line bg-line-default'
+            }
             style={{ left: `${months.length * scale.monthWidth}px` }}
           />
         );

--- a/src/index.css
+++ b/src/index.css
@@ -241,11 +241,19 @@
     position: absolute;
     top: 0;
     width: 1px;
-    height: 0;
+    height: 100%;
     transition: left 200ms ease-in-out, height 400ms ease-out 200ms;
   }
 
-  .timeline-vertical-line[data-revealed="true"] {
-    height: 100%;
+  /* Only year-boundary lines draw downward as they scroll into view; month
+     lines are full height from first paint. The `:not()` gives this rule
+     specificity (0,2,0) against the base rule's (0,1,0), so it wins on
+     specificity rather than source order — Tailwind rewrites this @layer
+     block at build time and author order inside it is not contractual.
+     The `height` transition leg above is inert for month lines: their
+     computed height stays the token `100%` and never changes, and a parent
+     resize alters only the used value, which does not start a transition. */
+  .timeline-vertical-line-reveal:not([data-revealed="true"]) {
+    height: 0;
   }
 }


### PR DESCRIPTION
## What

Every vertical grid line played the draw-down reveal as it scrolled into view — 12 per year — which read as noise rather than as passing year markers. This restricts the reveal to the brighter year-boundary lines. The dimmer month lines now render at their full height from first paint and never animate.

The animation itself is unchanged: 400ms ease-out with a 200ms delay, revealed once per line by the existing `IntersectionObserver`, still drawing in on initial load. It simply becomes opt-in, via a new `timeline-vertical-line-reveal` class that only year-boundary spans carry.

## How

**`src/index.css`** — the base `.timeline-vertical-line` rule flips from `height: 0` to `height: 100%`, and a new rule holds year lines collapsed until revealed:

```css
.timeline-vertical-line-reveal:not([data-revealed="true"]) { height: 0; }
```

Two deliberate choices here, both about not creating a silent regression:

- **`:not()` instead of a plain modifier class.** It gives the rule specificity `(0,2,0)` against the base rule's `(0,1,0)`, so it wins on specificity rather than source order. These rules live inside `@layer utilities`, which Tailwind rewrites at build time — author order inside it is not contractual, and an order dependency would fail with no build error.
- **The `transition` shorthand stays whole in the base rule.** Splitting the height leg out would pit two equal-specificity `transition` declarations against each other, resolvable *only* by source order, with no attribute selector available to break the tie. The height leg is provably inert for month lines anyway: their computed height stays the token `100%` and never changes, and a parent resize alters only the *used* value, which does not start a transition. This is verified empirically below.

**`src/components/Timeline/TimelineVerticalLines.tsx`** — the existing `isYearBoundary` test now drives the class, the ref and the `data-line-key`, so color and animation can never disagree. Month spans get no ref, no `data-line-key` and no observer entry. Since `setSpanRef` returns a fresh closure each render, React was detaching and reattaching every ref on every re-render of a component that re-renders on scroll; that churn drops by ~12x.

The reveal machinery itself (lines 30–87 — the observer, `revealedKeys`, `setSpanRef`, the reduced-motion escape hatch) is untouched. It simply has a smaller, correct input set.

**`src/TIMELINE_ARCHITECTURE.md`** — the "Vertical Lines" section updated to match.

This lands on both the editor and the viewer, which share the one `Timeline` component. That's intended.

## Verification

No test framework exists in this repo, so this was verified against a headless Chromium driving the real dev server and the real production CSS bundle.

`npm run lint` clean. `npx tsc --noEmit` clean — note `npm run build` is bare `vite build` and does **not** typecheck, so this was run separately. `npm run build` clean, and the new class confirmed present in the emitted bundle (Tailwind purges unused `@layer utilities` rules, so a class name assembled from fragments would have been silently dropped from production while working in dev).

Against the built stylesheet, 11/11 assertions passed, including:
- month line full height at first paint; year line collapsed
- year line still collapsed during the 200ms delay, mid-draw at ~420ms, full height after
- **month line fires zero `height` transition events on a parent resize** — the inert-leg claim, confirmed rather than assumed
- colors unchanged on both line types

In the live editor, 6/6 further assertions passed. The rendered grid gave 11 year lines and 122 month lines (a ratio of 11.09, matching whole-year emission); every month line held a single 480px height with no partial draws; scrolling right raised revealed year lines from 2 to 5 while month heights stayed constant; and under `prefers-reduced-motion: reduce` all 11 year lines revealed immediately with the observer skipped.

## Note

The leftmost line (index 0) is a January edge but is colored as a month line, because `isYearBoundary` tests whether the *left-hand* neighbor is December and index 0 has none. Left as-is: tying the animation to the existing flag keeps motion and color in agreement, so it stays dim *and* static rather than becoming a dim line that animates. It sits three years deep in the scroll padding and is effectively never seen. Happy to fix separately if wanted.

---
_Generated by [Claude Code](https://claude.ai/code/session_0145NvkAPiV5MgJ4gQbLNsU8)_