### PR TITLE
Rename side panel creation buttons

### DIFF
--- a/src/components/SidePanel/SidePanelBody.tsx
+++ b/src/components/SidePanel/SidePanelBody.tsx
@@ -554,8 +554,8 @@ export function SidePanelBody() {
 
       {/* Creation actions */}
       <div className="flex flex-col p-3 shrink-0">
-        <SidePanelActionButton icon={Telescope} label="Discover a Timeline" onClick={handleBuildWithAI} />
-        <SidePanelActionButton icon={CirclePlus} label="Create a Timeline" onClick={handleBuildFromScratch} />
+        <SidePanelActionButton icon={Telescope} label="AI Timeline" onClick={handleBuildWithAI} />
+        <SidePanelActionButton icon={CirclePlus} label="New Timeline" onClick={handleBuildFromScratch} />
         <SidePanelActionButton icon={FileSpreadsheet} label="Import Data" onClick={handleImportData} />
         <SidePanelActionButton icon={Download} label="Download Template" onClick={handleDownloadTemplate} />
       </div>


### PR DESCRIPTION
## Summary

Renames the two primary action buttons at the top of the timelines side panel:

- "Discover a Timeline" → "AI Timeline"
- "Create a Timeline" → "New Timeline"

## Details

Text-only change, one file: `src/components/SidePanel/SidePanelBody.tsx` (lines 557–558). The `label` prop passed to `SidePanelActionButton` is both the visible text and the button's accessible name (no separate `aria-label`), so updating it is sufficient.

No changes to handlers (`handleBuildWithAI` / `handleBuildFromScratch`), routing, icons, or any other component — both buttons still navigate to the same destinations as before.

Confirmed via full-repo search that these strings aren't duplicated elsewhere (no constants/i18n layer, no matching copy on the destination screens).

## Testing

- `npm run lint` — clean
- `npm run build` — succeeds
- Manually verified in dev server: side panel shows "AI Timeline" (Telescope icon) and "New Timeline" (CirclePlus icon); both still navigate correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQpLD8BkpNHQMFBgsc51S7)_