### PR TITLE
Fix the left panel: bind the open timeline to its contents, and make guest drafts visible

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { Header } from './components/Layout/Header';
 import { GlobalNav } from '@/components/Navigation/GlobalNav';
 import { Timeline } from './components/Timeline/Timeline';
 import { useTimelineState } from './hooks/useTimelineState';
-import { useTimeline } from './hooks/useTimeline';
+import { useTimeline, type TimelineData } from './hooks/useTimeline';
 import { useAuth } from './hooks/useAuth';
 import { useAutosave } from './hooks/useAutosave';
 import { useSidePanel } from './hooks/useSidePanel';
@@ -34,8 +34,8 @@ export function App() {
     verticalScale, currentVerticalScale, handleVerticalScaleChange,
     groupByCategory, handleGroupByCategoryChange,
   } = useTimelineState();
-  const { user } = useAuth();
-  const { saveTimeline, timelineId, loadTimeline, error: timelineError, retryInitialLoad } = useTimeline();
+  const { user, authReady } = useAuth();
+  const { getMostRecentTimelineId, createTimelineFrom, loadTimeline } = useTimeline();
   const location = useLocation();
   const routerNavigate = useNavigate();
   const [pendingSwitchTimelineId, setPendingSwitchTimelineId] = useState<string | null>(null);
@@ -48,12 +48,25 @@ export function App() {
   const [draftHydrated, setDraftHydrated] = useState(false);
   const [activeDraftId, setActiveDraftId] = useState<string | null>(null);
   const { loadAllDrafts, loadDraft, saveDraft, createDraft, clearAllDrafts, deleteDraft: deleteLocalDraft } = useLocalDraft();
-  const handledRouteStateRef = useRef(false);
+  // Which timeline's contents are actually in the editor right now. This is the
+  // only id the app may act on — autosave, Share and Delete all key off it.
+  // It is written in exactly one place: applyLoadedTimeline().
+  const [loadedTimelineId, setLoadedTimelineId] = useState<string | null>(null);
+  const [bootstrapError, setBootstrapError] = useState<string | null>(null);
+  const [bootstrapAttempt, setBootstrapAttempt] = useState(0);
+  // Latches the location we've already acted on. A boolean here meant the
+  // second navigation into an already-mounted /editor was ignored outright,
+  // which is what made "Create a Timeline" and "Import Data" no-ops.
+  const handledRouteStateRef = useRef<string | null>(null);
+  // Set once the editor has been given something to display, by either the
+  // route-state effect or the no-route-state bootstrap, so the two can't both
+  // claim the mount.
+  const editorSeededRef = useRef(false);
   const migrationDoneRef = useRef(false);
   const { setOnTimelineSelect, setOnDraftSelect, refreshTimelines, setOnOpenSettings, setActiveTimelineId, setActiveDraftId: setPanelActiveDraftId, setActiveTimelineTitle, setActiveEventCount, setActiveDominantCategoryColor } = useSidePanel();
 
   const timelineData = {
-    id: timelineId,
+    id: loadedTimelineId,
     title,
     description,
     events,
@@ -63,7 +76,7 @@ export function App() {
     groupByCategory,
   };
 
-  const { saveStatus, lastSavedTime, handleChange } = useAutosave(timelineData);
+  const { saveStatus, lastSavedTime, handleChange, flushPendingSave, cancelPendingSave } = useAutosave(timelineData);
 
   const handleAddEventClick = () => {
     setActivePanel(null);
@@ -76,11 +89,16 @@ export function App() {
     [events, categories],
   );
 
-  // Trigger autosave when timeline data changes
+  // Trigger autosave when timeline data changes.
+  //
+  // `loadedTimelineId` is null until a timeline's contents are actually in the
+  // editor, so this can no longer fire with a real id next to another
+  // timeline's (or the default empty) contents — which is what let a save
+  // rename a timeline and diff-delete all of its events.
   useEffect(() => {
-    if (timelineId) {
+    if (loadedTimelineId) {
       handleChange({
-        id: timelineId,
+        id: loadedTimelineId,
         title,
         description,
         events,
@@ -90,11 +108,16 @@ export function App() {
         groupByCategory,
       });
     }
-  }, [timelineId, title, description, events, categories, currentScale.value, currentVerticalScale.value, groupByCategory, handleChange]);
+  }, [loadedTimelineId, title, description, events, categories, currentScale.value, currentVerticalScale.value, groupByCategory, handleChange]);
 
-  // Hydrate from localStorage draft if logged out
+  // Hydrate from localStorage draft if logged out.
+  //
+  // Gated on `authReady`: `user` is null both before the session lookup answers
+  // and when the user is genuinely signed out, so without this every hard
+  // refresh of /editor ran the logged-out path first — hydrating a stale draft
+  // and clearing `location.state` before the signed-in effect below could read it.
   useEffect(() => {
-    if (!user && !draftHydrated) {
+    if (authReady && !user && !draftHydrated) {
       const routeState = location.state as {
         newTimeline?: boolean;
         skipCreationScreen?: boolean;
@@ -208,7 +231,7 @@ export function App() {
       // Clear the route state so refreshing doesn't re-trigger
       routerNavigate('/editor', { replace: true, state: {} });
     }
-  }, [user, draftHydrated, createDraft, handleScaleChange, handleVerticalScaleChange, handleGroupByCategoryChange, loadAllDrafts, loadDraft, location.state, routerNavigate, setDescription, setEvents, setTitle, updateCategories]);
+  }, [authReady, user, draftHydrated, createDraft, handleScaleChange, handleVerticalScaleChange, handleGroupByCategoryChange, loadAllDrafts, loadDraft, location.state, routerNavigate, setDescription, setEvents, setTitle, updateCategories]);
 
   // Save to localStorage when logged out
   useEffect(() => {
@@ -239,7 +262,7 @@ export function App() {
       (async () => {
         for (const draft of draftsWithEvents) {
           try {
-            await saveTimeline(draft.title, draft.events, draft.scale, draft.verticalScale ?? 'medium');
+            await createTimelineFrom(draft.title, draft.events, draft.scale, draft.verticalScale ?? 'medium');
           } catch (err: unknown) {
             if (err instanceof LimitReachedError) {
               alert(
@@ -258,33 +281,47 @@ export function App() {
       clearAllDrafts();
       setActiveDraftId(null);
     }
-  }, [user, draftHydrated, clearAllDrafts, loadAllDrafts, saveTimeline]);
+  }, [user, draftHydrated, clearAllDrafts, loadAllDrafts, createTimelineFrom]);
+
+  /**
+   * The one and only writer of the editor's contents *and* of the id those
+   * contents belong to. Every setter plus `setLoadedTimelineId` runs in a
+   * single synchronous block, so React 18 commits them together and no render
+   * — and therefore no autosave — can ever observe one timeline's id beside
+   * another timeline's data.
+   *
+   * If you add a field to the editor, add it here too: anything set outside
+   * this function reopens the desync this exists to prevent.
+   */
+  const applyLoadedTimeline = useCallback((data: TimelineData) => {
+    setTitle(data.title);
+    setDescription(data.description || '');
+    setEvents(data.events);
+    if (data.categories) {
+      updateCategories(data.categories);
+    } else {
+      resetCategories();
+    }
+    handleScaleChange(data.scale || 'medium');
+    handleVerticalScaleChange(data.verticalScale ?? 'small');
+    handleGroupByCategoryChange(data.groupByCategory ?? false);
+    setLoadedTimelineId(data.id);
+  }, [setTitle, setDescription, setEvents, updateCategories, resetCategories, handleScaleChange, handleVerticalScaleChange, handleGroupByCategoryChange]);
 
   const switchTimeline = useCallback(async (newTimelineId: string) => {
     try {
-      // Load new data first — don't clear state until we have the replacement
-      const {
-        title: newTitle,
-        description: newDescription,
-        events: newEvents,
-        categories: newCategories,
-        scale: newScale,
-        verticalScale: newVerticalScale,
-        groupByCategory: newGroupByCategory,
-      } = await loadTimeline(newTimelineId);
+      // Commit anything still pending for the outgoing timeline before its
+      // contents are replaced. The debounced save holds a snapshot of its
+      // arguments, and the next edit would overwrite them — silently dropping
+      // the last couple of seconds of work on the timeline we're leaving.
+      await flushPendingSave();
 
-      // Only update state after successful load
-      setTitle(newTitle);
-      setDescription(newDescription || '');
-      setEvents(newEvents);
-      if (newCategories) {
-        updateCategories(newCategories);
-      } else {
-        resetCategories();
-      }
-      handleScaleChange(newScale || 'medium');
-      handleVerticalScaleChange(newVerticalScale ?? 'small');
-      handleGroupByCategoryChange(newGroupByCategory ?? false);
+      // Load new data first — don't clear state until we have the replacement
+      const data = await loadTimeline(newTimelineId);
+
+      // Only update state after a successful load, and via the single
+      // atomic writer so the id and the contents can't drift apart.
+      applyLoadedTimeline(data);
     } catch (error) {
       console.error('Error switching timeline:', error);
       // `.single()` returns PGRST116 when the row doesn't exist — that's the
@@ -292,13 +329,19 @@ export function App() {
       // on home quietly rather than stranding them in /editor with an alert.
       const code = (error as { code?: string } | null)?.code;
       if (code === 'PGRST116') {
-        setActiveTimelineId(null);
+        setLoadedTimelineId(null);
         routerNavigate('/', { replace: true });
+        return;
+      }
+      // Creating a timeline goes through here too ('new'), so the plan cap is
+      // a normal outcome — telling the user to retry would be a lie.
+      if (error instanceof LimitReachedError) {
+        alert(limitReachedMessage(error.kind));
         return;
       }
       alert('Failed to load timeline. Please try again.');
     }
-  }, [loadTimeline, setTitle, setDescription, setEvents, updateCategories, resetCategories, handleScaleChange, handleVerticalScaleChange, handleGroupByCategoryChange, routerNavigate, setActiveTimelineId]);
+  }, [flushPendingSave, loadTimeline, applyLoadedTimeline, routerNavigate]);
 
   // Handle navigation from AI mode or the side panel with a specific timeline to load
   useEffect(() => {
@@ -313,10 +356,21 @@ export function App() {
       };
       importedEvents?: TimelineEvent[];
     } | null;
-    if (!user || handledRouteStateRef.current) return;
+    if (!authReady || !user) return;
+
+    // Latch on the location itself, not a boolean. /editor → /editor doesn't
+    // remount App, so a once-per-mount flag made every navigation after the
+    // first a silent no-op — "Create a Timeline", "Import Data" and a second
+    // hand-off from AI mode all did nothing at all.
+    //
+    // Recorded unconditionally, and only after the auth guard: the state:{}
+    // replacements below mint a fresh key, and that pass needs latching too,
+    // while an early pass with no user yet must not consume the real key.
+    if (handledRouteStateRef.current === location.key) return;
+    handledRouteStateRef.current = location.key;
 
     if (state?.importedEvents) {
-      handledRouteStateRef.current = true;
+      editorSeededRef.current = true;
       const imported = state.importedEvents;
       (async () => {
         await switchTimeline('new');
@@ -328,11 +382,11 @@ export function App() {
       })();
       routerNavigate('/editor', { replace: true, state: {} });
     } else if (state?.aiGenerated) {
-      handledRouteStateRef.current = true;
+      editorSeededRef.current = true;
       const aiData = state.aiGenerated;
       (async () => {
-        // Creates the timeline row in Supabase and sets timelineId so autosave
-        // will persist subsequent state updates to the new row.
+        // Creates the timeline row in Supabase and binds the editor to it, so
+        // autosave persists the state updates below to the new row.
         await switchTimeline('new');
         setTitle(aiData.title);
         setDescription(aiData.description);
@@ -345,7 +399,7 @@ export function App() {
       })();
       routerNavigate('/editor', { replace: true, state: {} });
     } else if (state?.timelineId) {
-      handledRouteStateRef.current = true;
+      editorSeededRef.current = true;
       if (state.timelineId === 'new' && state.skipCreationScreen) {
         switchTimeline('new');
       } else if (state.timelineId === 'new') {
@@ -357,7 +411,48 @@ export function App() {
       }
       routerNavigate('/editor', { replace: true, state: {} });
     }
-  }, [location.state, user, routerNavigate, setDescription, setEvents, setTitle, switchTimeline, updateCategories]);
+  }, [location.state, location.key, authReady, user, routerNavigate, setDescription, setEvents, setTitle, switchTimeline, updateCategories]);
+
+  // Signed in, on /editor, with nothing in the route state telling us what to
+  // show — a bookmark, a refresh, or the browser back button.
+  //
+  // Previously nothing loaded here at all: `useTimeline` just pointed itself at
+  // an arbitrary row on mount while the editor still held its empty defaults,
+  // and autosave then wrote those defaults over that row. Now the id only ever
+  // arrives attached to the data it names, via switchTimeline.
+  useEffect(() => {
+    if (!authReady || !user || editorSeededRef.current) return;
+
+    const state = location.state as {
+      timelineId?: string;
+      aiGenerated?: unknown;
+      importedEvents?: unknown;
+    } | null;
+    // The effect above owns these; it runs first and will set the seed flag.
+    if (state?.timelineId || state?.aiGenerated || state?.importedEvents) return;
+
+    editorSeededRef.current = true;
+    (async () => {
+      try {
+        const mostRecentId = await getMostRecentTimelineId();
+        if (mostRecentId) {
+          await switchTimeline(mostRecentId);
+        } else {
+          // Nothing to open — send them to the AI entry point to make one.
+          routerNavigate('/', { replace: true });
+        }
+      } catch (err) {
+        console.error('Failed to open a timeline:', err);
+        setBootstrapError('Failed to load your timelines. Please try again.');
+      }
+    })();
+  }, [authReady, user, location.state, bootstrapAttempt, getMostRecentTimelineId, switchTimeline, routerNavigate]);
+
+  const retryBootstrap = () => {
+    setBootstrapError(null);
+    editorSeededRef.current = false;
+    setBootstrapAttempt(n => n + 1);
+  };
 
   const handleTimelineSwitch = async (newTimelineId: string) => {
     if (newTimelineId === 'new') {
@@ -367,12 +462,14 @@ export function App() {
 
     // Dedup: if the user clicked the tile for the timeline that's already
     // loaded, there's nothing to switch to — skip the refetch.
-    if (newTimelineId === timelineId) {
+    //
+    // Compared against the *loaded* id specifically. When this compared against
+    // a separate pointer, a desynced pointer made the tile it named permanently
+    // unclickable: the guard matched, so its contents never loaded.
+    if (newTimelineId === loadedTimelineId) {
       return;
     }
 
-    // Switch immediately; any in-flight autosave captured its own snapshot
-    // (via debounce) and will still commit the outgoing timeline's data.
     await switchTimeline(newTimelineId);
   };
 
@@ -440,9 +537,9 @@ export function App() {
   // synchronously with the editor's render. Cleanup clears it on unmount so
   // non-editor routes (e.g. AI mode) don't show a stale highlight.
   useLayoutEffect(() => {
-    setActiveTimelineId(timelineId);
+    setActiveTimelineId(loadedTimelineId);
     return () => setActiveTimelineId(null);
-  }, [timelineId, setActiveTimelineId]);
+  }, [loadedTimelineId, setActiveTimelineId]);
 
   useLayoutEffect(() => {
     setPanelActiveDraftId(activeDraftId);
@@ -473,12 +570,20 @@ export function App() {
   };
 
   const handleDeleteTimeline = async () => {
+    // Drop any queued save before the row goes away. This is the one case where
+    // cancelling beats flushing: the editor now flushes on unmount, and
+    // navigating away below would otherwise re-insert the events we just
+    // deleted. Unbinding the editor is what makes that flush a no-op.
+    cancelPendingSave();
+    const deletingId = loadedTimelineId;
+    setLoadedTimelineId(null);
+
     try {
-      if (user && timelineId) {
+      if (user && deletingId) {
         const { error: deleteError } = await supabase
           .from('timelines')
           .delete()
-          .eq('id', timelineId);
+          .eq('id', deletingId);
         if (deleteError) throw deleteError;
       } else if (activeDraftId) {
         deleteLocalDraft(activeDraftId);
@@ -530,7 +635,7 @@ export function App() {
     <div className="app-container h-screen bg-black text-white overflow-hidden flex flex-col">
       <GlobalNav
         variant="timeline"
-        timelineId={timelineId}
+        timelineId={loadedTimelineId}
         timelineTitle={title}
         onTimelineTitleChange={setTitle}
         events={events}
@@ -569,12 +674,12 @@ export function App() {
         onDeleteTimeline={handleDeleteTimeline}
         mode={mode}
       />
-      {timelineError ? (
+      {bootstrapError ? (
         <div className="flex-1 flex items-center justify-center py-20">
           <div className="bg-gray-800 p-6 rounded-lg shadow-xl max-w-md w-full text-center">
-            <p className="text-red-400 mb-4">{timelineError}</p>
+            <p className="text-red-400 mb-4">{bootstrapError}</p>
             <button
-              onClick={retryInitialLoad}
+              onClick={retryBootstrap}
               className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition-colors"
             >
               Retry

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,7 @@ export function App() {
   const [pendingScrollDate, setPendingScrollDate] = useState<string | null>(null);
   const [draftHydrated, setDraftHydrated] = useState(false);
   const [activeDraftId, setActiveDraftId] = useState<string | null>(null);
-  const { loadAllDrafts, loadDraft, saveDraft, createDraft, clearAllDrafts, deleteDraft: deleteLocalDraft } = useLocalDraft();
+  const { loadAllDrafts, loadDraft, saveDraft, flushDraftSave, createDraft, clearAllDrafts, deleteDraft: deleteLocalDraft } = useLocalDraft();
   // Which timeline's contents are actually in the editor right now. This is the
   // only id the app may act on — autosave, Share and Delete all key off it.
   // It is written in exactly one place: applyLoadedTimeline().
@@ -58,6 +58,10 @@ export function App() {
   // second navigation into an already-mounted /editor was ignored outright,
   // which is what made "Create a Timeline" and "Import Data" no-ops.
   const handledRouteStateRef = useRef<string | null>(null);
+  // Same latch, for the logged-out effect. Guests take a completely separate
+  // route-state path ({newTimeline} rather than {timelineId}), so it needs its
+  // own — sharing one would let whichever effect ran first swallow the key.
+  const handledDraftRouteKeyRef = useRef<string | null>(null);
   // Set once the editor has been given something to display, by either the
   // route-state effect or the no-route-state bootstrap, so the two can't both
   // claim the mount.
@@ -117,7 +121,7 @@ export function App() {
   // refresh of /editor ran the logged-out path first — hydrating a stale draft
   // and clearing `location.state` before the signed-in effect below could read it.
   useEffect(() => {
-    if (authReady && !user && !draftHydrated) {
+    if (authReady && !user) {
       const routeState = location.state as {
         newTimeline?: boolean;
         skipCreationScreen?: boolean;
@@ -131,6 +135,32 @@ export function App() {
         };
         importedEvents?: TimelineEvent[];
       } | null;
+
+      // Two different guards, because there are two different questions here.
+      //
+      // When the route state carries an instruction, latch on location.key like
+      // the signed-in effect does — /editor → /editor doesn't remount App, so
+      // the old once-per-mount boolean made every later "Create a Timeline"
+      // click a silent no-op for guests.
+      //
+      // When it doesn't, we're bootstrapping the editor from whatever's in
+      // storage, and that must happen only once per mount: the state:{} reset
+      // at the end of this effect mints a fresh key, and re-running the
+      // bootstrap on it would re-hydrate over the draft just created — and over
+      // anything the user has typed since.
+      const hasRouteInstruction = !!(
+        routeState?.importedEvents ||
+        routeState?.aiGenerated ||
+        (routeState?.newTimeline && routeState.skipCreationScreen) ||
+        routeState?.draftId
+      );
+
+      if (hasRouteInstruction) {
+        if (handledDraftRouteKeyRef.current === location.key) return;
+        handledDraftRouteKeyRef.current = location.key;
+      } else if (draftHydrated) {
+        return;
+      }
 
       if (routeState?.importedEvents) {
         const newDraft = createDraft();
@@ -190,6 +220,9 @@ export function App() {
         updateCategories(newDraft.categories);
         handleScaleChange(newDraft.scale);
         handleVerticalScaleChange(newDraft.verticalScale ?? 'medium');
+        // Reset grouping too, or the previous draft's setting leaks into this
+        // brand-new one — the sibling branches below already do this.
+        handleGroupByCategoryChange(newDraft.groupByCategory ?? false);
       } else if (routeState?.draftId) {
         // Resuming a local draft (e.g. from the side panel)
         const draft = loadDraft(routeState.draftId);
@@ -231,7 +264,23 @@ export function App() {
       // Clear the route state so refreshing doesn't re-trigger
       routerNavigate('/editor', { replace: true, state: {} });
     }
-  }, [authReady, user, draftHydrated, createDraft, handleScaleChange, handleVerticalScaleChange, handleGroupByCategoryChange, loadAllDrafts, loadDraft, location.state, routerNavigate, setDescription, setEvents, setTitle, updateCategories]);
+  }, [authReady, user, draftHydrated, createDraft, handleScaleChange, handleVerticalScaleChange, handleGroupByCategoryChange, loadAllDrafts, loadDraft, location.state, location.key, routerNavigate, setDescription, setEvents, setTitle, updateCategories]);
+
+  // Guest drafts save on a 500 ms debounce, so a rename followed immediately by
+  // closing the tab or navigating away would be lost — the draft path has no
+  // equivalent of the signed-in beforeunload guard, because `hasUnsavedChanges`
+  // is never set for it. localStorage writes are synchronous, so flushing from
+  // an unload handler reliably commits.
+  useEffect(() => {
+    const flush = () => flushDraftSave();
+    window.addEventListener('beforeunload', flush);
+    window.addEventListener('pagehide', flush);
+    return () => {
+      window.removeEventListener('beforeunload', flush);
+      window.removeEventListener('pagehide', flush);
+      flush();
+    };
+  }, [flushDraftSave]);
 
   // Save to localStorage when logged out
   useEffect(() => {
@@ -478,6 +527,12 @@ export function App() {
     if (newDraftId === activeDraftId) {
       return;
     }
+    // Commit the outgoing draft's pending save before its contents are replaced.
+    // Without this the debounced call's arguments are overwritten by the
+    // incoming draft's snapshot and the last <500 ms of edits are dropped —
+    // the same hazard switchTimeline flushes for on the signed-in path.
+    flushDraftSave();
+
     const draft = loadDraft(newDraftId);
     if (!draft) {
       console.error('Draft not found:', newDraftId);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,7 +80,7 @@ export function App() {
     groupByCategory,
   };
 
-  const { saveStatus, lastSavedTime, handleChange, flushPendingSave, cancelPendingSave } = useAutosave(timelineData);
+  const { saveStatus, lastSavedTime, handleChange, markClean, flushPendingSave, cancelPendingSave } = useAutosave(timelineData);
 
   const handleAddEventClick = () => {
     setActivePanel(null);
@@ -348,19 +348,41 @@ export function App() {
    * this function reopens the desync this exists to prevent.
    */
   const applyLoadedTimeline = useCallback((data: TimelineData) => {
+    // Normalise ONCE and feed the same values to both the setters and
+    // markClean. `useTimeline`'s TimelineData has these optional while
+    // autosave's has them required, and this is where the two meet — if the
+    // baseline were taken from the raw payload while the editor got the
+    // normalised one, every load would look dirty and write itself back.
+    const description = data.description || '';
+    const scale = data.scale || 'medium';
+    const verticalScale = data.verticalScale ?? 'small';
+    const groupByCategory = data.groupByCategory ?? false;
+
+    // First, before any setter, so no ordering of effects can let the autosave
+    // effect see this content while the baseline still describes the last one.
+    markClean({
+      id: data.id,
+      title: data.title,
+      description,
+      events: data.events,
+      scale,
+      verticalScale,
+      groupByCategory,
+    });
+
     setTitle(data.title);
-    setDescription(data.description || '');
+    setDescription(description);
     setEvents(data.events);
     if (data.categories) {
       updateCategories(data.categories);
     } else {
       resetCategories();
     }
-    handleScaleChange(data.scale || 'medium');
-    handleVerticalScaleChange(data.verticalScale ?? 'small');
-    handleGroupByCategoryChange(data.groupByCategory ?? false);
+    handleScaleChange(scale);
+    handleVerticalScaleChange(verticalScale);
+    handleGroupByCategoryChange(groupByCategory);
     setLoadedTimelineId(data.id);
-  }, [setTitle, setDescription, setEvents, updateCategories, resetCategories, handleScaleChange, handleVerticalScaleChange, handleGroupByCategoryChange]);
+  }, [markClean, setTitle, setDescription, setEvents, updateCategories, resetCategories, handleScaleChange, handleVerticalScaleChange, handleGroupByCategoryChange]);
 
   const switchTimeline = useCallback(async (newTimelineId: string) => {
     try {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -271,7 +271,12 @@ export function App() {
   // equivalent of the signed-in beforeunload guard, because `hasUnsavedChanges`
   // is never set for it. localStorage writes are synchronous, so flushing from
   // an unload handler reliably commits.
-  useEffect(() => {
+  //
+  // useLayoutEffect, and declared above the side-panel pushes below, so that on
+  // unmount this cleanup runs *before* they null `activeDraftId`. That null is
+  // what makes the panel re-read localStorage; flushing afterwards would mean it
+  // re-read stale data and nothing ever corrected it.
+  useLayoutEffect(() => {
     const flush = () => flushDraftSave();
     window.addEventListener('beforeunload', flush);
     window.addEventListener('pagehide', flush);

--- a/src/TIMELINE_ARCHITECTURE.md
+++ b/src/TIMELINE_ARCHITECTURE.md
@@ -684,13 +684,53 @@ editor content outside `applyLoadedTimeline` reopens the bug.
 ### Save flow
 
 1. User makes a change (event edit, drag, rename, scale toggle, group toggle, etc.).
-2. `useAutosave.handleChange(data)` sets `saveStatus = 'saving'`, marks `hasUnsavedChanges`, and starts a 2000 ms debounce. `App.tsx` only calls it when `loadedTimelineId` is non-null, so a save can never target a timeline the editor hasn't loaded.
+2. `useAutosave.handleChange(data)` fingerprints the payload and **returns immediately if nothing changed** (see below). Otherwise it sets `saveStatus = 'saving'`, marks `hasUnsavedChanges`, and starts a 2000 ms debounce. `App.tsx` only calls it when `loadedTimelineId` is non-null, so a save can never target a timeline the editor hasn't loaded.
 3. After the debounce fires, `save(data)`:
    - `UPDATE` the `timelines` row (title, description, scale, group_by_category, updated_at).
    - `saveTimelineEvents(timelineId, events)` performs a diff-based sync: classifies each event as INSERT / UPDATE / DELETE relative to the server, then executes UPDATE → INSERT → DELETE. INSERT precedes DELETE deliberately: these are separate HTTP calls, not one transaction, so a mismatched client array fails the INSERT on a duplicate primary key *before* anything has been deleted.
 4. On success: `saveStatus = 'saved'`, `lastSavedTime = now`, `hasUnsavedChanges = false`.
 5. On failure: `saveStatus = 'error'`. A `window.online` listener retries `save(timelineData)` when the browser comes back online.
 6. A `beforeunload` listener fires `e.preventDefault()` while `hasUnsavedChanges` is true, prompting the browser's "leave site?" dialog.
+
+### Dirty tracking — why opening a timeline must not write
+
+`applyLoadedTimeline` sets the exact state the autosave effect watches, so applying
+freshly fetched data used to look identical to a user edit: opening any timeline
+rewrote its row ~2 s later with byte-identical data. Because `timelines.updated_at` is
+the side panel's sort key — and `useAutosave` is its only writer, there is no DB
+trigger — merely *looking* at a timeline moved it to the top of the list. It also ran
+the full `saveTimelineEvents` diff (an events SELECT) and armed the browser's "Leave
+site?" prompt, both for nothing.
+
+`src/utils/timelineFingerprint.ts` provides an **exact serialisation** (never a hash —
+a collision would silently drop a real save) of precisely what each store persists.
+`useAutosave` keeps two refs:
+
+- `intendedRef` — the store holds this, *or* a write for exactly this is armed or in
+  flight. Seeded by `markClean(...)`, which `applyLoadedTimeline` calls before any
+  setter, so a load is born clean.
+- `persistedRef` — a save of exactly this is known to have completed. A backstop for
+  callers that reach `save()` without going through `handleChange`, notably the
+  back-online retry.
+
+**The baseline advances at arm time, not on save success.** This is the subtle part.
+With success-only advancement, typing a character and deleting it inside the debounce
+window reads as clean on the way back — so `handleChange` returns early, the
+already-armed write still carries the intermediate text, and it commits a character the
+user removed with nothing left to reconcile it. Advancing on arm makes the revert
+dirty, which re-arms the debounce with the correct content.
+
+A failed save nulls **both** refs: if the `timelines` UPDATE succeeded and
+`saveTimelineEvents` then threw, the store is partially written and neither ref may
+authorise a skip. The id is part of the fingerprint, so a write armed for the outgoing
+timeline (the user can keep typing during `await loadTimeline`) can never be mistaken
+for the incoming one's baseline.
+
+The guest path does the same thing in `useLocalDraft`, with two differences: the
+baseline **seeds itself from localStorage** via `getDraft(id)` — for a synchronous
+store the honest baseline is the store itself, which avoids needing a hook into all
+five hydration branches — and its fingerprint **includes `categories`**, because
+`LocalDraft` persists them where the `timelines` UPDATE does not.
 
 **Flush, don't cancel.** The debounced call holds a *snapshot* of its arguments, and
 each new call replaces them — so dropping the timer discards the pending write rather
@@ -721,7 +761,8 @@ Four distinct mechanisms keep it honest, and they cover different things:
 
 | Layer | Signed in | Guest |
 |---|---|---|
-| Row set + titles | `useTimelines` realtime on the **`timelines` table** + `loadTimelines()` on panel open | `localDrafts` re-read, keyed on `activeDraftId` |
+| Row set + titles | `useTimelines` realtime on the **`timelines` table** + `loadTimelines()` on panel open | `localDrafts` re-read, keyed on `activeDraftId` *and* on the `DRAFTS_CHANGED_EVENT` the storage layer dispatches after every write |
+| Order | client-side `byUpdatedAtDesc` applied on fetch **and after every realtime merge**, so an edit moves its tile immediately | `getAllDrafts()` sorts by `savedAt`; the change event makes it live |
 | Live values for the open timeline | `activeTimelineTitle` / `activeEventCount` / `activeDominantCategoryColor` pushed from `App` | same — the overrides key off `isActive`, not `row.kind` |
 | Missing-row fallback | synthetic active row in the `rows` memo | same, via `activeDraftId` |
 | Counts + colour dots for *other* rows | `useTimelineMetadata`: write-through + explicit `refresh()` | recomputed from `localDrafts` |
@@ -856,7 +897,7 @@ Hooks consumed (directly or via composition) by the timeline page.
 | `useTimelineState` | `hooks/useTimelineState.ts` | Composes events, title, categories, scale, and groupByCategory into a single state hook |
 | `useTimeline` | `hooks/useTimeline.ts` | Loads / creates timeline records in Supabase; enforces plan limits before creation. Stateless by design — returns ids rather than holding a "current timeline" pointer |
 | `useEvents` | `hooks/useEvents.ts` | Local event CRUD (add, update, batch-add with dedup, clear) |
-| `useAutosave` | `hooks/useAutosave.ts` | Debounced persistence (2000 ms), flush/cancel controls, beforeunload guard, online retry |
+| `useAutosave` | `hooks/useAutosave.ts` | Debounced persistence (2000 ms), fingerprint dirty-check + `markClean`, flush/cancel controls, beforeunload guard, online retry |
 | `useTimelineScale` | `hooks/useTimelineScale.ts` | Scale toggle (`large` / `medium` / `small`) + current `TimelineScale` |
 | `useTimelineTitle` | `hooks/useTimelineTitle.ts` | Title and description state |
 | `useCategories` | `hooks/useCategories.ts` | Category config state with `DEFAULT_CATEGORIES` fallback |

--- a/src/TIMELINE_ARCHITECTURE.md
+++ b/src/TIMELINE_ARCHITECTURE.md
@@ -715,7 +715,37 @@ both claiming the same mount.
 
 ### Local draft
 
-`useLocalDraft` exposes `loadAllDrafts`, `loadDraft`, `saveDraft` (debounced 500 ms), `saveDraftImmediate`, `createDraft`, `deleteDraft`, `clearAllDrafts`, `getDraftCount`. It delegates persistence to `src/utils/draftStorage.ts`; the payload type is `LocalDraft` exported from that module.
+Guests get localStorage drafts rather than Supabase rows — one key,
+`timeline_drafts`, capped at `MAX_DRAFTS = 3` (`PLAN_LIMITS.guest.timelineLimit`).
+"Create a Timeline" branches on sign-in state in `SidePanelBody.handleBuildFromScratch`
+and sends guests `{newTimeline, skipCreationScreen}`, which only the logged-out
+hydration effect in `App.tsx` consumes — a fully separate path from the signed-in
+`{timelineId}` one, and one that needs its own fixes for the same classes of bug.
+
+`useLocalDraft` exposes `loadAllDrafts`, `loadDraft`, `saveDraft` (debounced 500 ms), `saveDraftImmediate`, `flushDraftSave`, `createDraft`, `deleteDraft`, `clearAllDrafts`, `getDraftCount`. It delegates persistence to `src/utils/draftStorage.ts`; the payload type is `LocalDraft` exported from that module.
+
+**Flush applies here too.** `flushDraftSave()` runs before `handleDraftSwitch`
+replaces the editor's contents, and on unmount / `beforeunload` / `pagehide` — the
+debounced save holds a snapshot whose arguments the next edit overwrites, so without
+it a rename made within 500 ms of switching drafts or closing the tab was lost
+silently. The `beforeunload` guard in `useAutosave` does not cover this: its
+`hasUnsavedChanges` flag is only ever set on the signed-in path.
+
+**Two latches, not one.** The logged-out effect keys route-state handling on
+`location.key` (like the signed-in effect) but still gates the *no-route-state*
+bootstrap on the once-per-mount `draftHydrated` flag. Both are needed: the key latch
+is what makes a second "Create a Timeline" work from inside `/editor`, while the
+mount flag stops the `state:{}` reset — which mints a fresh key — from re-hydrating
+over the draft just created.
+
+**Making a new draft visible.** `SidePanelBody` lives in `GlobalLayout` outside the
+router `<Outlet />` and is hidden with a transform rather than unmounted, so
+navigating to `/editor` never remounts it and it has no realtime channel to lean on.
+Its `localDrafts` read therefore depends on `activeDraftId`, which changes exactly
+when the guest's draft set does, and the synthetic active-row fallback in the `rows`
+memo covers guests as well as signed-in users — otherwise a freshly created draft
+stayed invisible behind the "Sign in to save timelines" empty state until the panel
+was toggled or the page reloaded.
 
 ### Event operations
 

--- a/src/TIMELINE_ARCHITECTURE.md
+++ b/src/TIMELINE_ARCHITECTURE.md
@@ -713,6 +713,45 @@ gate a hard refresh ran the logged-out draft path first and cleared `location.st
 before the signed-in path could read it. `editorSeededRef` keeps the two paths from
 both claiming the same mount.
 
+### Keeping the side panel current
+
+The panel is not remounted by navigation (`GlobalLayout` renders it outside the router
+`<Outlet />` and hides it with a transform), so nothing about it refreshes for free.
+Four distinct mechanisms keep it honest, and they cover different things:
+
+| Layer | Signed in | Guest |
+|---|---|---|
+| Row set + titles | `useTimelines` realtime on the **`timelines` table** + `loadTimelines()` on panel open | `localDrafts` re-read, keyed on `activeDraftId` |
+| Live values for the open timeline | `activeTimelineTitle` / `activeEventCount` / `activeDominantCategoryColor` pushed from `App` | same — the overrides key off `isActive`, not `row.kind` |
+| Missing-row fallback | synthetic active row in the `rows` memo | same, via `activeDraftId` |
+| Counts + colour dots for *other* rows | `useTimelineMetadata`: write-through + explicit `refresh()` | recomputed from `localDrafts` |
+
+**Nothing subscribes to the `events` table here.** `useTimelineMetadata` fetches keyed
+on the *set* of timeline ids, so a timeline's contents changing is invisible to it by
+construction. That is why it exposes two escape hatches:
+
+- `applyLocalMetadata(id, patch)` — the panel writes the editor's live count and colour
+  into the map continuously while a timeline is open. The active tile already renders
+  from the context values directly; this exists for the moment it stops being active,
+  which is when the tile would otherwise fall back to the page-load value and the badge
+  would visibly revert. This is only safe because `applyLoadedTimeline` puts the id and
+  the contents in one commit — otherwise it could file one timeline's count under
+  another's id.
+- `refresh()` — called on panel open and from the context's `refreshTimelines`, which
+  now refreshes rows *and* metadata.
+
+A failed metadata fetch unlatches its key so the next `refresh()` retries; latching it
+before the request and never clearing it meant one transient failure froze every badge
+at `0` for the life of the page.
+
+Deliberately **not** covered: changes made in another browser tab. Guest drafts have no
+`storage` listener, and closing the signed-in half would need an `events` realtime
+subscription — `useEventUsage` has one, but RLS on `postgres_changes` for that table is
+flagged as untested in the verification runbook. Also note the realtime DELETE on
+`timelines` likely never fires: the handler reads `payload.old.id` under a `user_id`
+filter, and with default replica identity a DELETE's `old` carries only the primary key.
+Deleting from this tab works because `refreshTimelines()` is called explicitly.
+
 ### Local draft
 
 Guests get localStorage drafts rather than Supabase rows — one key,
@@ -826,6 +865,6 @@ Hooks consumed (directly or via composition) by the timeline page.
 | `useEventDrag` | `hooks/useEventDrag.ts` | Pointer-driven drag state machine; defines `DRAG_THRESHOLD = 5` |
 | `useLocalDraft` | `hooks/useLocalDraft.ts` | localStorage draft CRUD with 500 ms debounced save |
 | `useTimelines` | `hooks/useTimelines.ts` | List of the user's timelines with realtime subscription and retry-with-backoff |
-| `useTimelineMetadata` | `hooks/useTimelineMetadata.ts` | Per-timeline event count, year range, and dominant category color (for timeline cards) |
+| `useTimelineMetadata` | `hooks/useTimelineMetadata.ts` | Per-timeline event count, year range, and dominant category color (for timeline cards). Returns `{ metadata, applyLocalMetadata, refresh }` — the fetch is keyed on the *set* of ids, so contents changes need the write-through or an explicit refresh |
 | `useSidePanel` | `hooks/useSidePanel.ts` | Accesses `SidePanelContext` (open/close state for the event details side panel) |
 | `useAuth` | `hooks/useAuth.ts` | Accesses `AuthContext` (current user, plus `authReady` — whether the session lookup has answered yet) |

--- a/src/TIMELINE_ARCHITECTURE.md
+++ b/src/TIMELINE_ARCHITECTURE.md
@@ -648,23 +648,70 @@ useTimelineState
 Other timeline-page hooks live alongside but are not composed by `useTimelineState`:
 
 ```
-useTimeline           ─ load / create / save the timeline record itself
+useTimeline           ─ load / create the timeline record itself (holds no state)
 useAutosave           ─ debounced persistence + status state
 useLocalDraft         ─ localStorage drafts
 useTimelineScroll     ─ scroll position + visible quarter range (consumed by Timeline.tsx)
 useEventDrag          ─ drag interaction state machine (consumed by Timeline.tsx)
 ```
 
+### Which timeline is open — `loadedTimelineId`
+
+`App.tsx` holds `loadedTimelineId`: the row whose contents are actually in the
+editor. It is the **only** id the app acts on — autosave, Share and Delete all key
+off it — and it is written in exactly one place, `applyLoadedTimeline(data)`, which
+sets it alongside every content setter (`setTitle`, `setDescription`, `setEvents`,
+categories, both scales, `groupByCategory`) in a single synchronous block. React 18
+commits that batch together, so no render can observe one timeline's id beside
+another timeline's data.
+
+This invariant is load-bearing, not stylistic. `useTimeline` previously kept its own
+`timelineId`, written in three places — including a mount effect that pointed it at
+an arbitrary row via `.limit(1)` with no `.order()`, and a `setTimelineId(id)` that
+fired *before* the three sequential fetches it named had returned. Autosave keyed off
+that pointer while reading the editor's separately-held contents, so the two could
+disagree, and a save would then write one timeline's title and events onto a
+different timeline's row — deleting the victim's events, because the event save is a
+diff. The same desync made the side panel paint the open timeline's name and count
+onto the wrong tile, and made that tile permanently unclickable (the switch dedup
+matched the stale pointer, so its contents never loaded).
+
+`useTimeline` therefore holds **no state at all** now. `getMostRecentTimelineId()`
+and `loadTimeline(id)` *return* ids; `loadTimeline` includes the resolved `id` in its
+`TimelineData` so the caller can bind it to the data it came with. Anything that sets
+editor content outside `applyLoadedTimeline` reopens the bug.
+
 ### Save flow
 
 1. User makes a change (event edit, drag, rename, scale toggle, group toggle, etc.).
-2. `useAutosave.handleChange(data)` sets `saveStatus = 'saving'`, marks `hasUnsavedChanges`, and starts a 2000 ms debounce.
+2. `useAutosave.handleChange(data)` sets `saveStatus = 'saving'`, marks `hasUnsavedChanges`, and starts a 2000 ms debounce. `App.tsx` only calls it when `loadedTimelineId` is non-null, so a save can never target a timeline the editor hasn't loaded.
 3. After the debounce fires, `save(data)`:
    - `UPDATE` the `timelines` row (title, description, scale, group_by_category, updated_at).
-   - `saveTimelineEvents(timelineId, events)` performs a diff-based sync: classifies each event as INSERT / UPDATE / DELETE relative to the server, then executes UPDATE → DELETE → INSERT.
+   - `saveTimelineEvents(timelineId, events)` performs a diff-based sync: classifies each event as INSERT / UPDATE / DELETE relative to the server, then executes UPDATE → INSERT → DELETE. INSERT precedes DELETE deliberately: these are separate HTTP calls, not one transaction, so a mismatched client array fails the INSERT on a duplicate primary key *before* anything has been deleted.
 4. On success: `saveStatus = 'saved'`, `lastSavedTime = now`, `hasUnsavedChanges = false`.
 5. On failure: `saveStatus = 'error'`. A `window.online` listener retries `save(timelineData)` when the browser comes back online.
 6. A `beforeunload` listener fires `e.preventDefault()` while `hasUnsavedChanges` is true, prompting the browser's "leave site?" dialog.
+
+**Flush, don't cancel.** The debounced call holds a *snapshot* of its arguments, and
+each new call replaces them — so dropping the timer discards the pending write rather
+than deferring it. `useAutosave` exposes `flushPendingSave()` (awaited by
+`switchTimeline` before it loads, and run on unmount) so the outgoing timeline's last
+≤2 s of edits commit instead of being overwritten by the incoming timeline's
+snapshot. `cancelPendingSave()` is correct only when the target row is going away —
+`handleDeleteTimeline` calls it, since flushing there would re-insert the events it
+just deleted.
+
+### Entering the editor
+
+`/editor` → `/editor` does not remount `App`, so the route-state effect latches on
+`location.key` rather than a once-per-mount boolean. A boolean made every navigation
+after the first a silent no-op, which is what broke "Create a Timeline", "Import
+Data", and a second hand-off from AI mode. Both the route-state effect and the
+no-route-state bootstrap are gated on `authReady` from `AuthContext` — `user` is null
+both before the session lookup answers and when genuinely signed out, so without the
+gate a hard refresh ran the logged-out draft path first and cleared `location.state`
+before the signed-in path could read it. `editorSeededRef` keeps the two paths from
+both claiming the same mount.
 
 ### Local draft
 
@@ -738,9 +785,9 @@ Hooks consumed (directly or via composition) by the timeline page.
 | Hook | File | Purpose |
 |---|---|---|
 | `useTimelineState` | `hooks/useTimelineState.ts` | Composes events, title, categories, scale, and groupByCategory into a single state hook |
-| `useTimeline` | `hooks/useTimeline.ts` | Loads / creates / saves the timeline record from Supabase; enforces plan limits before creation |
+| `useTimeline` | `hooks/useTimeline.ts` | Loads / creates timeline records in Supabase; enforces plan limits before creation. Stateless by design — returns ids rather than holding a "current timeline" pointer |
 | `useEvents` | `hooks/useEvents.ts` | Local event CRUD (add, update, batch-add with dedup, clear) |
-| `useAutosave` | `hooks/useAutosave.ts` | Debounced persistence (2000 ms), beforeunload guard, online retry |
+| `useAutosave` | `hooks/useAutosave.ts` | Debounced persistence (2000 ms), flush/cancel controls, beforeunload guard, online retry |
 | `useTimelineScale` | `hooks/useTimelineScale.ts` | Scale toggle (`large` / `medium` / `small`) + current `TimelineScale` |
 | `useTimelineTitle` | `hooks/useTimelineTitle.ts` | Title and description state |
 | `useCategories` | `hooks/useCategories.ts` | Category config state with `DEFAULT_CATEGORIES` fallback |
@@ -751,4 +798,4 @@ Hooks consumed (directly or via composition) by the timeline page.
 | `useTimelines` | `hooks/useTimelines.ts` | List of the user's timelines with realtime subscription and retry-with-backoff |
 | `useTimelineMetadata` | `hooks/useTimelineMetadata.ts` | Per-timeline event count, year range, and dominant category color (for timeline cards) |
 | `useSidePanel` | `hooks/useSidePanel.ts` | Accesses `SidePanelContext` (open/close state for the event details side panel) |
-| `useAuth` | `hooks/useAuth.ts` | Accesses `AuthContext` (current user) |
+| `useAuth` | `hooks/useAuth.ts` | Accesses `AuthContext` (current user, plus `authReady` — whether the session lookup has answered yet) |

--- a/src/components/SidePanel/SidePanelBody.tsx
+++ b/src/components/SidePanel/SidePanelBody.tsx
@@ -28,6 +28,7 @@ import {
   getDraft,
   saveDraft,
   deleteDraft as deleteLocalDraft,
+  DRAFTS_CHANGED_EVENT,
   MAX_DRAFTS,
   type LocalDraft,
 } from '@/utils/draftStorage'
@@ -180,6 +181,18 @@ export function SidePanelBody() {
       setLocalDrafts([])
     }
   }, [user, isOpen, activeDraftId])
+
+  // Re-read whenever the draft store is written, so a guest's edit reorders
+  // the list as it happens rather than sitting still and then snapping the next
+  // time they switch drafts. Naturally rate-limited by the 500 ms draft
+  // debounce — and an immediate re-read wouldn't work anyway, since the write
+  // is what it needs to observe.
+  useEffect(() => {
+    if (user) return
+    const reread = () => setLocalDrafts(getAllDrafts())
+    window.addEventListener(DRAFTS_CHANGED_EVENT, reread)
+    return () => window.removeEventListener(DRAFTS_CHANGED_EVENT, reread)
+  }, [user])
 
   // Freshen the list when the panel opens so the tile labels reflect any
   // recent edits that haven't come through the realtime channel yet.

--- a/src/components/SidePanel/SidePanelBody.tsx
+++ b/src/components/SidePanel/SidePanelBody.tsx
@@ -183,21 +183,6 @@ export function SidePanelBody() {
 
   // Freshen the list when the panel opens so the tile labels reflect any
   // recent edits that haven't come through the realtime channel yet.
-  useEffect(() => {
-    if (isOpen && user) {
-      loadTimelines()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, user])
-
-  // Expose loadTimelines to the context so actions originating outside this
-  // component (e.g. deleting from the editor's settings panel) can force an
-  // immediate refetch instead of waiting on the realtime channel.
-  useEffect(() => {
-    setRefreshTimelines(() => loadTimelines())
-    return () => setRefreshTimelines(null)
-  }, [setRefreshTimelines, loadTimelines])
-
   const rows = useMemo<TileRow[]>(() => {
     const baseRows: TileRow[] = user
       ? timelines.map(t => ({ id: t.id, title: t.title || DEFAULT_TIMELINE_TITLE, kind: 'timeline' as const }))
@@ -232,7 +217,59 @@ export function SidePanelBody() {
     () => rows.filter(r => r.kind === 'timeline').map(r => r.id),
     [rows],
   )
-  const timelineMetadata = useTimelineMetadata(timelineIds)
+  const { metadata: timelineMetadata, applyLocalMetadata, refresh: refreshMetadata } = useTimelineMetadata(timelineIds)
+
+  // Freshen the list when the panel opens so the tile labels reflect any
+  // recent edits that haven't come through the realtime channel yet.
+  useEffect(() => {
+    if (isOpen && user) {
+      loadTimelines()
+      // Counts and colour dots come from a separate query keyed on the set of
+      // timeline ids, so it never notices a timeline's *contents* changing.
+      // Refresh it explicitly or the badges stay at page-load values.
+      refreshMetadata()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, user])
+
+  // Expose the refresh to the context so actions originating outside this
+  // component (e.g. deleting from the editor's settings panel) can force an
+  // immediate refetch instead of waiting on the realtime channel. Refreshes
+  // both the rows and their metadata — the realtime channel covers `timelines`
+  // only, never `events`.
+  //
+  // These two effects live below useTimelineMetadata rather than beside the
+  // other subscriptions above because they name `refreshMetadata` in their
+  // dependency arrays, which are evaluated during render.
+  useEffect(() => {
+    setRefreshTimelines(() => {
+      loadTimelines()
+      refreshMetadata()
+    })
+    return () => setRefreshTimelines(null)
+  }, [setRefreshTimelines, loadTimelines, refreshMetadata])
+
+  // Write the editor's live numbers for the timeline it currently has open into
+  // the metadata map, continuously while it is open.
+  //
+  // The tile for the *active* timeline already renders from these context
+  // values directly (below), so this exists for the moment it stops being
+  // active: without it the tile falls back to whatever the last fetch returned
+  // — in practice the page-load value — and the badge visibly reverts to a
+  // stale count the instant you switch to another timeline.
+  //
+  // Safe only because `activeTimelineId` and `activeEventCount` now reach the
+  // context in the same commit (App's applyLoadedTimeline sets the id and the
+  // contents in one batch). Before that, this could have filed one timeline's
+  // count under another's id.
+  useEffect(() => {
+    if (!activeTimelineId) return
+    if (activeEventCount == null && activeDominantCategoryColor == null) return
+    applyLocalMetadata(activeTimelineId, {
+      ...(activeEventCount != null ? { eventCount: activeEventCount } : {}),
+      ...(activeDominantCategoryColor != null ? { dominantCategoryColor: activeDominantCategoryColor } : {}),
+    })
+  }, [activeTimelineId, activeEventCount, activeDominantCategoryColor, applyLocalMetadata])
 
   const handleTileClick = (row: TileRow) => {
     if (row.kind === 'timeline') {
@@ -513,7 +550,10 @@ export function SidePanelBody() {
             </div>
           ) : isLoading && user ? (
             <div className="px-2 py-4 text-[14px] text-[#9b9ea3]">Loading timelines…</div>
-          ) : error && user ? (
+          ) : error && user && rows.length === 0 ? (
+            // Only when there is nothing to show. `error` is also set when the
+            // realtime channel drops, and replacing a perfectly good list with
+            // an error card over a websocket blip is worse than saying nothing.
             <div className="px-2 py-4">
               <p className="text-[14px] text-[#9b9ea3] mb-2">{error}</p>
               <button

--- a/src/components/SidePanel/SidePanelBody.tsx
+++ b/src/components/SidePanel/SidePanelBody.tsx
@@ -165,13 +165,21 @@ export function SidePanelBody() {
   const [isImportOpen, setIsImportOpen] = useState(false)
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false)
 
+  // `activeDraftId` is in the deps because it is the only signal this component
+  // gets that the guest's draft list changed. This panel lives outside the
+  // router's <Outlet /> and is hidden with a transform rather than unmounted, so
+  // navigating to /editor never remounts it — without this, a draft created in
+  // the editor stayed invisible until the panel was toggled or the page
+  // reloaded, and the empty-state "sign in to save timelines" copy rendered
+  // where the new tile should have been. Signed-in users get this for free from
+  // the realtime channel; guests have no equivalent.
   useEffect(() => {
     if (!user) {
       setLocalDrafts(getAllDrafts())
     } else {
       setLocalDrafts([])
     }
-  }, [user, isOpen])
+  }, [user, isOpen, activeDraftId])
 
   // Freshen the list when the panel opens so the tile labels reflect any
   // recent edits that haven't come through the realtime channel yet.
@@ -195,24 +203,30 @@ export function SidePanelBody() {
       ? timelines.map(t => ({ id: t.id, title: t.title || DEFAULT_TIMELINE_TITLE, kind: 'timeline' as const }))
       : localDrafts.map(d => ({ id: d.id, title: d.title || DEFAULT_TIMELINE_TITLE, kind: 'draft' as const }))
 
-    // If the editor's active timeline isn't in the fetched list yet (new-timeline
-    // race, stale list, or dropped realtime event), synthesize a tile for it at
-    // the top using live context values so the user always sees their session.
-    const hasActiveRow = !!(user && activeTimelineId && baseRows.some(r => r.kind === 'timeline' && r.id === activeTimelineId))
-    if (!hasActiveRow && user && activeTimelineId) {
+    // If whatever the editor has open isn't in the list yet (new-timeline race,
+    // stale list, or dropped realtime event), synthesize a tile for it at the
+    // top using live context values so the user always sees their session.
+    //
+    // Guests need this at least as much as signed-in users: their draft is
+    // written to localStorage by the editor, and the read above can easily lose
+    // the race with it.
+    const activeId = user ? activeTimelineId : activeDraftId
+    const activeKind = user ? ('timeline' as const) : ('draft' as const)
+    const hasActiveRow = !!(activeId && baseRows.some(r => r.kind === activeKind && r.id === activeId))
+    if (!hasActiveRow && activeId) {
       return [
         {
-          id: activeTimelineId,
+          id: activeId,
           title: activeTimelineTitle && activeTimelineTitle.length > 0
             ? activeTimelineTitle
             : DEFAULT_TIMELINE_TITLE,
-          kind: 'timeline' as const,
+          kind: activeKind,
         },
         ...baseRows,
       ]
     }
     return baseRows
-  }, [user, timelines, localDrafts, activeTimelineId, activeTimelineTitle])
+  }, [user, timelines, localDrafts, activeTimelineId, activeDraftId, activeTimelineTitle])
 
   const timelineIds = useMemo(
     () => rows.filter(r => r.kind === 'timeline').map(r => r.id),

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -5,6 +5,13 @@ import { clearAllCachedEvents } from '../services/viewerEventCache';
 
 interface AuthContextType {
   user: User | null;
+  /**
+   * False until the initial session lookup has answered. `user` is null both
+   * before we know and when the user is genuinely signed out, so consumers that
+   * branch on signed-in vs signed-out must wait for this — otherwise they run
+   * their logged-out path on every full page load.
+   */
+  authReady: boolean;
   signInWithEmail: (email: string) => Promise<void>;
   verifyEmailOtp: (email: string, token: string) => Promise<void>;
   signOut: () => Promise<void>;
@@ -14,6 +21,7 @@ export const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
+  const [authReady, setAuthReady] = useState(false);
 
   const signOut = useCallback(async () => {
     try {
@@ -46,9 +54,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (error) {
         console.error('Error getting session:', error);
         handleAuthError(error);
+        // Still "ready" — we asked and got an answer, even a failed one.
+        // Leaving this false would hang every consumer forever.
+        setAuthReady(true);
         return;
       }
       setUser(session?.user ?? null);
+      setAuthReady(true);
     });
 
     // Listen for auth changes
@@ -60,6 +72,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       } else {
         setUser(session?.user ?? null);
       }
+      setAuthReady(true);
     });
 
     return () => subscription.unsubscribe();
@@ -82,7 +95,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [handleAuthError]);
 
   return (
-    <AuthContext.Provider value={{ user, signInWithEmail, verifyEmailOtp, signOut }}>
+    <AuthContext.Provider value={{ user, authReady, signInWithEmail, verifyEmailOtp, signOut }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -1,7 +1,13 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { debounce } from '../utils/debounce';
 import { supabase } from '../lib/supabase';
 import { saveTimelineEvents } from '../utils/saveEvents';
+import {
+  createEventsFingerprint,
+  fingerprintsEqual,
+  metaFingerprint,
+  type Fingerprint,
+} from '../utils/timelineFingerprint';
 import type { SaveStatus } from '../components/SaveStatusIndicator/SaveStatusIndicator';
 import type { TimelineEvent, CategoryConfig } from '../types/event';
 
@@ -16,13 +22,55 @@ interface TimelineData {
   groupByCategory: boolean;
 }
 
+/** What the caller must supply to declare the editor clean. */
+export type CleanState = Omit<TimelineData, 'categories'>;
+
 export function useAutosave(timelineData: TimelineData) {
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('saved');
   const [lastSavedTime, setLastSavedTime] = useState<Date>();
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
+  // Refs, not state: `handleChange` sits in the editor's autosave effect
+  // dependency array, so any identity churn here would re-fire that effect.
+  const eventsFpRef = useRef(createEventsFingerprint());
+  // What the database holds, OR what an armed/in-flight write is about to make
+  // it hold. Null means "unknown" — treat everything as dirty.
+  const intendedRef = useRef<Fingerprint | null>(null);
+  // What a save is known to have actually completed. Backstop only.
+  const persistedRef = useRef<Fingerprint | null>(null);
+
+  const fingerprintOf = useCallback((data: CleanState): Fingerprint => ({
+    // `categories` is deliberately absent: autosave does not persist them, so
+    // a category edit must not count as a change to be written.
+    meta: metaFingerprint({
+      id: data.id ?? '',
+      title: data.title,
+      description: data.description,
+      scale: data.scale,
+      verticalScale: data.verticalScale,
+      groupByCategory: data.groupByCategory,
+    }),
+    events: eventsFpRef.current(data.events),
+  }), []);
+
+  /**
+   * Declare this exact content as already stored. The editor calls it when a
+   * timeline finishes loading, so applying freshly fetched data doesn't look
+   * like an edit and trigger a write-back.
+   */
+  const markClean = useCallback((data: CleanState) => {
+    const fp = fingerprintOf(data);
+    intendedRef.current = fp;
+    persistedRef.current = fp;
+  }, [fingerprintOf]);
+
   const save = useCallback(async (data: TimelineData) => {
     if (!data.id) return;
+
+    // Backstop for callers that reach save() without going through
+    // handleChange — notably the back-online retry below. Skipping here also
+    // avoids saveTimelineEvents' full events SELECT.
+    if (fingerprintsEqual(persistedRef.current, fingerprintOf(data))) return;
 
     try {
       setSaveStatus('saving');
@@ -45,15 +93,26 @@ export function useAutosave(timelineData: TimelineData) {
       // Diff-based event save
       await saveTimelineEvents(data.id, data.events);
 
+      // This payload's fingerprint, not the editor's current one — a newer
+      // edit that landed mid-flight has already armed its own write.
+      persistedRef.current = fingerprintOf(data);
+
       const now = new Date();
       setSaveStatus('saved');
       setLastSavedTime(now);
       setHasUnsavedChanges(false);
     } catch (error) {
       console.error('Save error:', error);
+      // Null BOTH refs. If the timelines UPDATE succeeded and the event save
+      // then threw, the store is partially written, so neither ref can be
+      // trusted to authorise a skip. Nulling them makes the next change of any
+      // kind — including reverting to the previous content — dirty, so the
+      // editor can always recover.
+      intendedRef.current = null;
+      persistedRef.current = null;
       setSaveStatus('error');
     }
-  }, []);
+  }, [fingerprintOf]);
 
   const debouncedSave = useMemo(
     () => debounce(save, 2000),
@@ -61,10 +120,26 @@ export function useAutosave(timelineData: TimelineData) {
   );
 
   const handleChange = useCallback((data: TimelineData) => {
+    const fp = fingerprintOf(data);
+
+    // Nothing to do: either the store already holds this, or the write that
+    // will make it hold this is already armed. Return before touching
+    // saveStatus or hasUnsavedChanges — marking dirty here is what used to arm
+    // the browser's "Leave site?" prompt just for opening a timeline. Don't
+    // cancel the pending write either: when clean, that pending write *is* the
+    // write for this content.
+    if (fingerprintsEqual(intendedRef.current, fp)) return;
+
+    // Advance at arm time, not on save success. Otherwise typing a character
+    // and deleting it within the debounce window reads as clean on the way
+    // back, leaving the already-armed write to commit the character the user
+    // just removed, with nothing to reconcile it afterwards.
+    intendedRef.current = fp;
+
     setHasUnsavedChanges(true);
     setSaveStatus('saving');
     debouncedSave(data);
-  }, [debouncedSave]);
+  }, [debouncedSave, fingerprintOf]);
 
   // Commit any pending save now. Callers about to replace the editor's
   // contents (switching timelines) must call this — the debounced call holds a
@@ -118,6 +193,7 @@ export function useAutosave(timelineData: TimelineData) {
     saveStatus,
     lastSavedTime,
     handleChange,
+    markClean,
     flushPendingSave,
     cancelPendingSave
   };

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -66,10 +66,25 @@ export function useAutosave(timelineData: TimelineData) {
     debouncedSave(data);
   }, [debouncedSave]);
 
-  // Clean up debounced function on unmount
+  // Commit any pending save now. Callers about to replace the editor's
+  // contents (switching timelines) must call this — the debounced call holds a
+  // snapshot of the *outgoing* timeline, and the next handleChange would
+  // otherwise overwrite those arguments and discard them.
+  const flushPendingSave = useCallback(async () => {
+    await debouncedSave.flush();
+  }, [debouncedSave]);
+
+  // Drop the pending save without running it. Only correct when the target row
+  // is going away (deleting a timeline), where committing would resurrect it.
+  const cancelPendingSave = useCallback(() => {
+    debouncedSave.cancel();
+  }, [debouncedSave]);
+
+  // Flush — not cancel — on unmount, so navigating away from the editor
+  // doesn't drop the last edits.
   useEffect(() => {
     return () => {
-      debouncedSave.cancel();
+      void debouncedSave.flush();
     };
   }, [debouncedSave]);
 
@@ -102,6 +117,8 @@ export function useAutosave(timelineData: TimelineData) {
   return {
     saveStatus,
     lastSavedTime,
-    handleChange
+    handleChange,
+    flushPendingSave,
+    cancelPendingSave
   };
 }

--- a/src/hooks/useLocalDraft.ts
+++ b/src/hooks/useLocalDraft.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { debounce } from '../utils/debounce';
 import {
   getAllDrafts,
@@ -10,10 +10,40 @@ import {
   clearAllDrafts,
 } from '../utils/draftStorage';
 import type { LocalDraft } from '../utils/draftStorage';
+import {
+  createEventsFingerprint,
+  fingerprintsEqual,
+  metaFingerprint,
+  type Fingerprint,
+} from '../utils/timelineFingerprint';
 
 export type { LocalDraft } from '../utils/draftStorage';
 
 export function useLocalDraft() {
+  const eventsFpRef = useRef(createEventsFingerprint());
+  // Id-keyed, because the baseline for one draft says nothing about another.
+  const cleanRef = useRef<{ id: string; fp: Fingerprint | null } | null>(null);
+
+  const fingerprintOf = useCallback((draft: LocalDraft): Fingerprint => ({
+    // Unlike the signed-in path, categories ARE included: LocalDraft persists
+    // them and loadDraft restores them, so a category edit really is an edit.
+    //
+    // The `??` fallbacks must match the hydration branches in App.tsx exactly
+    // (note they use 'medium' for verticalScale where the signed-in path uses
+    // 'small'). If they drift, a draft written before those optional fields
+    // existed fingerprints dirty the moment it is opened and bumps `savedAt` —
+    // which is precisely the reordering bug this is meant to stop.
+    meta: metaFingerprint({
+      id: draft.id,
+      title: draft.title ?? '',
+      description: draft.description ?? '',
+      scale: draft.scale,
+      verticalScale: draft.verticalScale ?? 'medium',
+      groupByCategory: draft.groupByCategory ?? false,
+      categories: draft.categories,
+    }),
+    events: eventsFpRef.current(draft.events),
+  }), []);
   const loadAllDrafts = useCallback((): LocalDraft[] => {
     return getAllDrafts();
   }, []);
@@ -23,16 +53,45 @@ export function useLocalDraft() {
   }, []);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const saveDraft = useCallback(
+  const persistDraft = useCallback(
     debounce((draft: LocalDraft) => {
       storageSaveDraft(draft);
     }, 500),
     []
   );
 
+  /**
+   * Save unless the stored draft already matches.
+   *
+   * The baseline seeds itself from storage rather than from a hydration
+   * callback: for a synchronous store the honest answer to "what's saved?" is
+   * the store itself, and the editor hydrates drafts from five different
+   * branches with no single funnel to hook.
+   */
+  const saveDraft = useCallback((draft: LocalDraft) => {
+    const fp = fingerprintOf(draft);
+
+    // Reseed only when the draft changes, so the full-blob JSON.parse stays
+    // out of the per-keystroke path.
+    if (cleanRef.current?.id !== draft.id) {
+      const stored = getDraft(draft.id);
+      cleanRef.current = { id: draft.id, fp: stored ? fingerprintOf(stored) : null };
+    }
+
+    if (fingerprintsEqual(cleanRef.current.fp, fp)) return;
+
+    // Advanced at arm time, like the signed-in path: if this were advanced
+    // only after the write, typing a character and deleting it inside the
+    // 500 ms window would read as clean on the way back and let the armed
+    // write commit the removed character.
+    cleanRef.current = { id: draft.id, fp };
+    persistDraft(draft);
+  }, [fingerprintOf, persistDraft]);
+
   const saveDraftImmediate = useCallback((draft: LocalDraft) => {
     storageSaveDraft(draft);
-  }, []);
+    cleanRef.current = { id: draft.id, fp: fingerprintOf(draft) };
+  }, [fingerprintOf]);
 
   // Commit a pending debounced save now. The debounced call holds a *snapshot*
   // of its arguments and each new call replaces them, so anything that is about
@@ -40,8 +99,10 @@ export function useLocalDraft() {
   // flush first or that snapshot is silently discarded. localStorage writes are
   // synchronous, so this is safe to call from an unload handler.
   const flushDraftSave = useCallback(() => {
-    saveDraft.flush();
-  }, [saveDraft]);
+    // No-ops on its own when nothing is armed, which is exactly what a clean
+    // editor produces now that saveDraft skips unchanged drafts.
+    persistDraft.flush();
+  }, [persistDraft]);
 
   const handleCreateDraft = useCallback((): LocalDraft | null => {
     return createDraft();

--- a/src/hooks/useLocalDraft.ts
+++ b/src/hooks/useLocalDraft.ts
@@ -34,6 +34,15 @@ export function useLocalDraft() {
     storageSaveDraft(draft);
   }, []);
 
+  // Commit a pending debounced save now. The debounced call holds a *snapshot*
+  // of its arguments and each new call replaces them, so anything that is about
+  // to change which draft is being edited — or to tear the page down — has to
+  // flush first or that snapshot is silently discarded. localStorage writes are
+  // synchronous, so this is safe to call from an unload handler.
+  const flushDraftSave = useCallback(() => {
+    saveDraft.flush();
+  }, [saveDraft]);
+
   const handleCreateDraft = useCallback((): LocalDraft | null => {
     return createDraft();
   }, []);
@@ -55,6 +64,7 @@ export function useLocalDraft() {
     loadDraft,
     saveDraft,
     saveDraftImmediate,
+    flushDraftSave,
     createDraft: handleCreateDraft,
     deleteDraft: handleDeleteDraft,
     clearAllDrafts: handleClearAllDrafts,

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -1,9 +1,8 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import { supabase } from '../lib/supabase';
 import { TimelineEvent, CategoryConfig } from '../types/event';
 import { useAuth } from './useAuth';
 import { DEFAULT_TIMELINE_TITLE } from '../constants/defaults';
-import { saveTimelineEvents } from '../utils/saveEvents';
 import {
   LimitReachedError,
   getCurrentLimits,
@@ -35,7 +34,12 @@ async function checkCreateTimelineLimits(userId: string): Promise<void> {
   }
 }
 
-interface TimelineData {
+export interface TimelineData {
+  /**
+   * The row this data actually came from. Callers must bind their "currently
+   * open timeline" to this value and nothing else — see the note below.
+   */
+  id: string;
   title: string;
   description?: string;
   events: TimelineEvent[];
@@ -45,204 +49,168 @@ interface TimelineData {
   groupByCategory?: boolean;
 }
 
+/**
+ * Timeline record I/O.
+ *
+ * This hook deliberately holds **no "current timeline" state**. It used to keep
+ * a `timelineId` that was written in three places — including a mount effect
+ * that picked an arbitrary row, and a `setTimelineId(id)` that fired before the
+ * data it named had loaded. Because autosave keyed off that pointer while
+ * reading the editor's separately-held contents, the two could disagree, and a
+ * save would then write one timeline's title and events onto a different
+ * timeline's row (deleting the victim's events, since the event save is a
+ * diff).
+ *
+ * Every function here therefore *returns* an id rather than storing one. The
+ * caller is responsible for keeping the id and the contents it came with in a
+ * single atomic piece of state.
+ */
 export function useTimeline() {
   const { user } = useAuth();
-  const [timelineId, setTimelineId] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
 
-  const loadInitialTimeline = useCallback(async () => {
-    if (!user) {
-      setTimelineId(null);
-      setIsLoading(false);
-      setError(null);
-      return;
-    }
+  /**
+   * The most recently updated timeline for this user, or null if they have
+   * none. Ordered, unlike the arbitrary `.limit(1)` this replaces, so landing
+   * on `/editor` with no route state is at least deterministic.
+   */
+  const getMostRecentTimelineId = useCallback(async (): Promise<string | null> => {
+    if (!user) return null;
 
-    try {
-      setIsLoading(true);
-      setError(null);
+    const { data, error } = await supabase
+      .from('timelines')
+      .select('id')
+      .eq('user_id', user.id)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
 
-      const { data, error: fetchError } = await supabase
-        .from('timelines')
-        .select('id')
-        .eq('user_id', user.id)
-        .limit(1)
-        .maybeSingle();
+    if (error) throw error;
 
-      if (fetchError) {
-        throw fetchError;
-      }
-
-      setTimelineId(data?.id ?? null);
-    } catch (err) {
-      console.error('Error loading timeline:', err);
-      setError('Failed to load timeline. Please try again.');
-    } finally {
-      setIsLoading(false);
-    }
+    return data?.id ?? null;
   }, [user]);
-
-  const retryInitialLoad = () => {
-    loadInitialTimeline();
-  };
-
-  useEffect(() => {
-    loadInitialTimeline();
-  }, [loadInitialTimeline]);
 
   const loadTimeline = useCallback(async (id: string): Promise<TimelineData> => {
     if (!user) throw new Error('Must be signed in to load timeline');
-    
-    try {
-      // Set the timelineId immediately for UI feedback
-      setTimelineId(id === 'new' ? null : id);
-      
-      if (id === 'new') {
-        await checkCreateTimelineLimits(user.id);
 
-        // Create a new timeline
-        const { data: newTimeline, error: createError } = await supabase
-          .from('timelines')
-          .insert({ title: DEFAULT_TIMELINE_TITLE, user_id: user.id })
-          .select('id')
-          .single();
+    if (id === 'new') {
+      await checkCreateTimelineLimits(user.id);
 
-        if (createError) throw createError;
-        
-        // Update the timelineId with the newly created timeline
-        setTimelineId(newTimeline.id);
-        
-        return {
-          title: DEFAULT_TIMELINE_TITLE,
-          description: '',
-          events: [],
-          categories: undefined, // Will use default categories
-          scale: 'small',
-          verticalScale: 'medium',
-          groupByCategory: false
-        };
-      }
-
-      const { data: timeline, error: timelineError } = await supabase
+      const { data: newTimeline, error: createError } = await supabase
         .from('timelines')
-        .select('*')
-        .eq('id', id)
+        .insert({ title: DEFAULT_TIMELINE_TITLE, user_id: user.id })
+        .select('id')
         .single();
 
-      if (timelineError) throw timelineError;
-
-      const { data: events, error: eventsError } = await supabase
-        .from('events')
-        .select('*')
-        .eq('timeline_id', id);
-
-      if (eventsError) throw eventsError;
-
-      // Also load timeline-specific categories if they exist
-      const { data: categories, error: categoriesError } = await supabase
-        .from('timeline_categories')
-        .select('*')
-        .eq('timeline_id', id);
-
-      if (categoriesError && categoriesError.message !== 'relation "timeline_categories" does not exist') {
-        throw categoriesError;
-      }
+      if (createError) throw createError;
 
       return {
-        title: timeline.title,
-        description: timeline.description || '',
-        events: events.map(event => ({
-          id: event.id,
-          title: event.title,
-          startDate: event.start_date,
-          endDate: event.end_date,
-          category: event.category,
-          description: event.description ?? null,
-          imageUrl: event.image_url ?? null,
-          imageAttribution: event.image_attribution ?? null,
-          sources: event.sources ?? null,
-        })),
-        categories: categories || undefined,
-        scale: timeline.scale || 'large',
-        verticalScale: timeline.vertical_scale || 'medium',
-        groupByCategory: timeline.group_by_category ?? false
+        id: newTimeline.id,
+        title: DEFAULT_TIMELINE_TITLE,
+        description: '',
+        events: [],
+        categories: undefined, // Will use default categories
+        scale: 'small',
+        verticalScale: 'medium',
+        groupByCategory: false
       };
-    } catch (error) {
-      // Reset timelineId if there was an error
-      setTimelineId(id === 'new' ? null : timelineId);
-      throw error;
     }
-  }, [user, timelineId]);
 
-  const saveTimeline = useCallback(async (
+    const { data: timeline, error: timelineError } = await supabase
+      .from('timelines')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (timelineError) throw timelineError;
+
+    const { data: events, error: eventsError } = await supabase
+      .from('events')
+      .select('*')
+      .eq('timeline_id', id);
+
+    if (eventsError) throw eventsError;
+
+    // Also load timeline-specific categories if they exist
+    const { data: categories, error: categoriesError } = await supabase
+      .from('timeline_categories')
+      .select('*')
+      .eq('timeline_id', id);
+
+    if (categoriesError && categoriesError.message !== 'relation "timeline_categories" does not exist') {
+      throw categoriesError;
+    }
+
+    return {
+      id,
+      title: timeline.title,
+      description: timeline.description || '',
+      events: events.map(event => ({
+        id: event.id,
+        title: event.title,
+        startDate: event.start_date,
+        endDate: event.end_date,
+        category: event.category,
+        description: event.description ?? null,
+        imageUrl: event.image_url ?? null,
+        imageAttribution: event.image_attribution ?? null,
+        sources: event.sources ?? null,
+      })),
+      categories: categories || undefined,
+      scale: timeline.scale || 'large',
+      verticalScale: timeline.vertical_scale || 'medium',
+      groupByCategory: timeline.group_by_category ?? false
+    };
+  }, [user]);
+
+  /**
+   * Unconditionally create a new timeline row from the given data and return
+   * its id. Used by the local-draft migration on login, which always wants a
+   * fresh row — the previous implementation branched on the hook's internal
+   * `timelineId` and would *overwrite* an existing timeline when that pointer
+   * happened to be set.
+   */
+  const createTimelineFrom = useCallback(async (
     title: string,
     events: TimelineEvent[],
     scale: 'large' | 'medium' | 'small' = 'small',
     verticalScale: 'small' | 'medium' = 'medium',
-  ) => {
+  ): Promise<string> => {
     if (!user) throw new Error('Must be signed in to save');
 
-    try {
-      if (!timelineId) {
-        await checkCreateTimelineLimits(user.id);
+    await checkCreateTimelineLimits(user.id);
 
-        // Create new timeline
-        const { data: timeline, error: timelineError } = await supabase
-          .from('timelines')
-          .insert({ title, user_id: user.id, scale, vertical_scale: verticalScale })
-          .select('id')
-          .single();
+    const { data: timeline, error: timelineError } = await supabase
+      .from('timelines')
+      .insert({ title, user_id: user.id, scale, vertical_scale: verticalScale })
+      .select('id')
+      .single();
 
-        if (timelineError) throw timelineError;
-        setTimelineId(timeline.id);
+    if (timelineError) throw timelineError;
 
-        // Insert events with client-generated IDs
-        if (events.length > 0) {
-          const { error: eventsError } = await supabase
-            .from('events')
-            .insert(
-              events.map(event => ({
-                id: event.id,
-                timeline_id: timeline.id,
-                title: event.title,
-                start_date: event.startDate,
-                end_date: event.endDate,
-                category: event.category
-              }))
-            );
+    // Insert events with client-generated IDs
+    if (events.length > 0) {
+      const { error: eventsError } = await supabase
+        .from('events')
+        .insert(
+          events.map(event => ({
+            id: event.id,
+            timeline_id: timeline.id,
+            title: event.title,
+            start_date: event.startDate,
+            end_date: event.endDate,
+            category: event.category
+          }))
+        );
 
-          if (eventsError) throw eventsError;
-        }
-      } else {
-        // Update existing timeline
-        const { error: timelineError } = await supabase
-          .from('timelines')
-          .update({
-            title,
-            updated_at: new Date().toISOString(),
-            scale,
-            vertical_scale: verticalScale
-          })
-          .eq('id', timelineId);
-
-        if (timelineError) throw timelineError;
-
-        // Diff-based event save
-        await saveTimelineEvents(timelineId, events);
-      }
-    } catch (error) {
-      console.error('Error saving timeline:', error);
-      throw error;
+      if (eventsError) throw eventsError;
     }
-  }, [user, timelineId]);
+
+    return timeline.id;
+  }, [user]);
 
   return {
-    timelineId,
-    isLoading,
-    error,
-    retryInitialLoad,
-    saveTimeline,
+    getMostRecentTimelineId,
+    createTimelineFrom,
     loadTimeline
   };
 }

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -95,9 +95,21 @@ export function useTimeline() {
     if (id === 'new') {
       await checkCreateTimelineLimits(user.id);
 
+      // Write the display defaults explicitly rather than leaning on the
+      // column defaults, which differ ('large' / 'small'). Autosave used to
+      // paper over the mismatch by immediately rewriting the row on open; now
+      // that opening a timeline no longer writes, an untouched new timeline
+      // would keep the column defaults while the editor showed these — and
+      // reopening it would visibly change zoom.
       const { data: newTimeline, error: createError } = await supabase
         .from('timelines')
-        .insert({ title: DEFAULT_TIMELINE_TITLE, user_id: user.id })
+        .insert({
+          title: DEFAULT_TIMELINE_TITLE,
+          user_id: user.id,
+          scale: 'small',
+          vertical_scale: 'medium',
+          group_by_category: false,
+        })
         .select('id')
         .single();
 

--- a/src/hooks/useTimelineMetadata.ts
+++ b/src/hooks/useTimelineMetadata.ts
@@ -64,9 +64,14 @@ export function useTimelineMetadata(timelineIds: string[]) {
   }, []);
 
   useEffect(() => {
-    // `nonce` is part of the key so refresh() forces a fetch the id-set check
+    // Keyed on the *set* of ids, so the ids are sorted first — the list itself
+    // re-sorts whenever a timeline is edited, and an order-sensitive key would
+    // turn every reorder into two needless queries plus a full map replacement
+    // that discards the write-through values applyLocalMetadata just put there.
+    //
+    // `nonce` is part of the key so refresh() forces a fetch the set check
     // would otherwise skip.
-    const fetchKey = `${nonce}:${JSON.stringify(timelineIds)}`;
+    const fetchKey = `${nonce}:${[...timelineIds].sort().join(',')}`;
     if (fetchKey === prevFetchKeyRef.current) return;
     // Latched up front so `timelineIds` identity churn doesn't re-fire the
     // request; the error path below unlatches it again.

--- a/src/hooks/useTimelineMetadata.ts
+++ b/src/hooks/useTimelineMetadata.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
 import { getTimelineYearRange } from '../utils/timelineUtils';
 import { TimelineCategory } from '../types/event';
@@ -11,19 +11,73 @@ export interface TimelineMetadata {
   dominantCategoryColor: string;
 }
 
-export function useTimelineMetadata(timelineIds: string[]): Map<string, TimelineMetadata> {
+function emptyMetadata(): TimelineMetadata {
+  return {
+    eventCount: 0,
+    yearRange: new Date().getFullYear().toString(),
+    dominantCategoryColor: DEFAULT_DOT_COLOR,
+  };
+}
+
+/**
+ * Per-timeline event count, year range and dominant category colour, for the
+ * side panel's tiles.
+ *
+ * The fetch is keyed on the *set* of timeline ids, so a timeline's contents
+ * changing is invisible to it by construction — and there is deliberately no
+ * subscription to the `events` table here. Two escape hatches keep the numbers
+ * current instead:
+ *
+ * - `applyLocalMetadata` lets the editor write through what it already knows
+ *   about the timeline it has open, so those numbers survive the user switching
+ *   away from it. Without it the tile falls back to whatever was fetched when
+ *   the page loaded, and the badge visibly reverts.
+ * - `refresh` forces a real refetch, for the moments where a round trip is
+ *   warranted (the panel opening, an explicit refresh from the editor).
+ */
+export function useTimelineMetadata(timelineIds: string[]) {
   const [metadata, setMetadata] = useState<Map<string, TimelineMetadata>>(new Map());
-  const prevIdsKeyRef = useRef('');
+  const [nonce, setNonce] = useState(0);
+  const prevFetchKeyRef = useRef('');
+  const seqRef = useRef(0);
+
+  const refresh = useCallback(() => setNonce(n => n + 1), []);
+
+  const applyLocalMetadata = useCallback((id: string, patch: Partial<TimelineMetadata>) => {
+    setMetadata(prev => {
+      const existing = prev.get(id);
+      const merged = { ...(existing ?? emptyMetadata()), ...patch };
+      // Bail without allocating when nothing actually moved — this runs on
+      // every keystroke that changes the open timeline.
+      if (
+        existing &&
+        merged.eventCount === existing.eventCount &&
+        merged.yearRange === existing.yearRange &&
+        merged.dominantCategoryColor === existing.dominantCategoryColor
+      ) {
+        return prev;
+      }
+      const next = new Map(prev);
+      next.set(id, merged);
+      return next;
+    });
+  }, []);
 
   useEffect(() => {
-    const idsKey = JSON.stringify(timelineIds);
-    if (idsKey === prevIdsKeyRef.current) return;
-    prevIdsKeyRef.current = idsKey;
+    // `nonce` is part of the key so refresh() forces a fetch the id-set check
+    // would otherwise skip.
+    const fetchKey = `${nonce}:${JSON.stringify(timelineIds)}`;
+    if (fetchKey === prevFetchKeyRef.current) return;
+    // Latched up front so `timelineIds` identity churn doesn't re-fire the
+    // request; the error path below unlatches it again.
+    prevFetchKeyRef.current = fetchKey;
 
     if (timelineIds.length === 0) {
       setMetadata(new Map());
       return;
     }
+
+    const seq = ++seqRef.current;
 
     const fetchMetadata = async () => {
       const [eventsResult, timelinesResult] = await Promise.all([
@@ -37,9 +91,24 @@ export function useTimelineMetadata(timelineIds: string[]): Map<string, Timeline
           .in('id', timelineIds),
       ]);
 
+      // A newer fetch has superseded this one. These genuinely overlap when the
+      // synthetic active row appears and then disappears, and without this the
+      // older response can land last and win.
+      if (seq !== seqRef.current) return;
+
       if (eventsResult.error) {
         console.error('Error fetching timeline metadata:', eventsResult.error);
+        // Unlatch so the next id change or refresh() retries. Leaving this
+        // latched meant a single transient failure froze every badge at 0 for
+        // the rest of the page's life.
+        prevFetchKeyRef.current = '';
         return;
+      }
+
+      if (timelinesResult.error) {
+        // Not fatal — every dot just falls back to the default palette — but it
+        // used to be swallowed silently, which made the cause impossible to see.
+        console.error('Error fetching timeline categories:', timelinesResult.error);
       }
 
       // Build a map of timeline-specific category configs
@@ -54,11 +123,7 @@ export function useTimelineMetadata(timelineIds: string[]): Map<string, Timeline
 
       // Initialize all timelines with defaults (so 0-event timelines get entries)
       for (const id of timelineIds) {
-        result.set(id, {
-          eventCount: 0,
-          yearRange: new Date().getFullYear().toString(),
-          dominantCategoryColor: DEFAULT_DOT_COLOR,
-        });
+        result.set(id, emptyMetadata());
       }
 
       // Group events by timeline_id
@@ -95,7 +160,7 @@ export function useTimelineMetadata(timelineIds: string[]): Map<string, Timeline
     };
 
     fetchMetadata();
-  }, [timelineIds]);
+  }, [timelineIds, nonce]);
 
-  return metadata;
+  return { metadata, applyLocalMetadata, refresh };
 }

--- a/src/hooks/useTimelines.ts
+++ b/src/hooks/useTimelines.ts
@@ -6,6 +6,29 @@ import { useAuth } from './useAuth';
 const MAX_RETRIES = 3;
 const RETRY_DELAY = 1000; // 1 second
 
+/**
+ * Sort key for the side panel: most recently edited first.
+ *
+ * Compares parsed instants, never the raw strings. The REST fetch returns
+ * PostgREST's ISO-8601 (`...T12:34:56+00:00`) but the realtime payload's
+ * timestamp formatting is not guaranteed to match it, and space-separated
+ * variants have shipped historically. `' '` sorts below `'T'`, so a
+ * lexicographic comparison across the two forms would send the timeline the
+ * user *just* edited to the bottom of the list.
+ *
+ * If you ever see the edited timeline sink instead of rise, that is Date.parse
+ * returning NaN on the realtime format — start here.
+ */
+function toTime(value: string | null | undefined): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function byUpdatedAtDesc(a: Timeline, b: Timeline): number {
+  return toTime(b.updated_at) - toTime(a.updated_at);
+}
+
 export function useTimelines() {
   const { user } = useAuth();
   const [timelines, setTimelines] = useState<Timeline[]>([]);
@@ -40,8 +63,13 @@ export function useTimelines() {
         .map(timeline => ({
           ...timeline,
           title: timeline.title || 'Name your timeline'
-        }));
-      
+        }))
+        // Redundant after the server's .order(), but it makes the client
+        // comparator the single source of order — so if it can't read the
+        // timestamp format, the initial list breaks visibly here rather than
+        // silently in the realtime path.
+        .sort(byUpdatedAtDesc);
+
       setTimelines(validTimelines);
       setError(null);
     } catch (err) {
@@ -81,12 +109,30 @@ export function useTimelines() {
         (payload) => {
           // Handle different types of changes
           if (payload.eventType === 'INSERT') {
-            setTimelines(prev => [payload.new as Timeline, ...prev]);
+            const inserted = payload.new as Timeline;
+            setTimelines(prev => {
+              // Replace-if-present rather than prepending blindly: a
+              // concurrent loadTimelines() may already have picked this row up
+              // (very reachable — creating a timeline inserts while the
+              // panel's open-refetch is in flight), and a duplicate here means
+              // a duplicate React key and a doubled tile.
+              const exists = prev.some(t => t.id === inserted.id);
+              const next = exists
+                ? prev.map(t => (t.id === inserted.id ? { ...t, ...inserted } : t))
+                : [inserted, ...prev];
+              return next.sort(byUpdatedAtDesc);
+            });
           } else if (payload.eventType === 'DELETE') {
             setTimelines(prev => prev.filter(t => t.id !== payload.old.id));
           } else if (payload.eventType === 'UPDATE') {
-            setTimelines(prev => 
-              prev.map(t => t.id === payload.new.id ? { ...t, ...payload.new } : t)
+            // Re-sort after merging, so an edit moves its tile immediately
+            // instead of the list silently drifting out of order and snapping
+            // on the next refetch. `.map()` already returned a fresh array, so
+            // sorting it is safe — never sort `prev` itself.
+            setTimelines(prev =>
+              prev
+                .map(t => t.id === payload.new.id ? { ...t, ...payload.new } : t)
+                .sort(byUpdatedAtDesc)
             );
           }
         }

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,16 +1,36 @@
-export function debounce<T extends (...args: unknown[]) => void>(
+/**
+ * Trailing-edge debounce.
+ *
+ * `flush()` exists because the pending call holds a *snapshot* of its
+ * arguments. Cancelling it silently discards that snapshot — for the autosave
+ * that means losing the last ≤2s of edits to the timeline being navigated away
+ * from. Callers that are about to replace the debounced state (switching
+ * timelines, unmounting the editor) must flush rather than cancel.
+ */
+export function debounce<T extends (...args: never[]) => unknown>(
   func: T,
   wait: number
 ): {
   (...args: Parameters<T>): void;
   cancel: () => void;
+  flush: () => ReturnType<T> | undefined;
 } {
   let timeout: NodeJS.Timeout | undefined;
-  
+  let pendingArgs: Parameters<T> | undefined;
+
+  function invoke(): ReturnType<T> | undefined {
+    const args = pendingArgs;
+    pendingArgs = undefined;
+    if (!args) return undefined;
+    return func(...args) as ReturnType<T>;
+  }
+
   function debounced(...args: Parameters<T>) {
+    pendingArgs = args;
+
     const later = () => {
       timeout = undefined;
-      func(...args);
+      invoke();
     };
 
     clearTimeout(timeout);
@@ -20,6 +40,16 @@ export function debounce<T extends (...args: unknown[]) => void>(
   debounced.cancel = () => {
     clearTimeout(timeout);
     timeout = undefined;
+    pendingArgs = undefined;
+  };
+
+  // Run the pending call now instead of waiting out the timer. No-op when
+  // nothing is pending, so it's safe to call unconditionally.
+  debounced.flush = (): ReturnType<T> | undefined => {
+    if (timeout === undefined) return undefined;
+    clearTimeout(timeout);
+    timeout = undefined;
+    return invoke();
   };
 
   return debounced;

--- a/src/utils/draftStorage.ts
+++ b/src/utils/draftStorage.ts
@@ -35,9 +35,20 @@ function readDrafts(): LocalDraft[] {
   }
 }
 
+/**
+ * Fired after any successful write, so the side panel can re-read.
+ *
+ * A `storage` listener would not do: that event fires only in *other* tabs,
+ * never the one that wrote. Hanging this off the storage layer rather than the
+ * editor means create, save, delete and duplicate are all covered wherever
+ * they're called from.
+ */
+export const DRAFTS_CHANGED_EVENT = 'timeline-academy:drafts-changed'
+
 function writeDrafts(drafts: LocalDraft[]): void {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ drafts }))
+    window.dispatchEvent(new Event(DRAFTS_CHANGED_EVENT))
   } catch {
     // Storage full or disabled — silently ignore
   }

--- a/src/utils/saveEvents.ts
+++ b/src/utils/saveEvents.ts
@@ -71,7 +71,14 @@ export async function saveTimelineEvents(
     .filter(e => !clientIds.has(e.id))
     .map(e => e.id);
 
-  // 3. Execute operations: UPDATE first, then DELETE, then INSERT
+  // 3. Execute operations: UPDATE, then INSERT, then DELETE.
+  //
+  // INSERT must precede DELETE. These are separate HTTP calls, not one
+  // transaction, so a DELETE that runs first commits on its own. If the caller
+  // ever hands us a client array belonging to a *different* timeline, those
+  // events carry ids that already exist, the INSERT fails 23505 — and running
+  // it first means it fails before anything has been deleted. Deleting first
+  // would empty the timeline and then fail, which is unrecoverable.
 
   // Updates — Supabase doesn't support batch update by different IDs,
   // so we issue individual upserts for changed rows.
@@ -89,17 +96,6 @@ export async function saveTimelineEvents(
         sources: event.sources ?? null,
       })
       .eq('id', event.id)
-      .eq('timeline_id', timelineId);
-
-    if (error) throw error;
-  }
-
-  // Deletes
-  if (toDeleteIds.length > 0) {
-    const { error } = await supabase
-      .from('events')
-      .delete()
-      .in('id', toDeleteIds)
       .eq('timeline_id', timelineId);
 
     if (error) throw error;
@@ -123,6 +119,17 @@ export async function saveTimelineEvents(
           sources: event.sources ?? null,
         }))
       );
+
+    if (error) throw error;
+  }
+
+  // Deletes
+  if (toDeleteIds.length > 0) {
+    const { error } = await supabase
+      .from('events')
+      .delete()
+      .in('id', toDeleteIds)
+      .eq('timeline_id', timelineId);
 
     if (error) throw error;
   }

--- a/src/utils/timelineFingerprint.ts
+++ b/src/utils/timelineFingerprint.ts
@@ -1,0 +1,118 @@
+import type { TimelineEvent, CategoryConfig } from '../types/event';
+
+/**
+ * Fingerprints for deciding whether a timeline actually changed.
+ *
+ * Autosave used to write unconditionally, so merely *opening* a timeline
+ * rewrote its row — bumping `updated_at` and reshuffling the side panel, which
+ * sorts on it. These fingerprints let the save paths compare "what's in the
+ * editor" against "what the store already has" and skip the write when they
+ * match.
+ *
+ * Deliberately an exact serialisation rather than a hash. A hash collision here
+ * would silently drop a real save, which is a terrible payoff for saving a few
+ * hundred bytes of memory — and there is no size problem to solve, since both
+ * strings are already held in memory anyway.
+ */
+
+/**
+ * Split in two so the common case is cheap. Typing in the title changes `meta`
+ * on every keystroke while `events` stays byte-identical — and because the
+ * events string is memoised on array identity, comparing it is a pointer
+ * comparison rather than a memcmp over what can be a megabyte of JSON.
+ */
+export interface Fingerprint {
+  meta: string;
+  events: string;
+}
+
+interface MetaInput {
+  id: string;
+  title: string;
+  description: string;
+  scale: string;
+  verticalScale: string;
+  groupByCategory: boolean;
+  /** Guest drafts persist categories; signed-in timelines do not. */
+  categories?: CategoryConfig[];
+}
+
+/**
+ * Everything the store actually persists, plus the id.
+ *
+ * The id matters: a user can keep typing while `loadTimeline` is in flight,
+ * arming a save that carries the *outgoing* timeline's id. Scoping the
+ * fingerprint by id means such a save can never be mistaken for the incoming
+ * timeline's baseline.
+ *
+ * Serialised as a JSON array, not a template string — JSON escapes quotes and
+ * control characters, so a title containing a delimiter can't forge a field
+ * boundary, and array position sidesteps key-order questions. Inside an array
+ * `undefined` also serialises to `null`, which is the normalisation we want.
+ */
+export function metaFingerprint(input: MetaInput): string {
+  return JSON.stringify([
+    input.id,
+    input.title,
+    input.description,
+    input.scale,
+    input.verticalScale,
+    input.groupByCategory,
+    input.categories
+      ? input.categories.map(c => [c.id, c.label, c.color, c.visible])
+      : null,
+  ]);
+}
+
+/**
+ * Builds an events fingerprinter with a one-slot cache keyed on array identity.
+ *
+ * Identity is a sound key here because nothing in this codebase mutates an
+ * event array or an event object in place — every edit path builds new ones. So
+ * a cache hit means the events genuinely did not change, and the expensive
+ * stringify only runs on a real event mutation (add, drag, delete, table-editor
+ * commit, enrichment) rather than per keystroke.
+ *
+ * Create one per hook instance rather than sharing a module-level cache, so the
+ * signed-in and guest paths can't evict each other.
+ */
+export function createEventsFingerprint(): (events: TimelineEvent[]) => string {
+  let lastArray: TimelineEvent[] | null = null;
+  let lastResult = '';
+
+  return (events: TimelineEvent[]): string => {
+    if (events === lastArray) return lastResult;
+
+    // Order-insensitive on purpose: nothing persists event order. The event
+    // save is map/set based, there is no ordering column, and the timeline
+    // renders by date. A fingerprint that changed on reorder would arm writes
+    // that change nothing in the store — the exact bug this exists to prevent.
+    // Plain code-unit compare, not localeCompare: these are UUIDs, and
+    // localeCompare is an order of magnitude slower for no benefit.
+    const sorted = [...events].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+    // `?? null` mirrors the normalisation in saveEvents.ts, so an event created
+    // in this session (fields undefined) fingerprints identically to the same
+    // event after a reload from the store (fields null).
+    lastResult = JSON.stringify(
+      sorted.map(e => [
+        e.id,
+        e.title,
+        e.startDate,
+        e.endDate,
+        e.category,
+        e.description ?? null,
+        e.imageUrl ?? null,
+        e.imageAttribution ?? null,
+        e.sources ? e.sources.map(s => [s.title, s.url]) : null,
+      ]),
+    );
+    lastArray = events;
+    return lastResult;
+  };
+}
+
+/** A null baseline means "unknown" — always treat that as dirty. */
+export function fingerprintsEqual(a: Fingerprint | null, b: Fingerprint): boolean {
+  return a !== null && a.meta === b.meta && a.events === b.events;
+}


### PR DESCRIPTION
Fixes the left-panel report — a timeline name appearing twice, a timeline whose contents never open, a dead "Create a Timeline" button — plus a destructive bug behind them, and the guest-side equivalents found while testing the deploy preview.

Two commits, two separate code paths.

---

# 1. Signed in — `timelineId` desynced from the editor's contents

`timelineId` (which timeline is open) and the editor's contents were independent React state with nothing binding them. On a plain first mount they reliably disagreed:

| t | what runs |
|---|---|
| 0 | `loadInitialTimeline` fires — one round trip |
| 0 | route-state effect → `switchTimeline(X)` → `setTimelineId(X)`, then **three sequential** round trips |
| ~1 RTT | `loadInitialTimeline` resolves → `setTimelineId(R)`, an **arbitrary** row (`.limit(1)`, no `.order()`). Nothing sets the id after this. |
| ~3 RTT | `switchTimeline` installs **X's** contents |

The pointer says R, the screen shows X. Not a rare race — it fires for any signed-in user with more than one timeline.

| Symptom | Mechanism |
|---|---|
| Same name twice | The panel overrides a row's title **and** count with the live editor values when `row.id === activeTimelineId`. Pointer on R, contents from X → R's tile renders X's name and count, identical to X's own tile. |
| That tile never opens | The switch dedup early-returns when `newTimelineId === timelineId`. Already R, so clicking R was a permanent no-op. |
| "Create a Timeline" dead | The route-state effect latched on a boolean set once and never reset, and `/editor` → `/editor` doesn't remount `App`. Also broke "Import Data". |
| **Data loss** | Autosave fired on the pointer with whatever contents were in memory: `timelines.update({title}).eq('id', R)`, then `saveTimelineEvents(R, X_events)` — a diff that deletes every server event not in the client array. Share and Delete read the same pointer. |

**The fix.** `loadedTimelineId` in `App.tsx`, written only by `applyLoadedTimeline(data)`, which sets it alongside all seven content setters in one synchronous block — React commits the batch together, so no render (and no autosave) can observe one timeline's id beside another's data. `useTimeline` now holds **no state at all**: `getMostRecentTimelineId()` and `loadTimeline()` return ids, and `loadTimeline` reports the row its data came from. That removes the pointer that could desync rather than patching this instance of it.

Plus: a `location.key` latch for the route state; `authReady` in `AuthContext` (a hard refresh ran the logged-out path first and ate `location.state`); a debounce `flush()` so switching stops discarding the outgoing timeline's last ≤2 s of edits; and `saveTimelineEvents` reordered to INSERT-before-DELETE, so a mismatched client array fails on a duplicate key *before* anything is deleted rather than after.

---

# 2. Guests — created drafts never appeared in the panel

Found on the deploy preview: a signed-out visitor clicks "Create a Timeline", renames it, and the panel shows the "Sign in to save timelines" empty state where the tile should be. Guests take a completely separate route-state path (`{newTimeline}`, not `{timelineId}`), so none of the above touched it.

**The panel never re-read localStorage.** `SidePanelBody` loaded drafts only on `[user, isOpen]`, and creating a draft changes neither. No remount saves it either — `GlobalLayout` renders the panel outside the router `<Outlet />` and hides it with a transform. Signed-in users have two safety nets guests had none of: the realtime INSERT subscription, and the synthetic active-row fallback, which was gated on `user &&` twice.

Fixed by depending the draft read on `activeDraftId` — the one signal that changes exactly when the guest's draft set does — and extending the synthetic active-row fallback to drafts, so the tile appears even if the read loses the race with the write. The rename needed nothing; the live-title override already applies to draft rows, it just needed a row to exist.

**The latch had a twin.** The first commit fixed the signed-in boolean and left the logged-out effect on `draftHydrated`, set in six places and never reset — so for a guest already in `/editor`, a second "Create a Timeline" was a total no-op. Now latched on `location.key`, while `draftHydrated` still gates the *no-route-state* bootstrap: both are load-bearing, since the `state:{}` reset mints a fresh key and would otherwise re-hydrate over the draft just created.

**Guest renames were also being dropped.** The 500 ms draft debounce is now flushed before switching drafts and on unmount/`pagehide`. `saveDraftImmediate` already existed with zero callers, and `useAutosave`'s `beforeunload` guard never covered this path — its `hasUnsavedChanges` flag is only set for signed-in saves.

---

## Verification

`npm run lint`, `npx tsc --noEmit`, `npm run build` all clean.

**The guest path is verified end-to-end in a browser** against an empty profile — it's localStorage-only, so it was fully testable here:

| check | result |
|---|---|
| Create from `/` → tile appears, no toggle or reload | ✅ empty state → `0 Untitled Timeline` |
| Rename → tile follows | ✅ tile and localStorage both update |
| Create ×3 from inside `/editor` (the latch) | ✅ three drafts, each appearing instantly |
| 4th create → cap | ✅ "You've reached the 3-timeline limit…" |
| Rename, switch draft 80 ms later | ✅ rename survives |
| Rename, reload 80 ms later | ✅ rename survives |

**The signed-in paths were not exercised** — no Supabase credentials in this environment. Both routes mount with no console errors, but these need a real account before merge:

- **The load-bearing one.** DevTools → Network → filter `events`. Open a timeline, wait 5 s: **no `DELETE /events` may appear**, and the only `PATCH /timelines?id=eq.…` should target the timeline being edited. Repeat on a hard refresh of `/editor`, and while switching between timelines.
- Every tile shows its own title and count; clicking each loads its own events.
- Hard-refresh `/editor` → lands on the most recently updated timeline with its events.
- Share → the copied `/view/<id>` opens the timeline you were actually editing.
- Guest drafts created before signing in migrate exactly once, with none overwritten.

## Deliberately not in scope

A generation counter for rapid switches (after this change a late response can only install a *consistent* pair, so the residue is a cosmetic "clicked A then B, briefly saw A"); `Promise.all` for the three sequential fetches; stale sidebar counts in `useTimelineMetadata`; the disagreeing `scale` defaults; `timeline_categories` being read but never written; and three `draftStorage` hazards — `saveDraft` silently no-ops at the cap, corrupt stored JSON destroys all drafts on the next write, and two tabs clobber each other.