### PR TITLE
Add animated loading state to AI search generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.22.0",
         "tailwind-merge": "^3.5.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "thinking-orbs": "^0.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -5775,6 +5776,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/thinking-orbs": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/thinking-orbs/-/thinking-orbs-0.2.0.tgz",
+      "integrity": "sha512-CQux/YsLlB9nY60BDpZ/uW7knAvXg+U2T/gzrzuLRw8xlzfJPLXZxAg2tbbIBGp/nE2Kol1GfbMOJnoH+tcb/A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
@@ -10046,6 +10057,12 @@
       "requires": {
         "thenify": ">= 3.1.0 < 4"
       }
+    },
+    "thinking-orbs": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/thinking-orbs/-/thinking-orbs-0.2.0.tgz",
+      "integrity": "sha512-CQux/YsLlB9nY60BDpZ/uW7knAvXg+U2T/gzrzuLRw8xlzfJPLXZxAg2tbbIBGp/nE2Kol1GfbMOJnoH+tcb/A==",
+      "requires": {}
     },
     "tmp": {
       "version": "0.2.7",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.0",
     "tailwind-merge": "^3.5.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "thinking-orbs": "^0.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/components/AIMode/AIModePage.tsx
+++ b/src/components/AIMode/AIModePage.tsx
@@ -15,6 +15,7 @@ export function AIModePage() {
     isGenerating,
     isClassifying,
     classifiedType,
+    categoryLabels,
     error,
     classifyAndGenerate,
     abort,
@@ -83,6 +84,7 @@ export function AIModePage() {
         isGenerating={isGenerating}
         isClassifying={isClassifying}
         classifiedType={classifiedType}
+        categoryLabels={categoryLabels}
         error={error}
       />
       <ApiKeyModal

--- a/src/components/NewTimeline/GeneratingIndicator.tsx
+++ b/src/components/NewTimeline/GeneratingIndicator.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react'
+import { ThinkingOrb } from 'thinking-orbs'
+
+interface GeneratingIndicatorProps {
+  subject: string
+  phase: 'classifying' | 'generating'
+  categoryLabels: string[]
+}
+
+// Generation is a single non-streaming Sonnet call, so there is no real
+// progress to report. The copy instead tracks the two phases the hook does
+// expose, then cycles the category labels it already resolved for the
+// classified subject so a long wait still reads as specific work.
+const GENERATING_HOLD_MS = 6000
+const ROTATE_MS = 3500
+
+export function GeneratingIndicator({
+  subject,
+  phase,
+  categoryLabels,
+}: GeneratingIndicatorProps) {
+  const [step, setStep] = useState(0)
+  const hasLabels = categoryLabels.length > 0
+
+  // Depend on `hasLabels` rather than the array itself — a caller passing a
+  // fresh `[]` literal would otherwise restart the rotation on every render.
+  useEffect(() => {
+    setStep(0)
+    if (phase !== 'generating' || !hasLabels) return
+
+    let rotate: ReturnType<typeof setInterval> | undefined
+    const hold = setTimeout(() => {
+      setStep(1)
+      rotate = setInterval(() => setStep((s) => s + 1), ROTATE_MS)
+    }, GENERATING_HOLD_MS)
+
+    return () => {
+      clearTimeout(hold)
+      if (rotate) clearInterval(rotate)
+    }
+  }, [phase, hasLabels])
+
+  const trimmedSubject = subject.trim()
+
+  // Announced once per phase. The visible label rotates every few seconds,
+  // which would make a live region chatty, so it stays aria-hidden and this
+  // parallel message carries the announcement instead.
+  const announcement =
+    phase === 'classifying'
+      ? `Researching ${trimmedSubject}`
+      : 'Building the timeline'
+
+  let message: string
+  if (phase === 'classifying') {
+    message = `Researching ${trimmedSubject}…`
+  } else if (step === 0 || !hasLabels) {
+    message = 'Building the timeline…'
+  } else {
+    message = `Gathering ${categoryLabels[(step - 1) % categoryLabels.length]}…`
+  }
+
+  return (
+    <div className="mt-[24px] flex flex-col items-start gap-[10px] duration-150 ease-in fill-mode-forwards animate-in fade-in-0 slide-in-from-top-1">
+      <div className="inline-flex items-center gap-[16px] max-w-full pl-[12px] pr-[28px] py-[12px] rounded-full border border-[#262626] bg-[rgba(184,184,184,0.04)] backdrop-blur-[4px] shadow-[0px_8px_32px_0px_rgba(155,158,163,0.04)]">
+        <ThinkingOrb
+          state="searching"
+          size={64}
+          theme="dark"
+          aria-hidden="true"
+          className="shrink-0"
+        />
+        <span
+          aria-hidden="true"
+          className="font-['Avenir',sans-serif] text-[20px] leading-[28px] text-text-tertiary whitespace-nowrap overflow-hidden text-ellipsis"
+        >
+          {message}
+        </span>
+      </div>
+
+      <p className="body-m text-text-tertiary pl-[16px]">Press Esc to cancel</p>
+
+      <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {announcement}
+      </span>
+    </div>
+  )
+}

--- a/src/components/NewTimeline/NewTimelineScreen.tsx
+++ b/src/components/NewTimeline/NewTimelineScreen.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import type { SubjectType } from '@/constants/pillDefinitions'
 import { SubjectSuggestions } from '@/components/AIMode/SubjectSuggestions'
+import { GeneratingIndicator } from '@/components/NewTimeline/GeneratingIndicator'
 import { useSubjectSuggestions } from '@/hooks/useSubjectSuggestions'
 
 interface NewTimelineScreenProps {
@@ -9,6 +10,7 @@ interface NewTimelineScreenProps {
   isGenerating: boolean
   isClassifying: boolean
   classifiedType: SubjectType | null
+  categoryLabels: string[]
   error: string | null
 }
 
@@ -110,6 +112,7 @@ export function NewTimelineScreen({
   onCancel,
   isGenerating,
   isClassifying,
+  categoryLabels,
   error,
 }: NewTimelineScreenProps) {
   const [name, setName] = useState('')
@@ -211,6 +214,7 @@ export function NewTimelineScreen({
           <form
             ref={formRef}
             onSubmit={handleSubmit}
+            aria-busy={isWorking}
             className="w-[996px] max-w-full flex flex-col"
           >
             <h2 className="header-xsmall text-text-tertiary m-0">
@@ -264,7 +268,15 @@ export function NewTimelineScreen({
               )}
             </div>
 
-            {error && (
+            {isWorking && (
+              <GeneratingIndicator
+                subject={name}
+                phase={isClassifying ? 'classifying' : 'generating'}
+                categoryLabels={categoryLabels}
+              />
+            )}
+
+            {!isWorking && error && (
               <p className="mt-[16px] text-sm text-red-400">{error}</p>
             )}
           </form>


### PR DESCRIPTION
## What

Typing a subject on `/` and pressing Enter kicks off three sequential awaits — a limit pre-flight, a Haiku classify call, and a **non-streaming** Sonnet `max_tokens: 4096` generate call. Until now the only visible feedback for that entire wait was `disabled:opacity-70` on the 60px input. No spinner, no copy, no progress, no live region — and no loading UI on the `/editor` side either, since navigation only fires once the full result is in hand.

This adds a `GeneratingIndicator`: the [`thinking-orbs`](https://github.com/Jakubantalik/thinking-orbs) `searching` orb (a dotted globe with a sweeping scan meridian) in a pill of status copy, rendered under the input while work is in flight.

## Status copy

The copy tracks the two phases `useAIMode` already exposes, then cycles the category labels it had been resolving and **discarding** — `categoryLabels` was computed from `PILL_DEFINITIONS[type]` and returned by the hook, but no component consumed it. It's free, specific data about what's being built:

| Phase | Copy |
|---|---|
| `isClassifying` | `Researching Marie Curie…` |
| `isGenerating`, first 6s | `Building the timeline…` |
| `isGenerating`, after 6s | `Gathering Personal Life…` → `Gathering Career & Education…` → … (3.5s each, looping) |

A `Press Esc to cancel` hint sits under the pill. Escape was already wired to `abort()`; nothing told the user.

## Notes

- **Bundled, not lazy-loaded.** The package adds **+16.3 kB raw / +6.9 kB gzip** (744.91 → 761.22 kB; gzip 230.36 → 237.21 kB). The repo's lazy-load precedent exists for `exceljs` at ~1MB; here a chunk fetch at the exact moment the orb needs to paint would defeat the purpose.
- **`theme="dark"` is pinned** rather than left on `auto`. The app is dark-only — `index.html` hard-codes `<html class="dark">` and `index.css` has a single `:root` block with no `.dark` override. `auto` would resolve correctly anyway, but pinning skips the library's `MutationObserver`.
- The orb is plain 2D canvas — no WebGL, no workers, no network. It respects `prefers-reduced-motion` with a static frame and pauses itself offscreen and on hidden tabs. **No CSP change needed**, which was worth checking: `script-src 'self'` with no `blob:`/`worker-src` would have broken a worker-based library.
- The visible label is `aria-hidden`; a parallel `role="status"` region announces the **phase** only, so a rotating label doesn't make a screen reader chatty.
- The error message is now gated on `!isWorking` so a stale error can't stack with the indicator, and the form is marked `aria-busy`.

## Verification

No test framework is configured, so this was driven in Chromium against a stubbed Anthropic endpoint:

- ✅ Phase copy and rotation land in the documented order
- ✅ Canvas paints **distinct frames** (pixel-sum differs across frames); under emulated `prefers-reduced-motion: reduce` the sums are **byte-identical** — confirmed frozen
- ✅ Esc mid-generation removes the pill and re-enables the input
- ✅ Success path navigates to `/editor` with the generated events present, no pill left behind
- ✅ Error path (401 from Anthropic) shows the red error text with no pill remaining
- ✅ **Zero CSP violations** serving a real `dist/` build with `netlify.toml`'s production header applied — this one can't be caught by `npm run dev` or `npm run preview`
- ✅ `tsc --noEmit` and `npm run lint` clean

## Not addressed

- **`abort()` doesn't cancel the in-flight request** (`useAIMode.ts:129-136`) — it sets a flag that stops the *result* from being applied. Esc hides the pill, but the Sonnet call keeps running and still consumes a rate-limit slot. Pre-existing; worth a follow-up.
- `classifiedType` remains a dead prop on `NewTimelineScreen`. Left alone to keep the diff tight.
- `thinking-orbs` is new — v0.2.0, published 2026-08-03, three releases, single author, MIT. `^0.2.0` on a `0.x` resolves to `>=0.2.0 <0.3.0`, so a breaking `0.3.0` won't be picked up automatically.

---
_Generated by [Claude Code](https://claude.ai/code/session_019XgamSsk46Q6J8BrdJR5UR)_