### PR TITLE
Add OpenAI as a second BYOK provider; single-screen key modal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ src/
 ├── hooks/            # Custom React hooks (useTimeline, useEvents, useAutosave, useAIMode, etc.)
 ├── contexts/         # React Context providers (AuthContext, SidePanelContext)
 ├── services/         # AI generation + external APIs:
-│                     #   aiTimeline, anthropicDirect (BYOK), eventEnrichment,
+│                     #   aiTimeline, anthropicDirect + openaiDirect (BYOK),
+│                     #   llmShared (provider-neutral), eventEnrichment,
 │                     #   llmPrompts, userApiKey, viewerEventCache,
 │                     #   wikipediaSearch, wikipediaImage
 ├── utils/            # Helpers (csvParser, excelSheet/excelExport, dateUtils,
@@ -105,7 +106,7 @@ Each of these was learned the expensive way. See `docs/2026-08-05-security-revie
 
 That sentence is the whole model. Everything below is how it is enforced.
 
-- **Four states, three of them tiers.** `useAccountTier()` (`src/hooks/useAccountTier.ts`) is the single source of truth, derived from two independent axes — is there an account, is there an Anthropic key:
+- **Four states, three of them tiers.** `useAccountTier()` (`src/hooks/useAccountTier.ts`) is the single source of truth, derived from two independent axes — is there an account, is there a BYOK key (OpenAI *or* Anthropic; limits are identical either way, so the provider is deliberately not a third axis):
 
   | State | Signed in | Key | Storage | Limits |
   |---|---|---|---|---|
@@ -117,7 +118,8 @@ That sentence is the whole model. Everything below is how it is enforced.
   **Trial is deliberately not a fourth plan.** It is absent from `PLAN_LIMITS`, has no row in the tier table, and costs nothing to host — so there is nothing to meter. `Plan` in `src/constants/plans.ts` holds only the three durable tiers.
 
 - **`useAccountTier` must be consumed with its `'loading'` state respected.** `user` is null both before the session lookup answers and when genuinely signed out; answering `trial` in that window points a signed-in user's editor at the wrong store. Same trap `authReady` exists to close.
-- **Server-funded AI requires sign-in.** Anonymous visitors hitting Generate get a gate offering email sign-in or their own Anthropic key. BYOK runs browser-direct (`services/anthropicDirect.ts`) and never touches our servers.
+- **Server-funded AI requires sign-in.** Anonymous visitors hitting Generate get a gate offering email sign-in or their own OpenAI or Anthropic key. BYOK runs browser-direct (`services/anthropicDirect.ts`, `services/openaiDirect.ts`) and never touches our servers. When both keys are saved, `getActiveCredential()` in `services/userApiKey.ts` resolves which one is used — and when exactly one key exists it wins regardless of the stored preference, which is what keeps the tier logic and the routing logic from disagreeing.
+- **`connect-src` in `netlify.toml` must list every provider host the browser calls directly.** A missing entry fails *only* in production — the dev server sends no CSP and `npm run preview` doesn't apply the header file — and it surfaces as a generic "Failed to fetch", which reads like an app bug rather than a blocked request.
 - **Storage reconciliation promotes upward only** (`App.tsx`). Content in a store below the current tier is moved up on mount — never on a transition watcher, because the identity change usually happens while the editor is unmounted (the key gate lives on `/`, sign-in can start from the side panel anywhere). Removing a key drops you to trial and must leave localStorage drafts exactly where they are: dormant, not deleted.
 - **The only gate on trial work** is starting something new while the single slot is occupied. Everything else already autosaves, so navigating away and refreshing were never lossy.
 - **Identity is email-only** — passwordless OTP, 6-digit codes, custom SMTP via Resend from `timeline.academy`. Supabase's Email OTP Length setting must stay at 6 to match the UI.

--- a/docs/2026-08-12-openai-byok-prd.md
+++ b/docs/2026-08-12-openai-byok-prd.md
@@ -1,0 +1,165 @@
+# OpenAI as a second BYOK provider — 12 August 2026
+
+Product requirements and implementation record for adding OpenAI alongside Anthropic in bring-your-own-key mode, collapsing the key-entry modal to a single screen, and refreshing model pins that had fallen a generation behind on both providers. Written alongside the change rather than after it, so the "verified vs. unverified" split in section 7 is the honest state at merge time, not an aspiration.
+
+---
+
+## 1. Summary
+
+Timeline Academy's AI ran on Anthropic only. A visitor who wanted to generate without an account had to paste an Anthropic key, and the key-entry flow cost two screens: a "Generate with AI" modal offering **Add Anthropic key** / **Sign in instead**, then a second screen with the `sk-ant-…` input hidden behind a Back button.
+
+Two problems. Anthropic being the only option excluded anyone who already had an OpenAI account and no reason to open an Anthropic one. And the extra click hid the actual ask behind a button that only restated it.
+
+What shipped:
+
+- **OpenAI is a first-class BYOK provider**, with the same three capabilities as Anthropic: timeline generation, subject classification, and event enrichment with live web search feeding the Sources list.
+- **The modal is one screen.** Both key fields are visible on open. Either key alone is sufficient. When both are present, a default-provider picker appears.
+- **Model pins are current on both providers**, and the three Sonnet 5 breaking changes that refresh triggered are handled.
+- **Two cost-honesty changes**: the modal no longer describes BYOK as "free", and Regenerate now confirms before spending.
+
+The tier model is unchanged. `byok_enabled` is still a boolean, no provider is recorded server-side, and **no migration or SQL change was needed** — which is the main reason this landed without touching the part of the system that has historically drifted.
+
+---
+
+## 2. Product decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Modal layout | One screen, both inputs visible | The reveal step restated the ask instead of advancing it |
+| Both keys saved | Explicit default-provider picker | Users should be able to see and choose which account gets billed |
+| Sign-in affordance | Demoted to a text link | Keys are the primary path in this modal; sign-in is the alternative |
+| Tier treatment | Any key grants `byok` / `byok-anon` identically | Limits do not vary by provider, so provider is not an axis |
+| Enrichment | Full parity — OpenAI web search feeds the same Sources list | A description without sources is a materially worse product |
+| Provider failure | No silent failover; an explicit "Retry with «other»" action | Spending on an account the user did not pick for this request is a surprise, and auto-retry hides a broken key |
+| Model selection | App-controlled, no UI | Model IDs go stale; a user-facing dropdown becomes wrong within months and asks students to make a choice they have no basis for |
+| Cost disclosure | Qualitative, no figures | Numbers drift with provider pricing and vary by timeline size |
+
+**Rejected: a user-facing model picker.** The API key is an authentication credential; the model is a per-request parameter. The app already chose per task — a capable model for generation and enrichment, a cheap one for classification — and that split is not a judgement a user can make better, since they cannot see which call is a one-word classification.
+
+---
+
+## 3. The CORS question — unresolved, and it gates the transport
+
+Anthropic supports browser-direct calls deliberately: `anthropicDirect.ts:32` sends `anthropic-dangerous-direct-browser-access: true`, which is Anthropic's explicit opt-in for exactly this use case.
+
+**OpenAI publishes no equivalent.** Whether `api.openai.com` returns permissive CORS headers to browser-origin requests is a property of their policy, not something the client can assert. Public evidence is genuinely split: browser-based bring-your-own-key apps exist and appear to work, and there are also many developer reports of browser-origin requests failing while identical server-side calls succeed.
+
+**This was not verified.** The development container's egress proxy returns 403 on CONNECT to `api.openai.com` and blocks OpenAI's documentation domains, so neither a live call nor an authoritative doc read was possible. The implementation assumes browser-direct works, because that is the outcome that preserves the existing privacy property.
+
+Before trusting the OpenAI path, run this from the browser console on a page served by `npm run dev`, then read DevTools → Network:
+
+```js
+fetch('https://api.openai.com/v1/models', { headers: { Authorization: 'Bearer ' + key } })
+```
+
+`curl` cannot answer this. CORS is a browser-only mechanism, and `curl` succeeds against endpoints browsers refuse to call — the same distinction that cost hours during the August 2025 outage.
+
+**If it is blocked**, the OpenAI path needs a pass-through edge function that forwards the key without storing or logging it, and three things become mandatory rather than optional: the modal's OpenAI helper text must say the key transits our server, `PrivacyPolicyPage.tsx` must say the same, and the relay must never log the key or the provider error body — `2026-08-05-security-review-handoff.md` §2 records that relaying provider error bodies verbatim was already fixed once.
+
+---
+
+## 4. What changed
+
+**New modules.** `src/types/ai.ts` holds the provider-neutral types. `src/services/llmShared.ts` holds `parseTimelineJson`, `stripCodeFence`, `readApiError`, `readSseStream` and `ProviderError`. `src/services/openaiDirect.ts` mirrors `anthropicDirect.ts`. `src/constants/byokProviders.ts` holds the display metadata every surface reads from, so provider naming cannot drift. `src/components/Settings/ByokDefaultProviderPicker.tsx` is one component mounted in two places over one persisted value.
+
+Extracting the shared core first was not tidiness. `anthropicDirect.ts` imported `EnrichmentStreamHandlers` from `eventEnrichment.ts`, which imported `enrichEventDirect` back — a type-only cycle that was harmless with one provider and would not have been with two.
+
+**Storage.** `src/services/userApiKey.ts` was rewritten around three slots. `timeline_byok_anthropic_key` keeps its exact name: renaming it is silent data loss for every existing BYOK user, with no error and no migration path. The old `getAnthropicKey` / `setAnthropicKey` / `clearAnthropicKey` / `useAnthropicKey` exports were **deleted rather than shimmed** — their meaning shifts subtly from "the Anthropic key" to "the key in use", and a same-named shim would let a stale call site compile while reading the wrong slot. The compiler found all seven importers.
+
+The resolution rule in `getActiveCredential()` has one branch that is load-bearing rather than an optimisation: **when exactly one key exists it wins, regardless of a stale preference.** Without it, a user whose preference says `openai` who then removes their OpenAI key reads as `byok` to the tier logic (a key exists) and as "no key" to the routing logic — a split brain surfacing as a sign-in gate they should never see.
+
+The cross-tab `storage` listener now watches all three slots and handles `e.key === null`, which is what another tab's `localStorage.clear()` produces and which the old single-key filter silently dropped.
+
+**Routing.** `aiTimeline.ts` and `eventEnrichment.ts` branch on the resolved credential and accept an optional `providerOverride` for the retry action. The override deliberately does not change the stored default, so a one-off retry never silently redefines which provider a user is on.
+
+**CSP.** `netlify.toml` gained `https://api.openai.com` in `connect-src`.
+
+---
+
+## 5. Refreshing the model pins, and the three things that broke
+
+Both providers were a generation behind: the client pinned `claude-sonnet-4-6` and `claude-haiku-4-5-20251001`, the edge functions pinned `gpt-4o` and `gpt-4o-mini`. Current pins and list prices:
+
+| Role | Was | Now | $/MTok in → out |
+|---|---|---|---|
+| Anthropic capable | `claude-sonnet-4-6` | `claude-sonnet-5` | $3 → $15 |
+| Anthropic cheap | `claude-haiku-4-5-20251001` | `claude-haiku-4-5` | $1 → $5 |
+| OpenAI capable | `gpt-4o` | `gpt-5.6-terra` | $2 → $12 |
+| OpenAI cheap | `gpt-4o-mini` | `gpt-5.6-luna` | $0.20 → $1.20 |
+
+All four are deliberately mid- or budget-tier. `claude-fable-5` ($10/$50) and `gpt-5.6-sol` ($5/$30) cost several times as much for bounded JSON generation and short prose, and on BYOK that spend lands on the user's own account. **The reasoning is in a comment beside each constant**, because "upgrade to the better model" looks like an obvious improvement to anyone who has not thought about the workload.
+
+Moving to `claude-sonnet-5` broke three things, each of which fails only at runtime:
+
+1. **Non-default `temperature` returns a 400.** `anthropicDirect.ts` set `temperature: 0.4` on generation and `_shared/llm-client.ts` did the same. The second one is the default server-funded path — left in place, it would have broken generation for every free-tier user on the first request after deploy. Both removed.
+2. **Adaptive thinking is now on by default**, where Sonnet 4.6 ran thinking-off when `thinking` was omitted, and `max_tokens` caps thinking *plus* response text. The two calls resolve this in opposite directions on purpose. Generation sets `thinking: {type: 'disabled'}` — it emits a fixed JSON schema with no tools, so there is nothing for reasoning to improve. Enrichment leaves thinking on and raises `max_tokens` from 1024 to 4096, because with thinking off Sonnet 5 reaches for tools noticeably less often, and an enrichment where `web_search` never fires produces a description with an empty Sources list and no error anywhere.
+3. **Assistant prefill returns a 400 on Sonnet-tier models.** Both prefill sites turned out to run on Haiku 4.5 — `classifySubjectDirect` and `_shared/classify.ts` — which still supports it. No change needed, but the constraint is now commented at both sites so a future pin change does not silently break them.
+
+The web-search tool was upgraded from `web_search_20250305` to `web_search_20260209` on both enrichment paths. The newer variant filters results before they enter the context window, which lands directly on the most expensive call in the product.
+
+---
+
+## 6. What actually drives the AI bill
+
+Worth recording, because the intuition that "the app picks the model, so the app could pick something ruinous" points at the wrong risk.
+
+**Enrichment results are cached, and the guard is solid.** `EventDetailPanel.tsx:28-30` checks `Boolean(event?.description)` before every call and short-circuits when one exists. The result persists on all three storage paths — Supabase `events.description` for signed-in users, localStorage drafts for logged-out, and a per-browser cache for public viewers — and `timelineFingerprint.ts:104` includes `description`, so the write actually arms. A user pays once per event, not once per open. There is no batching anywhere: `enrichEvent` has exactly one call site, reachable only by a deliberate click.
+
+**Per-unit costs** on Sonnet 5: classification is a fraction of a cent, generation is roughly $0.02, and each event opened is roughly $0.06 — dominated by up to three web searches at $10 per 1,000, not by tokens. Exploring a thirty-event timeline end to end lands near $2, once.
+
+**The real exposures are not model choice**, and three of the four are unchanged by this work:
+
+- **BYOK has no client-side rate limiting.** `_shared/rate-limiter.ts` is Deno code the browser never imports, and `eventEnrichment.ts` returns before it. The 5/day and 30/day caps protect Timeline Academy's budget, not the user's.
+- **Aborted enrichments bill but do not persist.** `EventDetailPanel.tsx` bails on `ctrl.signal.aborted` inside `onDone`, so closing the panel mid-stream discards work the provider already charged for, and reopening starts a fresh call.
+- **Regenerate was uncapped** — no confirmation, no counter. **Fixed here**: the footer button now confirms, and the message says a new billed call including a fresh web search will run. The error-state "Try again" deliberately does *not* confirm, because recovering from a failure is not accidental repeat spend.
+- **The only cost-adjacent copy in the product called it free.** `ApiKeyModal.tsx` said BYOK was "free, no rate limits" — true of *our* limits, and read by users as free. **Fixed here.**
+
+---
+
+## 7. Verified vs. unverified
+
+Following the convention in `2026-08-07-verification-runbook.md`: shipped is not the same as verified.
+
+**Verified in a real browser** against `npm run dev`, driven by Playwright:
+
+- The modal renders one screen with both fields visible, no Back button, no reveal step.
+- Empty submit produces the form-level error; the modal stays open.
+- Pasting an `sk-ant-…` key into the OpenAI field produces an error naming the mix-up, and clears as soon as the field is corrected.
+- The default-provider picker appears live while the second key is typed, not only after a save.
+- Saving both keys writes all three localStorage slots correctly.
+- **Back-compat**: a pre-existing `timeline_byok_anthropic_key` alone still promotes the visitor out of trial, and the slot is untouched.
+- **Cross-tab**: a write to the OpenAI or preference slot in one tab is observed by another, and `localStorage.clear()` in one tab is observed by the other.
+- No clipping at a 600px viewport height.
+
+**Verified by the compiler**: `tsc --noEmit` reports no errors in any file this change touched, and `eslint` is clean.
+
+**NOT verified — do these before trusting the feature:**
+
+1. **The CORS question in section 3.** Everything about the OpenAI transport rests on it.
+2. **Every OpenAI request and stream-event shape.** The Responses API request body, the `response.output_text.delta` / `response.output_text.annotation.added` / `response.completed` event names, and the `url_citation` annotation fields all come from secondary sources, because OpenAI's documentation domains are egress-blocked from the development container. Capture one real SSE transcript and reconcile before relying on the Sources list.
+3. **The GPT-5.6 parameter contract.** Whether `max_tokens`, `response_format` and the absence of `temperature` are correct for that family is unconfirmed. `temperature` was removed defensively on the OpenAI paths, which is the safe direction: if the model accepts it, the cost is slightly more output variance; if it rejects it, keeping it would 400 every request.
+4. **Anthropic generation after the pin refresh.** The `temperature` removal and the thinking/`max_tokens` interaction are both silent-until-production. Run one generation and one enrichment on a real Anthropic key.
+5. **Production CSP.** `curl -sI https://<site>/ | grep -i content-security-policy` and confirm `api.openai.com` is present, then run one real OpenAI enrichment against production.
+
+**A gap worth knowing about**: `npm run build` is `vite build` alone and does **not** type-check. There are 16 pre-existing TypeScript errors in the repository that ship silently as a result. `npx tsc --noEmit -p tsconfig.app.json` is the real gate; none of the 16 are in files this change touched.
+
+---
+
+## 8. Open items
+
+- Persist partial descriptions when an enrichment is aborted, so impatient clicking does not re-bill. Needs care: a partial description must not be stored as if it were complete.
+- `UsageLimits.tsx` shows BYOK events as "Unlimited" with an infinity glyph while `plans.ts` caps them at 1200 and `useAIMode.ts` enforces it.
+- Server-side provider selection is inconsistent: `generate-timeline/index.ts` reads `DEFAULT_LLM_PROVIDER`, while `_shared/classify.ts` picks by key presence.
+- The edge functions' OpenAI path is rarely exercised — it runs only when `DEFAULT_LLM_PROVIDER` is `openai`, or when `ANTHROPIC_API_KEY` is unset — so its refreshed pins are the least-tested part of this change.
+
+---
+
+## 9. Decisions worth not re-litigating
+
+- **No user-facing model picker.** Rejected in section 2. The maintenance burden is permanent and the user has no basis for the choice.
+- **No automatic failover between providers.** Silently spending on the user's other account is a surprise nobody asked for, and it masks an invalid key. The explicit retry action does the same job with the user's consent.
+- **The provider is not a tier axis.** Recording it in `app_metadata` would mean an SQL change and a migration for no behavioural difference, since limits are identical either way. `byok_enabled` stays boolean.
+- **The stored preference is not cleared when its provider's key is removed.** The one-key-wins branch in `getActiveCredential()` covers the gap, and re-adding that key restores what the user actually asked for.
+- **`timeline_byok_anthropic_key` keeps its name forever**, or keeps it until someone writes a read-old/write-new migration. It is not a naming inconsistency worth tidying.
+- **Old exports were deleted, not shimmed.** The compiler catching seven call sites was the point; a shim would have traded that for a silent wrong-slot read.
+- **Cost copy stays qualitative.** A concrete figure is a claim that drifts with provider pricing and varies by timeline size, and being wrong about money is worse than being vague about it.

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,9 +11,15 @@
     # Fonts for Aleo/IBM Plex Mono/JetBrains Mono, cdnfonts for Avenir);
     # 'unsafe-inline' is for React's inline style attributes. connect-src
     # covers Supabase (REST + realtime websocket), browser-direct BYOK calls
-    # to Anthropic, and browser-direct Wikipedia lookups. img-src covers
-    # Wikimedia event thumbnails.
-    Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.cdnfonts.com; img-src 'self' data: https://*.wikimedia.org; font-src 'self' data: https://fonts.gstatic.com https://fonts.cdnfonts.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.anthropic.com https://en.wikipedia.org; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
+    # to Anthropic and OpenAI, and browser-direct Wikipedia lookups. img-src
+    # covers Wikimedia event thumbnails.
+    #
+    # connect-src must list EVERY provider host the browser calls directly.
+    # A missing entry fails only in production — the dev server sends no CSP
+    # and `npm run preview` does not apply these headers — and it surfaces as
+    # a generic "Failed to fetch", which reads like a broken app rather than a
+    # blocked request.
+    Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.cdnfonts.com; img-src 'self' data: https://*.wikimedia.org; font-src 'self' data: https://fonts.gstatic.com https://fonts.cdnfonts.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.anthropic.com https://api.openai.com https://en.wikipedia.org; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
     # Keep /view/<uuid> share URLs (the access capability) out of Referer
     # headers sent to external hosts.
     Referrer-Policy = "strict-origin-when-cross-origin"

--- a/src/components/AIMode/AIModePage.tsx
+++ b/src/components/AIMode/AIModePage.tsx
@@ -6,7 +6,8 @@ import { AuthModal } from '@/components/Auth/AuthModal'
 import { ApiKeyModal } from '@/components/Modal/ApiKeyModal'
 import { useAIMode } from '@/hooks/useAIMode'
 import { useAuth } from '@/hooks/useAuth'
-import { getAnthropicKey } from '@/services/userApiKey'
+import { hasAnyKey } from '@/services/userApiKey'
+import type { ByokProvider } from '@/types/ai'
 
 export function AIModePage() {
   const navigate = useNavigate()
@@ -17,21 +18,31 @@ export function AIModePage() {
     classifiedType,
     categoryLabels,
     error,
+    retryProvider,
     classifyAndGenerate,
     abort,
   } = useAIMode()
 
   // Server-funded generation requires sign-in; anonymous visitors can instead
-  // add their own Anthropic key (browser-direct, never touches our servers).
-  // When a signed-out, keyless visitor hits Generate we stash the subject,
-  // open the gate, and resume once either path completes.
+  // add their own OpenAI or Anthropic key. When a signed-out, keyless visitor
+  // hits Generate we stash the subject, open the gate, and resume once either
+  // path completes.
   const [showApiKeyModal, setShowApiKeyModal] = useState(false)
   const [showAuthModal, setShowAuthModal] = useState(false)
   const pendingSubjectRef = useRef<string | null>(null)
+  // The last subject actually attempted, so a retry against the other
+  // provider knows what to re-run. `pendingSubjectRef` can't serve here — it
+  // is cleared as soon as the gate resolves.
+  const lastSubjectRef = useRef<string | null>(null)
 
-  const runGeneration = async (subject: string) => {
+  const runGeneration = async (
+    subject: string,
+    providerOverride?: ByokProvider,
+  ) => {
+    lastSubjectRef.current = subject
     try {
-      const { title, description, events, categories } = await classifyAndGenerate(subject)
+      const { title, description, events, categories } =
+        await classifyAndGenerate(subject, providerOverride)
       navigate('/editor', {
         state: {
           aiGenerated: { title, description, events, categories },
@@ -43,7 +54,7 @@ export function AIModePage() {
   }
 
   const handleAIGenerate = async (subject: string) => {
-    if (!user && !getAnthropicKey()) {
+    if (!user && !hasAnyKey()) {
       pendingSubjectRef.current = subject
       setShowApiKeyModal(true)
       return
@@ -86,6 +97,11 @@ export function AIModePage() {
         classifiedType={classifiedType}
         categoryLabels={categoryLabels}
         error={error}
+        retryProvider={retryProvider}
+        onRetryWithProvider={(provider) => {
+          const subject = lastSubjectRef.current
+          if (subject) void runGeneration(subject, provider)
+        }}
       />
       <ApiKeyModal
         isOpen={showApiKeyModal}

--- a/src/components/EventDetailPanel/EventDetailPanel.tsx
+++ b/src/components/EventDetailPanel/EventDetailPanel.tsx
@@ -8,6 +8,9 @@ import {
   fetchEventImage,
 } from '@/services/eventEnrichment'
 import type { EventSource, TimelineEvent } from '@/types/event'
+import type { ByokProvider } from '@/types/ai'
+import { PROVIDER_META } from '@/constants/byokProviders'
+import { getKey } from '@/services/userApiKey'
 
 interface EventDetailPanelProps {
   open: boolean
@@ -43,7 +46,20 @@ export function EventDetailPanel({
   const [imageAttribution, setImageAttribution] = useState<string | null>(null)
   const [sources, setSources] = useState<EventSource[]>([])
   const [errorMessage, setErrorMessage] = useState('')
+  const [errorProvider, setErrorProvider] = useState<ByokProvider | null>(null)
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false)
+  const [showRegenerateConfirm, setShowRegenerateConfirm] = useState(false)
+
+  // The other provider, offered only when the user has a key for it. No
+  // automatic failover — spending on an account the user didn't pick for this
+  // request is a surprise, and it hides that a key is broken.
+  const retryProvider: ByokProvider | null = errorProvider
+    ? (() => {
+        const other: ByokProvider =
+          errorProvider === 'openai' ? 'anthropic' : 'openai'
+        return getKey(other) ? other : null
+      })()
+    : null
   const abortRef = useRef<AbortController | null>(null)
   const panelRef = useRef<HTMLElement | null>(null)
 
@@ -77,6 +93,7 @@ export function EventDetailPanel({
     setImageAttribution(null)
     setSources([])
     setErrorMessage('')
+    setErrorProvider(null)
 
     runGeneration(event, false)
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -92,15 +109,15 @@ export function EventDetailPanel({
   // Escape closes the panel. Click outside the panel also closes it (desktop
   // has no visible backdrop so the timeline behind stays visible, but a click
   // anywhere off-panel should still dismiss the way Cancel would). Suppress
-  // outside-click while the destructive Remove confirmation modal is open so
-  // clicking the modal's overlay doesn't also dismiss the panel.
+  // outside-click while a confirmation modal is open so clicking the modal's
+  // overlay doesn't also dismiss the panel underneath it.
   useEffect(() => {
     if (!open) return
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
     }
     const handleMouseDown = (e: MouseEvent) => {
-      if (showRemoveConfirm) return
+      if (showRemoveConfirm || showRegenerateConfirm) return
       const node = panelRef.current
       if (!node) return
       const target = e.target as Node | null
@@ -116,9 +133,13 @@ export function EventDetailPanel({
       document.removeEventListener('keydown', handleKey)
       document.removeEventListener('mousedown', handleMouseDown)
     }
-  }, [open, onClose, showRemoveConfirm])
+  }, [open, onClose, showRemoveConfirm, showRegenerateConfirm])
 
-  function runGeneration(currentEvent: TimelineEvent, preserveImage: boolean) {
+  function runGeneration(
+    currentEvent: TimelineEvent,
+    preserveImage: boolean,
+    providerOverride?: ByokProvider,
+  ) {
     // Abort any prior in-flight generation
     if (abortRef.current) abortRef.current.abort()
     const ctrl = new AbortController()
@@ -132,6 +153,7 @@ export function EventDetailPanel({
     }
     setSources([])
     setErrorMessage('')
+    setErrorProvider(null)
 
     let descBuffer = ''
     let collectedSources: EventSource[] = []
@@ -181,20 +203,32 @@ export function EventDetailPanel({
           })
           setState('loaded')
         },
-        onError: (message) => {
+        onError: (message, provider) => {
           if (ctrl.signal.aborted) return
           setErrorMessage(message)
+          setErrorProvider(provider ?? null)
           setState('error')
         },
       },
       ctrl.signal,
+      providerOverride,
     )
   }
 
-  function handleRegenerate() {
+  /** Run generation immediately, no confirmation. Used for error recovery,
+   *  where the previous attempt produced nothing to protect. */
+  function regenerateNow(providerOverride?: ByokProvider) {
     if (!event) return
     // Preserve image only if we already have one.
-    runGeneration(event, !!imageUrl)
+    runGeneration(event, !!imageUrl, providerOverride)
+  }
+
+  /** Footer "Regenerate", which replaces a description that already worked.
+   *  Confirmed because each run is a fresh billed call — on a BYOK key that
+   *  is the user's own money, and nothing else in the product caps it. */
+  function handleRegenerate() {
+    if (!event) return
+    setShowRegenerateConfirm(true)
   }
 
   function handleRemove() {
@@ -298,12 +332,22 @@ export function EventDetailPanel({
                     <p className="body-m text-[#9B9EA3] m-0">
                       Couldn't generate details. {errorMessage ? `(${errorMessage})` : ''}
                     </p>
-                    <button
-                      onClick={handleRegenerate}
-                      className="self-start font-['Avenir',sans-serif] text-[14px] leading-[20px] text-[#DADEE5] underline hover:text-white"
-                    >
-                      Try again
-                    </button>
+                    <div className="flex flex-wrap gap-3">
+                      <button
+                        onClick={() => regenerateNow()}
+                        className="font-['Avenir',sans-serif] text-[14px] leading-[20px] text-[#DADEE5] underline hover:text-white"
+                      >
+                        Try again
+                      </button>
+                      {retryProvider && (
+                        <button
+                          onClick={() => regenerateNow(retryProvider)}
+                          className="font-['Avenir',sans-serif] text-[14px] leading-[20px] text-[#9B9EA3] underline hover:text-[#DADEE5]"
+                        >
+                          Retry with {PROVIDER_META[retryProvider].label}
+                        </button>
+                      )}
+                    </div>
                   </div>
                 ) : (
                   description &&
@@ -358,6 +402,16 @@ export function EventDetailPanel({
         title="Remove event details"
         message="This will clear the description, image, and sources for this event. The event itself will not be deleted."
         confirmLabel="Remove"
+        cancelLabel="Cancel"
+      />
+
+      <ConfirmationModal
+        isOpen={showRegenerateConfirm}
+        onClose={() => setShowRegenerateConfirm(false)}
+        onConfirm={() => regenerateNow()}
+        title="Regenerate description?"
+        message="This replaces the current description and runs a new AI request, including a fresh web search. If you're using your own API key, it will be billed to that account."
+        confirmLabel="Regenerate"
         cancelLabel="Cancel"
       />
     </>,

--- a/src/components/Legal/PrivacyPolicyPage.tsx
+++ b/src/components/Legal/PrivacyPolicyPage.tsx
@@ -45,10 +45,10 @@ export function PrivacyPolicyPage() {
           <strong>Netlify</strong> — hosts and serves the website.
         </li>
         <li>
-          <strong>Anthropic</strong> (and, as a fallback, <strong>OpenAI</strong>)
-          — when you generate a timeline or event description with AI, the
-          subject or event title you typed (plus dates and the timeline's
-          title) is sent to the AI provider. We never include your email,
+          <strong>Anthropic</strong> and <strong>OpenAI</strong> — when you
+          generate a timeline or event description with AI, the subject or
+          event title you typed (plus dates and the timeline's title) is sent
+          to whichever provider is in use. We never include your email,
           account ID, or any other identifier in these requests.
         </li>
         <li>
@@ -59,20 +59,27 @@ export function PrivacyPolicyPage() {
         </li>
       </ul>
 
-      <h2>If you use your own Anthropic API key</h2>
+      <h2>If you use your own API key</h2>
       <p>
-        In bring-your-own-key mode, your key is stored only in your browser's
-        local storage — it is never sent to our servers. AI requests then go
-        directly from your browser to Anthropic, which means Anthropic sees
-        your IP address for those requests. Anyone with access to your device
-        and browser profile could read the stored key; remove it in Settings
-        any time.
+        You can bring your own OpenAI or Anthropic API key. It is stored only
+        in your browser's local storage — it is never sent to our servers. AI
+        requests then go directly from your browser to the provider whose key
+        you supplied, which means that provider sees your IP address for those
+        requests, and bills the usage to your account with them rather than to
+        us. Anyone with access to your device and browser profile could read
+        the stored key; remove it in Settings any time.
+      </p>
+      <p>
+        Requests we send to OpenAI on your behalf are marked not to be stored,
+        so they do not accumulate in your OpenAI dashboard. If you save keys
+        for both providers, you choose which one is used by default, and only
+        that provider receives your requests.
       </p>
 
       <h2>What we store in your browser</h2>
       <p>
         Local storage on your device may hold: unsaved timeline drafts, your
-        optional Anthropic API key, AI-generated content for shared timelines
+        optional OpenAI or Anthropic API keys, AI-generated content for shared timelines
         you've viewed, your session sign-in token, and interface preferences.
         Clearing your browser's site data removes all of it.
       </p>

--- a/src/components/Modal/ApiKeyModal.tsx
+++ b/src/components/Modal/ApiKeyModal.tsx
@@ -1,6 +1,17 @@
 import { useEffect, useState } from 'react'
 import { Modal } from './Modal'
-import { setAnthropicKey } from '@/services/userApiKey'
+import { ByokDefaultProviderPicker } from '@/components/Settings/ByokDefaultProviderPicker'
+import { PROVIDER_META, PROVIDER_ORDER } from '@/constants/byokProviders'
+import {
+  getPreferredProvider,
+  hasAnyKey,
+  maskKey,
+  setKey,
+  setPreferredProvider,
+  useByokKeys,
+  validateKeyFormat,
+} from '@/services/userApiKey'
+import type { ByokProvider } from '@/types/ai'
 
 interface ApiKeyModalProps {
   isOpen: boolean
@@ -13,106 +24,213 @@ interface ApiKeyModalProps {
   onRequestSignIn: () => void
 }
 
+type DraftMap = Record<ByokProvider, string>
+type FieldErrors = Partial<Record<ByokProvider | 'form', string>>
+
+const EMPTY_DRAFTS: DraftMap = { openai: '', anthropic: '' }
+const NOT_EDITING: Record<ByokProvider, boolean> = {
+  openai: false,
+  anthropic: false,
+}
+
 export function ApiKeyModal({
   isOpen,
   onClose,
   onKeySaved,
   onRequestSignIn,
 }: ApiKeyModalProps) {
-  const [draft, setDraft] = useState('')
-  const [error, setError] = useState<string | null>(null)
-  const [showInput, setShowInput] = useState(false)
+  const stored = useByokKeys()
+  const [drafts, setDrafts] = useState<DraftMap>(EMPTY_DRAFTS)
+  // A field with a saved key shows the masked value until the user chooses to
+  // replace it — we never prefill an input with a secret, but the modal
+  // shouldn't pretend the key isn't there either.
+  const [editing, setEditing] =
+    useState<Record<ByokProvider, boolean>>(NOT_EDITING)
+  const [preferred, setPreferred] = useState<ByokProvider>('anthropic')
+  const [errors, setErrors] = useState<FieldErrors>({})
 
   // Reset state every time the modal opens.
   useEffect(() => {
     if (isOpen) {
-      setDraft('')
-      setError(null)
-      setShowInput(false)
+      setDrafts(EMPTY_DRAFTS)
+      setEditing(NOT_EDITING)
+      setErrors({})
+      setPreferred(getPreferredProvider() ?? 'anthropic')
     }
   }, [isOpen])
 
+  /** Would this provider have a key after a save? Reacts to drafts as well as
+   *  stored state, so the picker appears as the second key is typed rather
+   *  than only after a save. */
+  const willHaveKey = (provider: ByokProvider) =>
+    Boolean(drafts[provider].trim()) || Boolean(stored[provider])
+
+  const showPicker = willHaveKey('openai') && willHaveKey('anthropic')
+
   const save = () => {
-    const trimmed = draft.trim()
-    if (!trimmed) {
-      setError('Paste a key first.')
+    const entries = PROVIDER_ORDER.map(
+      (provider) => [provider, drafts[provider].trim()] as const,
+    ).filter(([, value]) => value !== '')
+
+    if (entries.length === 0) {
+      // Nothing typed. If keys are already saved this is a preference-only
+      // commit — the only way a two-key user can change their default from
+      // here — otherwise it's an empty submit.
+      if (hasAnyKey()) {
+        if (showPicker) setPreferredProvider(preferred)
+        onKeySaved()
+        return
+      }
+      setErrors({ form: 'Paste at least one key.' })
       return
     }
-    if (!trimmed.startsWith('sk-ant-')) {
-      setError('Anthropic keys start with sk-ant-. Double-check and try again.')
+
+    // Validate every field before persisting any of them. Validating and
+    // saving per field would leave someone who pasted one good key and one
+    // typo with the good key silently stored behind an error message.
+    const nextErrors: FieldErrors = {}
+    for (const [provider, value] of entries) {
+      const message = validateKeyFormat(provider, value)
+      if (message) nextErrors[provider] = message
+    }
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors)
       return
     }
-    setAnthropicKey(trimmed)
+
+    for (const [provider, value] of entries) setKey(provider, value)
+
+    // Keep the stored preference honest even with one key, so the Settings
+    // picker is already correct the moment a second key appears.
+    const present = PROVIDER_ORDER.filter(willHaveKey)
+    setPreferredProvider(present.length > 1 ? preferred : present[0])
+
     onKeySaved()
   }
+
+  // Focus the first field the user actually has to fill in.
+  const firstEmpty = PROVIDER_ORDER.find((provider) => !stored[provider])
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Generate with AI">
       <div className="space-y-4">
         <p className="body-m text-[#c9ced4] m-0">
-          Timeline Academy uses Claude to generate event details and timelines.
-          You can use your own Anthropic API key (free, no rate limits) or sign
-          in to use ours.
+          Timeline Academy uses AI to generate event details and timelines. Add
+          your own OpenAI or Anthropic key to generate without an account —
+          usage is billed to that provider account, not to us. Or sign in to
+          use ours.
         </p>
 
-        {!showInput ? (
-          <div className="flex flex-col gap-2">
-            <button
-              onClick={() => setShowInput(true)}
-              className={glassPrimary}
-            >
-              Add Anthropic key
-            </button>
-            <button
-              onClick={onRequestSignIn}
-              className={glassSecondary}
-            >
-              Sign in instead
-            </button>
-          </div>
-        ) : (
-          <div className="flex flex-col gap-2">
-            <input
-              type="password"
-              placeholder="sk-ant-..."
-              value={draft}
-              onChange={(e) => setDraft(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') save()
-              }}
-              autoFocus
-              spellCheck={false}
-              autoComplete="off"
-              className="w-full h-9 bg-[#242526] border border-[#262626] rounded-[8px] px-3 py-[7.5px] outline-none focus:border-[#404040] font-['JetBrains_Mono',monospace] text-[12px] text-[#DADEE5]"
-            />
-            {error && (
-              <p className="body-m text-destructive m-0">{error}</p>
-            )}
-            <p className="font-['Avenir',sans-serif] text-[12px] leading-[16px] text-[#6b6e73] m-0">
-              Get a key at{' '}
+        {PROVIDER_ORDER.map((provider) => {
+          const meta = PROVIDER_META[provider]
+          const savedKey = stored[provider]
+          const showInput = !savedKey || editing[provider]
+
+          return (
+            <div key={provider} className="flex flex-col gap-1">
+              <label
+                htmlFor={`byok-${provider}`}
+                className="label-m-type2 text-[#9B9EA3]"
+              >
+                {meta.label}
+              </label>
+
+              {showInput ? (
+                <input
+                  id={`byok-${provider}`}
+                  type="password"
+                  placeholder={meta.placeholder}
+                  value={drafts[provider]}
+                  onChange={(e) => {
+                    setDrafts((prev) => ({
+                      ...prev,
+                      [provider]: e.target.value,
+                    }))
+                    // Clear this field's complaint as soon as it is being
+                    // addressed — otherwise a corrected field keeps showing
+                    // the old error until the next save attempt, which reads
+                    // as "still wrong". The form-level error goes too, since
+                    // it only ever means "nothing typed".
+                    setErrors((prev) =>
+                      prev[provider] || prev.form
+                        ? { ...prev, [provider]: undefined, form: undefined }
+                        : prev,
+                    )
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') save()
+                  }}
+                  autoFocus={firstEmpty === provider}
+                  spellCheck={false}
+                  autoComplete="off"
+                  className="w-full h-9 bg-[#242526] border border-[#262626] rounded-[8px] px-3 py-[7.5px] outline-none focus:border-[#404040] font-['JetBrains_Mono',monospace] text-[12px] text-[#DADEE5]"
+                />
+              ) : (
+                <div className="flex items-center justify-between gap-2 h-9 px-3">
+                  <code className="font-['JetBrains_Mono',monospace] text-[12px] text-[#9B9EA3]">
+                    {maskKey(savedKey)}
+                  </code>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setEditing((prev) => ({ ...prev, [provider]: true }))
+                    }
+                    className="font-['Avenir',sans-serif] text-[12px] text-[#9B9EA3] underline hover:text-[#DADEE5]"
+                  >
+                    Replace
+                  </button>
+                </div>
+              )}
+
+              {errors[provider] && (
+                <p className="body-m text-destructive m-0">
+                  {errors[provider]}
+                </p>
+              )}
+            </div>
+          )
+        })}
+
+        {showPicker && (
+          <ByokDefaultProviderPicker
+            value={preferred}
+            onChange={setPreferred}
+          />
+        )}
+
+        {errors.form && (
+          <p className="body-m text-destructive m-0">{errors.form}</p>
+        )}
+
+        <p className="font-['Avenir',sans-serif] text-[12px] leading-[16px] text-[#6b6e73] m-0">
+          Get a key at{' '}
+          {PROVIDER_ORDER.map((provider, i) => (
+            <span key={provider}>
+              {i > 0 && ' or '}
               <a
-                href="https://console.anthropic.com/settings/keys"
+                href={PROVIDER_META[provider].consoleUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="underline hover:text-[#9B9EA3]"
               >
-                console.anthropic.com
+                {PROVIDER_META[provider].consoleLabel}
               </a>
-              . Stored only in this browser.
-            </p>
-            <div className="flex gap-2 justify-end">
-              <button
-                onClick={() => setShowInput(false)}
-                className={glassSecondary}
-              >
-                Back
-              </button>
-              <button onClick={save} className={glassPrimary}>
-                Save & continue
-              </button>
-            </div>
-          </div>
-        )}
+            </span>
+          ))}
+          . Stored only in this browser.
+        </p>
+
+        <div className="flex flex-col gap-2">
+          <button onClick={save} className={glassPrimary}>
+            Save &amp; continue
+          </button>
+          <button
+            onClick={onRequestSignIn}
+            className="self-center font-['Avenir',sans-serif] text-[14px] leading-[20px] text-[#9B9EA3] underline hover:text-[#DADEE5] transition-colors"
+          >
+            Sign in instead
+          </button>
+        </div>
       </div>
     </Modal>
   )
@@ -124,12 +242,4 @@ const glassPrimary = `
   shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
   font-['Avenir',sans-serif] font-medium text-[14px] text-[#dadee5]
   hover:bg-[rgba(37,99,235,0.9)] transition-all
-`
-
-const glassSecondary = `
-  relative px-[16px] py-[8px] rounded-[10px]
-  backdrop-blur-[12px] bg-white/10 border border-white/[0.15]
-  shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
-  font-['Avenir',sans-serif] font-medium text-[14px] text-[#c9ced4]
-  hover:bg-white/20 hover:text-[#dadee5] transition-all
 `

--- a/src/components/Modal/ApiKeyModal.tsx
+++ b/src/components/Modal/ApiKeyModal.tsx
@@ -112,7 +112,12 @@ export function ApiKeyModal({
   const firstEmpty = PROVIDER_ORDER.find((provider) => !stored[provider])
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Generate with AI">
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Generate with AI"
+      size="compact"
+    >
       <div className="space-y-4">
         <p className="body-m text-[#c9ced4] m-0">
           Timeline Academy uses AI to generate event details and timelines. Add

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -8,7 +8,7 @@ interface ModalProps {
   onClose: () => void;
   children: React.ReactNode;
   title: string;
-  size?: 'default' | 'large';
+  size?: 'compact' | 'default' | 'large';
 }
 
 export function Modal({ isOpen, onClose, children, title, size = 'default' }: ModalProps) {
@@ -23,6 +23,9 @@ export function Modal({ isOpen, onClose, children, title, size = 'default' }: Mo
   if (typeof document === 'undefined') return null;
 
   const sizeClasses = {
+    // Narrow column for short, single-purpose forms. Every variant keeps the
+    // viewport cap so the modal still shrinks on small screens.
+    compact: 'w-[420px] max-w-[90vw]',
     default: 'w-[550px] max-w-[90vw]',
     large: 'w-[960px] max-w-[95vw] min-h-[600px]'
   };

--- a/src/components/NewTimeline/NewTimelineScreen.tsx
+++ b/src/components/NewTimeline/NewTimelineScreen.tsx
@@ -3,6 +3,8 @@ import type { SubjectType } from '@/constants/pillDefinitions'
 import { SubjectSuggestions } from '@/components/AIMode/SubjectSuggestions'
 import { GeneratingIndicator } from '@/components/NewTimeline/GeneratingIndicator'
 import { useSubjectSuggestions } from '@/hooks/useSubjectSuggestions'
+import { PROVIDER_META } from '@/constants/byokProviders'
+import type { ByokProvider } from '@/types/ai'
 
 interface NewTimelineScreenProps {
   onAIGenerate: (subject: string) => void
@@ -12,6 +14,11 @@ interface NewTimelineScreenProps {
   classifiedType: SubjectType | null
   categoryLabels: string[]
   error: string | null
+  /** Set when the failure came from one BYOK provider and the user has a key
+   *  for the other one. Null otherwise — including on the server-funded path,
+   *  which has no alternative to offer. */
+  retryProvider?: ByokProvider | null
+  onRetryWithProvider?: (provider: ByokProvider) => void
 }
 
 const PLACEHOLDER_NAMES = [
@@ -114,6 +121,8 @@ export function NewTimelineScreen({
   isClassifying,
   categoryLabels,
   error,
+  retryProvider,
+  onRetryWithProvider,
 }: NewTimelineScreenProps) {
   const [name, setName] = useState('')
   const [placeholderText, setPlaceholderText] = useState('')
@@ -277,7 +286,18 @@ export function NewTimelineScreen({
             )}
 
             {!isWorking && error && (
-              <p className="mt-[16px] text-sm text-red-400">{error}</p>
+              <div className="mt-[16px] flex flex-wrap items-baseline gap-2">
+                <p className="text-sm text-red-400 m-0">{error}</p>
+                {retryProvider && onRetryWithProvider && (
+                  <button
+                    type="button"
+                    onClick={() => onRetryWithProvider(retryProvider)}
+                    className="text-sm text-[#9B9EA3] underline hover:text-[#DADEE5] transition-colors"
+                  >
+                    Retry with {PROVIDER_META[retryProvider].label}
+                  </button>
+                )}
+              </div>
             )}
           </form>
         </div>

--- a/src/components/Settings/ApiKeySection.tsx
+++ b/src/components/Settings/ApiKeySection.tsx
@@ -1,20 +1,34 @@
 import { useState } from 'react'
+import { ByokDefaultProviderPicker } from './ByokDefaultProviderPicker'
+import { PROVIDER_META, PROVIDER_ORDER } from '@/constants/byokProviders'
 import {
-  clearAnthropicKey,
+  clearKey,
+  hasAnyKey,
   maskKey,
-  setAnthropicKey,
-  useAnthropicKey,
+  setKey,
+  setPreferredProvider,
+  useByokCredential,
+  useByokKeys,
+  validateKeyFormat,
 } from '@/services/userApiKey'
 import { useAuth } from '@/hooks/useAuth'
+import type { ByokProvider } from '@/types/ai'
 
 interface ApiKeySectionProps {
   defaultExpanded?: boolean
 }
 
 export function ApiKeySection({ defaultExpanded = false }: ApiKeySectionProps) {
-  const key = useAnthropicKey()
+  const stored = useByokKeys()
+  const active = useByokCredential()
   const { user } = useAuth()
-  const [editing, setEditing] = useState(defaultExpanded && !key)
+
+  // Only one row edits at a time, so a single draft/error pair still models
+  // the state correctly — the same shape this section always had, widened
+  // from a boolean to "which provider".
+  const [editing, setEditing] = useState<ByokProvider | null>(
+    defaultExpanded && !hasAnyKey() ? 'openai' : null,
+  )
   const [draft, setDraft] = useState('')
   const [error, setError] = useState<string | null>(null)
 
@@ -26,39 +40,46 @@ export function ApiKeySection({ defaultExpanded = false }: ApiKeySectionProps) {
   // This section used to bail out entirely when signed out, which left the
   // account-free byok-anon tier with no way to see, replace or remove the key
   // it is defined by.
-  const status: 'byok' | 'server' | 'none' = key ? 'byok' : user ? 'server' : 'none'
+  const status: 'byok' | 'server' | 'none' = active
+    ? 'byok'
+    : user
+      ? 'server'
+      : 'none'
 
-  const startEdit = () => {
+  const bothPresent = Boolean(stored.anthropic && stored.openai)
+
+  const startEdit = (provider: ByokProvider) => {
     setDraft('')
     setError(null)
-    setEditing(true)
+    setEditing(provider)
   }
 
   const cancelEdit = () => {
-    setEditing(false)
+    setEditing(null)
     setDraft('')
     setError(null)
   }
 
   const save = () => {
+    if (!editing) return
     const trimmed = draft.trim()
-    if (!trimmed) {
-      setError('Paste a key first.')
+    const message = validateKeyFormat(editing, trimmed)
+    if (message) {
+      setError(message)
       return
     }
-    if (!trimmed.startsWith('sk-ant-')) {
-      setError('Anthropic keys start with sk-ant-. Double-check and try again.')
-      return
-    }
-    setAnthropicKey(trimmed)
-    setEditing(false)
+    setKey(editing, trimmed)
+    setEditing(null)
     setDraft('')
     setError(null)
   }
 
-  const remove = () => {
-    clearAnthropicKey()
-    setEditing(false)
+  const remove = (provider: ByokProvider) => {
+    // Removing the non-active key of two does not change tier — hasAnyKey()
+    // stays true. Removing the last one drops a signed-out visitor back to
+    // trial, which leaves their localStorage drafts dormant, not deleted.
+    clearKey(provider)
+    setEditing(null)
   }
 
   return (
@@ -66,72 +87,116 @@ export function ApiKeySection({ defaultExpanded = false }: ApiKeySectionProps) {
       <span className="label-m-type2 text-[#9B9EA3]">AI Settings</span>
       <div className="h-px bg-[#262626] w-full" />
 
-      <StatusPill status={status} />
+      {/* One pill, not one per provider: it answers "where does AI actually
+          go", and that has exactly one answer. */}
+      <StatusPill
+        status={status}
+        providerLabel={active ? PROVIDER_META[active.provider].label : undefined}
+      />
 
-      {!editing && key && (
-        <div className="flex items-center justify-between gap-2">
-          <code className="font-['JetBrains_Mono',monospace] text-[12px] text-[#c9ced4] break-all">
-            {maskKey(key)}
-          </code>
-          <div className="flex gap-1.5 shrink-0">
-            <button onClick={startEdit} className={glassButton}>
-              Replace
-            </button>
-            <button onClick={remove} className={glassButton}>
-              Remove
-            </button>
+      {PROVIDER_ORDER.map((provider) => {
+        const meta = PROVIDER_META[provider]
+        const savedKey = stored[provider]
+        const isEditing = editing === provider
+        const isDefault = bothPresent && active?.provider === provider
+
+        return (
+          <div key={provider} className="flex flex-col gap-1.5">
+            <div className="flex items-center gap-2">
+              <span className="label-m-type2 text-[#9B9EA3]">{meta.label}</span>
+              {isDefault && (
+                <span className="font-['Avenir',sans-serif] text-[11px] text-[#6b6e73]">
+                  Default
+                </span>
+              )}
+            </div>
+
+            {!isEditing && savedKey && (
+              <div className="flex items-center justify-between gap-2">
+                <code className="font-['JetBrains_Mono',monospace] text-[12px] text-[#c9ced4] break-all">
+                  {maskKey(savedKey)}
+                </code>
+                <div className="flex gap-1.5 shrink-0">
+                  <button
+                    onClick={() => startEdit(provider)}
+                    className={glassButton}
+                  >
+                    Replace
+                  </button>
+                  <button
+                    onClick={() => remove(provider)}
+                    className={glassButton}
+                  >
+                    Remove
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {!isEditing && !savedKey && (
+              <button
+                onClick={() => startEdit(provider)}
+                className={`${glassButton} self-start`}
+              >
+                Add {meta.label} key
+              </button>
+            )}
+
+            {isEditing && (
+              <div className="flex flex-col gap-2">
+                <input
+                  type="password"
+                  placeholder={meta.placeholder}
+                  value={draft}
+                  onChange={(e) => setDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') save()
+                    else if (e.key === 'Escape') cancelEdit()
+                  }}
+                  autoFocus
+                  spellCheck={false}
+                  autoComplete="off"
+                  className="w-full h-9 bg-[#242526] border border-[#262626] rounded-[8px] px-3 py-[7.5px] body-m text-[#DADEE5] outline-none focus:border-[#404040] font-['JetBrains_Mono',monospace] text-[12px]"
+                />
+                {error && <p className="body-m text-destructive m-0">{error}</p>}
+                <div className="flex gap-1.5">
+                  <button onClick={save} className={glassButton}>
+                    Save
+                  </button>
+                  <button onClick={cancelEdit} className={glassButton}>
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
-        </div>
-      )}
+        )
+      })}
 
-      {!editing && !key && (
-        <button onClick={startEdit} className={`${glassButton} self-start`}>
-          Add Anthropic key
-        </button>
-      )}
-
-      {editing && (
-        <div className="flex flex-col gap-2">
-          <input
-            type="password"
-            placeholder="sk-ant-..."
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') save()
-              else if (e.key === 'Escape') cancelEdit()
-            }}
-            autoFocus
-            spellCheck={false}
-            autoComplete="off"
-            className="w-full h-9 bg-[#242526] border border-[#262626] rounded-[8px] px-3 py-[7.5px] body-m text-[#DADEE5] outline-none focus:border-[#404040] font-['JetBrains_Mono',monospace] text-[12px]"
-          />
-          {error && (
-            <p className="body-m text-destructive m-0">{error}</p>
-          )}
-          <div className="flex gap-1.5">
-            <button onClick={save} className={glassButton}>
-              Save
-            </button>
-            <button onClick={cancelEdit} className={glassButton}>
-              Cancel
-            </button>
-          </div>
-        </div>
+      {bothPresent && (
+        <ByokDefaultProviderPicker
+          value={stored.preferred ?? 'anthropic'}
+          onChange={setPreferredProvider}
+        />
       )}
 
       <p className="font-['Avenir',sans-serif] text-[12px] leading-[16px] text-[#6b6e73] m-0">
         Get a key at{' '}
-        <a
-          href="https://console.anthropic.com/settings/keys"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline hover:text-[#9B9EA3]"
-        >
-          console.anthropic.com
-        </a>
+        {PROVIDER_ORDER.map((provider, i) => (
+          <span key={provider}>
+            {i > 0 && ' or '}
+            <a
+              href={PROVIDER_META[provider].consoleUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-[#9B9EA3]"
+            >
+              {PROVIDER_META[provider].consoleLabel}
+            </a>
+          </span>
+        ))}
         . Stored only in this browser — anyone with access to this device can
-        see it.
+        see it. Usage is billed to that provider account, not to us.
       </p>
     </div>
   )
@@ -139,12 +204,14 @@ export function ApiKeySection({ defaultExpanded = false }: ApiKeySectionProps) {
 
 function StatusPill({
   status,
+  providerLabel,
 }: {
   status: 'byok' | 'server' | 'none'
+  providerLabel?: string
 }) {
   const config = {
     byok: {
-      label: 'Using your Anthropic key',
+      label: `Using your ${providerLabel ?? 'own'} key`,
       dot: '#259E23',
       text: '#c9ced4',
     },

--- a/src/components/Settings/ByokDefaultProviderPicker.tsx
+++ b/src/components/Settings/ByokDefaultProviderPicker.tsx
@@ -1,0 +1,58 @@
+import { useId } from 'react'
+import { PROVIDER_META, PROVIDER_ORDER } from '@/constants/byokProviders'
+import type { ByokProvider } from '@/types/ai'
+
+interface ByokDefaultProviderPickerProps {
+  value: ByokProvider
+  onChange: (provider: ByokProvider) => void
+}
+
+/**
+ * Which saved key gets used when the user has both.
+ *
+ * Mounted in two places — the key modal and the Settings panel — over one
+ * persisted value, so there is a single source of truth and no reconciliation
+ * between them. Settings owns it editorially, but the modal must be able to
+ * set it too: an anonymous visitor with two keys may never open Settings
+ * before their first generation, which is exactly the case this exists for.
+ *
+ * Real radio inputs rather than styled buttons — there is no segmented-control
+ * primitive in this codebase, and hand-rolling `role="radiogroup"` means
+ * re-implementing arrow-key navigation for a worse result.
+ */
+export function ByokDefaultProviderPicker({
+  value,
+  onChange,
+}: ByokDefaultProviderPickerProps) {
+  // Both mount points can be in the DOM at once, and radio grouping is by
+  // `name` — a fixed string would let one picker steal the other's selection.
+  const groupName = useId()
+
+  return (
+    <fieldset className="m-0 p-0 border-0">
+      <legend className="label-m-type2 text-[#9B9EA3] mb-2 p-0">
+        Default provider
+      </legend>
+      <div className="flex gap-4">
+        {PROVIDER_ORDER.map((provider) => (
+          <label
+            key={provider}
+            className="flex items-center gap-2 cursor-pointer"
+          >
+            <input
+              type="radio"
+              name={groupName}
+              value={provider}
+              checked={value === provider}
+              onChange={() => onChange(provider)}
+              className="accent-[#2563eb]"
+            />
+            <span className="body-m text-[#c9ced4]">
+              {PROVIDER_META[provider].label}
+            </span>
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  )
+}

--- a/src/constants/byokProviders.ts
+++ b/src/constants/byokProviders.ts
@@ -1,0 +1,35 @@
+// Display metadata for the BYOK providers.
+//
+// Every user-facing mention of a provider — the modal fields, the Settings
+// rows, the status pill, the retry button — reads from here, so provider
+// naming and console links cannot drift between surfaces.
+
+import type { ByokProvider } from '@/types/ai'
+
+export interface ProviderMeta {
+  /** Human-readable name, as shown in labels and buttons. */
+  label: string
+  /** Input placeholder, which doubles as a hint at the expected key prefix. */
+  placeholder: string
+  consoleUrl: string
+  /** Bare domain, used as the visible link text. */
+  consoleLabel: string
+}
+
+export const PROVIDER_META: Record<ByokProvider, ProviderMeta> = {
+  openai: {
+    label: 'OpenAI',
+    placeholder: 'sk-...',
+    consoleUrl: 'https://platform.openai.com/api-keys',
+    consoleLabel: 'platform.openai.com',
+  },
+  anthropic: {
+    label: 'Anthropic',
+    placeholder: 'sk-ant-...',
+    consoleUrl: 'https://console.anthropic.com/settings/keys',
+    consoleLabel: 'console.anthropic.com',
+  },
+}
+
+/** The order providers are listed in wherever both are shown. */
+export const PROVIDER_ORDER: ByokProvider[] = ['openai', 'anthropic']

--- a/src/constants/plans.ts
+++ b/src/constants/plans.ts
@@ -13,7 +13,7 @@ export interface PlanLimits {
 }
 
 export const PLAN_LIMITS: Record<Plan, PlanLimits> = {
-  // Has an Anthropic key but no account: browser-only localStorage drafts.
+  // Has a BYOK key (either provider) but no account: browser-only drafts.
   'byok-anon': { eventLimit: 150, timelineLimit: 3 },
   free: { eventLimit: 300, timelineLimit: 10 },
   byok: { eventLimit: 1200, timelineLimit: 25 },

--- a/src/hooks/useAIMode.ts
+++ b/src/hooks/useAIMode.ts
@@ -1,6 +1,9 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useMemo } from 'react';
 import { classifySubject, generateTimeline } from '../services/aiTimeline';
+import { ProviderError } from '../services/llmShared';
+import { getKey } from '../services/userApiKey';
 import { TimelineEvent, CategoryConfig } from '../types/event';
+import type { ByokProvider } from '../types/ai';
 import { PILL_DEFINITIONS } from '../constants/pillDefinitions';
 import { DEFAULT_CATEGORIES } from '../constants/categories';
 import type { SubjectType } from '../constants/pillDefinitions';
@@ -25,12 +28,29 @@ export function useAIMode() {
   const [classifiedType, setClassifiedType] = useState<SubjectType | null>(null);
   const [categoryLabels, setCategoryLabels] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
+  // Which BYOK provider produced the current error, when one did. Drives the
+  // "retry with the other provider" affordance.
+  const [errorProvider, setErrorProvider] = useState<ByokProvider | null>(null);
   const abortedRef = useRef(false);
 
-  const classifyAndGenerate = useCallback(async (subject: string): Promise<GenerateResult> => {
+  // The other provider, offered only when the user actually has a key for it.
+  // No automatic failover: spending on an account the user didn't pick for
+  // this request is a surprise, and it hides the fact that a key is broken.
+  const retryProvider = useMemo<ByokProvider | null>(() => {
+    if (!errorProvider) return null;
+    const other: ByokProvider =
+      errorProvider === 'openai' ? 'anthropic' : 'openai';
+    return getKey(other) ? other : null;
+  }, [errorProvider]);
+
+  const classifyAndGenerate = useCallback(async (
+    subject: string,
+    providerOverride?: ByokProvider
+  ): Promise<GenerateResult> => {
     abortedRef.current = false;
     setIsClassifying(true);
     setError(null);
+    setErrorProvider(null);
     setClassifiedType(null);
     setCategoryLabels([]);
 
@@ -64,7 +84,7 @@ export function useAIMode() {
 
     let type: SubjectType;
     try {
-      const result = await classifySubject(subject);
+      const result = await classifySubject(subject, providerOverride);
       if (abortedRef.current) throw new Error('Cancelled');
       type = result.type;
       setClassifiedType(type);
@@ -78,6 +98,7 @@ export function useAIMode() {
       }
       const msg = err instanceof Error ? err.message : 'Failed to classify subject';
       setError(msg);
+      setErrorProvider(err instanceof ProviderError ? err.provider : null);
       setIsClassifying(false);
       throw err;
     }
@@ -87,7 +108,12 @@ export function useAIMode() {
 
     try {
       const pills = PILL_DEFINITIONS[type];
-      const result = await generateTimeline(subject, type, pills);
+      const result = await generateTimeline(
+        subject,
+        type,
+        pills,
+        providerOverride
+      );
       if (abortedRef.current) throw new Error('Cancelled');
 
       const events: TimelineEvent[] = result.events.map((e) => ({
@@ -120,6 +146,7 @@ export function useAIMode() {
       }
       const msg = err instanceof Error ? err.message : 'Something went wrong';
       setError(msg);
+      setErrorProvider(err instanceof ProviderError ? err.provider : null);
       throw err;
     } finally {
       setIsGenerating(false);
@@ -133,12 +160,14 @@ export function useAIMode() {
     setClassifiedType(null);
     setCategoryLabels([]);
     setError(null);
+    setErrorProvider(null);
   }, []);
 
   const resetClassification = useCallback(() => {
     setClassifiedType(null);
     setCategoryLabels([]);
     setError(null);
+    setErrorProvider(null);
   }, []);
 
   return {
@@ -147,6 +176,7 @@ export function useAIMode() {
     classifiedType,
     categoryLabels,
     error,
+    retryProvider,
     classifyAndGenerate,
     abort,
     resetClassification,

--- a/src/hooks/useAccountTier.ts
+++ b/src/hooks/useAccountTier.ts
@@ -1,20 +1,23 @@
 import { useAuth } from './useAuth'
-import { useAnthropicKey } from '@/services/userApiKey'
+import { useHasByokKey } from '@/services/userApiKey'
 
 /**
  * Who the current visitor is, for every purpose that cares.
  *
- * Two independent axes — is there an account, and is there an Anthropic key —
- * which together make four states. Before this hook they were re-derived from
- * a bare `!user` in five different files, which worked only while key-presence
- * didn't matter. It does now: a visitor with a key and no account keeps their
- * work in a different place than one with neither.
+ * Two independent axes — is there an account, and is there a BYOK key (from
+ * either provider) — which together make four states. Before this hook they
+ * were re-derived from a bare `!user` in five different files, which worked
+ * only while key-presence didn't matter. It does now: a visitor with a key and
+ * no account keeps their work in a different place than one with neither.
  *
  *   'loading'    auth hasn't answered yet — do nothing
  *   'trial'      no account, no key  → one sessionStorage timeline, dies with the tab
  *   'byok-anon'  no account, has key → localStorage drafts, unmetered AI (their key)
  *   'free'       account, no key     → Supabase, our AI budget, rate limited
  *   'byok'       account + key       → Supabase, unmetered AI (their key)
+ *
+ * Which provider the key belongs to is deliberately not an axis: limits are
+ * identical either way, so the tier table stays two-dimensional.
  *
  * Only the last three are `Plan`s in constants/plans.ts. Trial has no limits to
  * enforce and no row in the tier table — it is a state, not a tier.
@@ -23,7 +26,7 @@ export type AccountTier = 'loading' | 'trial' | 'byok-anon' | 'free' | 'byok'
 
 export function useAccountTier(): AccountTier {
   const { user, authReady } = useAuth()
-  const apiKey = useAnthropicKey()
+  const hasKey = useHasByokKey()
 
   // `user` is null both before the session lookup answers and when genuinely
   // signed out. Answering 'trial' during that window would point a signed-in
@@ -31,8 +34,8 @@ export function useAccountTier(): AccountTier {
   // the same trap the hydration effect in App.tsx guards against.
   if (!authReady) return 'loading'
 
-  if (!user) return apiKey ? 'byok-anon' : 'trial'
-  return apiKey ? 'byok' : 'free'
+  if (!user) return hasKey ? 'byok-anon' : 'trial'
+  return hasKey ? 'byok' : 'free'
 }
 
 /** True for the two states whose content lives in the browser, not Supabase. */

--- a/src/lib/limits.ts
+++ b/src/lib/limits.ts
@@ -1,5 +1,5 @@
 import { PLAN_LIMITS, type Plan, type PlanLimits } from '@/constants/plans'
-import { getAnthropicKey } from '@/services/userApiKey'
+import { hasAnyKey } from '@/services/userApiKey'
 import { supabase } from './supabase'
 
 export type LimitKind = 'event' | 'timeline'
@@ -33,7 +33,7 @@ async function refreshPlan(): Promise<void> {
     cachedPlan = 'byok-anon'
     return
   }
-  cachedPlan = getAnthropicKey() ? 'byok' : 'free'
+  cachedPlan = hasAnyKey() ? 'byok' : 'free'
 }
 
 void refreshPlan()

--- a/src/services/aiTimeline.ts
+++ b/src/services/aiTimeline.ts
@@ -1,27 +1,39 @@
 import { supabase } from '../lib/supabase';
-import { getAnthropicKey } from './userApiKey';
+import { getActiveCredential, getCredentialFor } from './userApiKey';
 import {
   classifySubjectDirect,
   generateTimelineDirect,
 } from './anthropicDirect';
-import { TimelineCategory } from '../types/event';
+import {
+  classifySubjectOpenAIDirect,
+  generateTimelineOpenAIDirect,
+} from './openaiDirect';
+import { ProviderError } from './llmShared';
 import type { SubjectType, PillDefinition } from '../constants/pillDefinitions';
+import type {
+  ByokCredential,
+  ByokProvider,
+  ClassificationResult,
+  GeneratedTimeline,
+} from '@/types/ai';
 
-export interface GeneratedTimeline {
-  timelineTitle: string;
-  timelineDescription: string;
-  categoryMapping?: Record<string, string>;
-  events: Array<{
-    title: string;
-    startDate: string;
-    endDate: string;
-    category: TimelineCategory;
-  }>;
+/**
+ * Which BYOK credential this call should use, or null for the server path.
+ *
+ * `override` exists for the retry-with-the-other-provider action: it targets
+ * one provider for a single call without touching the stored default, so a
+ * one-off retry never silently redefines which provider the user is on.
+ */
+function resolveCredential(
+  override?: ByokProvider
+): ByokCredential | null {
+  return override ? getCredentialFor(override) : getActiveCredential();
 }
 
-export interface ClassificationResult {
-  type: SubjectType;
-}
+// Moved to @/types/ai so llmShared.ts can reference GeneratedTimeline without
+// importing this module (which imports the direct clients, which import
+// llmShared). Re-exported so existing importers keep working.
+export type { ClassificationResult, GeneratedTimeline } from '@/types/ai';
 
 /**
  * Classify a subject into a type. Uses the cheapest/fastest model.
@@ -31,13 +43,24 @@ export interface ClassificationResult {
  * session JWT automatically).
  */
 export async function classifySubject(
-  subject: string
+  subject: string,
+  providerOverride?: ByokProvider
 ): Promise<ClassificationResult> {
   const validTypes: SubjectType[] = ['person', 'event', 'topic', 'organization'];
 
-  const byokKey = getAnthropicKey();
-  if (byokKey) {
-    const type = await classifySubjectDirect(subject, byokKey);
+  const credential = resolveCredential(providerOverride);
+  if (credential) {
+    let type: string;
+    try {
+      type =
+        credential.provider === 'openai'
+          ? await classifySubjectOpenAIDirect(subject, credential.key)
+          : await classifySubjectDirect(subject, credential.key);
+    } catch (err) {
+      // Wrapped here rather than inside each client so there is one wrap site
+      // per call, and so the UI knows which provider to offer a retry against.
+      throw new ProviderError((err as Error).message, credential.provider);
+    }
     return {
       type: validTypes.includes(type as SubjectType)
         ? (type as SubjectType)
@@ -79,10 +102,11 @@ export async function classifySubject(
 export async function generateTimeline(
   subject: string,
   subjectType?: SubjectType,
-  categories?: PillDefinition[]
+  categories?: PillDefinition[],
+  providerOverride?: ByokProvider
 ): Promise<GeneratedTimeline> {
-  const byokKey = getAnthropicKey();
-  if (byokKey) {
+  const credential = resolveCredential(providerOverride);
+  if (credential) {
     const categoryDefs =
       categories && categories.length > 0
         ? categories.map((c) => ({
@@ -91,7 +115,17 @@ export async function generateTimeline(
             promptSnippet: c.promptSnippet,
           }))
         : undefined;
-    return generateTimelineDirect(subject, categoryDefs, byokKey);
+    try {
+      return credential.provider === 'openai'
+        ? await generateTimelineOpenAIDirect(
+            subject,
+            categoryDefs,
+            credential.key
+          )
+        : await generateTimelineDirect(subject, categoryDefs, credential.key);
+    } catch (err) {
+      throw new ProviderError((err as Error).message, credential.provider);
+    }
   }
 
   const body: Record<string, unknown> = { subject };

--- a/src/services/anthropicDirect.ts
+++ b/src/services/anthropicDirect.ts
@@ -6,23 +6,30 @@
 // Required header: anthropic-dangerous-direct-browser-access: true.
 // Anthropic accepts this on browser-origin requests but warns against it for
 // production server-side use. For BYOK that's exactly the trade-off we want.
+// OpenAI publishes no equivalent opt-in — see openaiDirect.ts.
 
-import type {
-  EnrichmentStreamHandlers,
-  // re-export for callers via eventEnrichment.ts
-} from './eventEnrichment'
 import {
   getSystemPrompt,
   getUserPrompt,
+  buildEnrichUserPrompt,
   CLASSIFICATION_PROMPT,
+  ENRICH_SYSTEM_PROMPT,
   type CategoryDefinition,
 } from './llmPrompts'
+import { parseTimelineJson, readApiError, readSseStream } from './llmShared'
+import type { EnrichmentStreamHandlers, GeneratedTimeline } from '@/types/ai'
 import type { EventSource, TimelineEvent } from '@/types/event'
-import type { GeneratedTimeline } from './aiTimeline'
 
 const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages'
-const MODEL_SONNET = 'claude-sonnet-4-6'
-const MODEL_HAIKU = 'claude-haiku-4-5-20251001'
+
+// Deliberately mid-tier, not frontier. This workload is bounded JSON
+// generation and short prose — Opus- and Fable-tier models cost several times
+// as much for no gain the user can see, and BYOK spend lands on the user's own
+// account. Do not "upgrade" these to a frontier model without a reason.
+//
+// Model IDs are complete as written; do not append date suffixes.
+const MODEL_SONNET = 'claude-sonnet-5'
+const MODEL_HAIKU = 'claude-haiku-4-5'
 
 function headers(key: string): Record<string, string> {
   return {
@@ -36,28 +43,6 @@ function headers(key: string): Record<string, string> {
 // ---------------------------------------------------------------------------
 // Event enrichment (streaming)
 // ---------------------------------------------------------------------------
-
-const ENRICH_SYSTEM_PROMPT = `You are writing a 1-2 paragraph description of a historical event for an educational timeline. Use the web_search tool to find authoritative sources before writing. Keep the description concise (max ~150 words for simple events, two short paragraphs for complex ones). Use a neutral encyclopedic tone. Do not include inline citations or footnotes — sources are listed separately. Do not invent facts that aren't in the search results.`
-
-function buildEnrichUserPrompt(
-  event: TimelineEvent,
-  timelineTitle: string,
-): string {
-  const lines: string[] = []
-  lines.push(`Write a description for this event: "${event.title}"`)
-  if (event.startDate || event.endDate) {
-    if (event.startDate && event.endDate && event.startDate !== event.endDate) {
-      lines.push(`Date range: ${event.startDate} to ${event.endDate}`)
-    } else if (event.startDate) {
-      lines.push(`Date: ${event.startDate}`)
-    }
-  }
-  if (timelineTitle) lines.push(`Timeline context: ${timelineTitle}`)
-  lines.push(
-    'Use the web_search tool to find sources, then write the description. Output only the description text — no headings, no source lists.',
-  )
-  return lines.join('\n')
-}
 
 export async function enrichEventDirect(
   event: TimelineEvent,
@@ -73,11 +58,24 @@ export async function enrichEventDirect(
       headers: headers(apiKey),
       body: JSON.stringify({
         model: MODEL_SONNET,
-        max_tokens: 1024,
+        // Sonnet 5 runs adaptive thinking by default, and max_tokens caps
+        // thinking PLUS response text. The old 1024 was sized for the
+        // description alone and would now truncate mid-sentence.
+        //
+        // We leave thinking on rather than disabling it to claw the budget
+        // back: with thinking off, Sonnet 5 reaches for tools noticeably less
+        // often, and this call is only worth making if web_search actually
+        // fires — a description with an empty Sources list is the failure
+        // mode nothing else here would catch. max_tokens is a ceiling, not a
+        // charge; only tokens actually produced are billed.
+        max_tokens: 4096,
         system: ENRICH_SYSTEM_PROMPT,
         tools: [
           {
-            type: 'web_search_20250305',
+            // Dynamic filtering: results are filtered before they reach the
+            // context window. Enrichment cost is dominated by search-result
+            // input tokens, so this is the cheapest lever available here.
+            type: 'web_search_20260209',
             name: 'web_search',
             max_uses: 3,
           },
@@ -91,27 +89,15 @@ export async function enrichEventDirect(
     })
   } catch (err) {
     if ((err as Error).name === 'AbortError') return
-    handlers.onError((err as Error).message || 'Network error')
+    handlers.onError((err as Error).message || 'Network error', 'anthropic')
     return
   }
 
   if (!res.ok || !res.body) {
-    let message = `Anthropic API error (${res.status})`
-    try {
-      const body = await res.text()
-      // Most Anthropic errors include a useful `.error.message`.
-      try {
-        const parsed = JSON.parse(body) as {
-          error?: { message?: string; type?: string }
-        }
-        if (parsed?.error?.message) message = parsed.error.message
-      } catch {
-        if (body) message = body.slice(0, 200)
-      }
-    } catch {
-      // ignore
-    }
-    handlers.onError(message)
+    handlers.onError(
+      await readApiError(res, 'Anthropic API error', MODEL_SONNET),
+      'anthropic',
+    )
     return
   }
 
@@ -119,158 +105,51 @@ export async function enrichEventDirect(
   const seenUrls = new Set<string>()
   const blockTypes = new Map<number, string>()
 
-  const reader = res.body.getReader()
-  const decoder = new TextDecoder()
-  let buffer = ''
-
   try {
-    while (true) {
-      const { value, done } = await reader.read()
-      if (done) break
-      buffer += decoder.decode(value, { stream: true })
-      let idx
-      while ((idx = buffer.indexOf('\n\n')) !== -1) {
-        const rawEvent = buffer.slice(0, idx)
-        buffer = buffer.slice(idx + 2)
-        const lines = rawEvent.split('\n')
-        let eventName = ''
-        let dataStr = ''
-        for (const line of lines) {
-          if (line.startsWith('event: ')) eventName = line.slice(7).trim()
-          else if (line.startsWith('data: ')) dataStr += line.slice(6)
+    await readSseStream(res.body, (eventName, data) => {
+      if (eventName === 'content_block_start') {
+        const index = data.index as number
+        const block = data.content_block as Record<string, unknown>
+        if (block && typeof block.type === 'string') {
+          blockTypes.set(index, block.type)
         }
-        if (!dataStr) continue
-        let data: Record<string, unknown>
-        try {
-          data = JSON.parse(dataStr)
-        } catch {
-          continue
-        }
-
-        if (eventName === 'content_block_start') {
-          const index = data.index as number
-          const block = data.content_block as Record<string, unknown>
-          if (block && typeof block.type === 'string') {
-            blockTypes.set(index, block.type)
-          }
-          if (block?.type === 'web_search_tool_result') {
-            const content = block.content as Array<Record<string, unknown>> | undefined
-            if (Array.isArray(content)) {
-              for (const item of content) {
-                if (item.type === 'web_search_result') {
-                  const url = item.url as string | undefined
-                  const title = (item.title as string | undefined) ?? ''
-                  if (url && !seenUrls.has(url)) {
-                    seenUrls.add(url)
-                    sources.push({ title: title || url, url })
-                  }
+        if (block?.type === 'web_search_tool_result') {
+          const content = block.content as Array<Record<string, unknown>> | undefined
+          if (Array.isArray(content)) {
+            for (const item of content) {
+              if (item.type === 'web_search_result') {
+                const url = item.url as string | undefined
+                const title = (item.title as string | undefined) ?? ''
+                if (url && !seenUrls.has(url)) {
+                  seenUrls.add(url)
+                  sources.push({ title: title || url, url })
                 }
               }
             }
           }
-        } else if (eventName === 'content_block_delta') {
-          const index = data.index as number
-          const delta = data.delta as Record<string, unknown>
-          const blockType = blockTypes.get(index)
-          if (blockType === 'text' && delta?.type === 'text_delta') {
-            const text = delta.text as string
-            if (text) handlers.onDelta(text)
-          }
+        }
+      } else if (eventName === 'content_block_delta') {
+        const index = data.index as number
+        const delta = data.delta as Record<string, unknown>
+        const blockType = blockTypes.get(index)
+        if (blockType === 'text' && delta?.type === 'text_delta') {
+          const text = delta.text as string
+          if (text) handlers.onDelta(text)
         }
       }
-    }
+    })
 
     handlers.onSources(sources)
     handlers.onDone()
   } catch (err) {
     if ((err as Error).name === 'AbortError') return
-    handlers.onError((err as Error).message || 'Stream interrupted')
+    handlers.onError((err as Error).message || 'Stream interrupted', 'anthropic')
   }
 }
 
 // ---------------------------------------------------------------------------
 // Timeline generation (non-streaming JSON)
 // ---------------------------------------------------------------------------
-
-function stripCodeFence(text: string): string {
-  const t = text.trim()
-  if (!t.startsWith('```')) return t
-  return t.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '').trim()
-}
-
-function parseTimelineJson(text: string): GeneratedTimeline {
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(stripCodeFence(text))
-  } catch {
-    throw new Error('LLM returned invalid JSON')
-  }
-
-  const obj = parsed as Record<string, unknown>
-  if (typeof obj.timelineTitle !== 'string' || !obj.timelineTitle) {
-    throw new Error('Missing timelineTitle in LLM response')
-  }
-  if (typeof obj.timelineDescription !== 'string') {
-    throw new Error('Missing timelineDescription in LLM response')
-  }
-  if (!Array.isArray(obj.events) || obj.events.length === 0) {
-    throw new Error('Missing or empty events array in LLM response')
-  }
-
-  const validCategories = new Set([
-    'category_1',
-    'category_2',
-    'category_3',
-    'category_4',
-  ])
-
-  const events = (obj.events as Array<Record<string, unknown>>)
-    .filter(
-      (e) =>
-        typeof e.category === 'string' && validCategories.has(e.category),
-    )
-    .map((e, i) => {
-      if (typeof e.title !== 'string' || !e.title) {
-        throw new Error(`Event ${i}: missing title`)
-      }
-      if (typeof e.startDate !== 'string' || !e.startDate) {
-        throw new Error(`Event ${i}: missing startDate`)
-      }
-      if (typeof e.endDate !== 'string' || !e.endDate) {
-        throw new Error(`Event ${i}: missing endDate`)
-      }
-      return {
-        title: (e.title as string).slice(0, 55),
-        startDate: e.startDate as string,
-        endDate: e.endDate as string,
-        category: e.category as
-          | 'category_1'
-          | 'category_2'
-          | 'category_3'
-          | 'category_4',
-      }
-    })
-
-  if (events.length === 0) {
-    throw new Error('No valid events in LLM response')
-  }
-
-  let categoryMapping: Record<string, string> | undefined
-  if (
-    obj.categoryMapping &&
-    typeof obj.categoryMapping === 'object' &&
-    !Array.isArray(obj.categoryMapping)
-  ) {
-    categoryMapping = obj.categoryMapping as Record<string, string>
-  }
-
-  return {
-    timelineTitle: obj.timelineTitle as string,
-    timelineDescription: obj.timelineDescription as string,
-    categoryMapping,
-    events,
-  }
-}
 
 export async function generateTimelineDirect(
   subject: string,
@@ -289,20 +168,20 @@ export async function generateTimelineDirect(
       max_tokens: 4096,
       system: getSystemPrompt(),
       messages: [{ role: 'user', content: userPrompt }],
-      temperature: 0.4,
+      // No `temperature`: Sonnet 5 rejects a non-default value with a 400.
+      // The old 0.4 is gone rather than moved — steer with the prompt.
+      //
+      // Thinking is off because this call emits a fixed JSON schema and uses
+      // no tools, so there is nothing for reasoning to improve, and adaptive
+      // thinking would eat into the same max_tokens the JSON needs. (The
+      // enrichment call above makes the opposite trade for the opposite
+      // reason — it depends on a tool firing.)
+      thinking: { type: 'disabled' },
     }),
   })
 
   if (!res.ok) {
-    const body = await res.text().catch(() => '')
-    let message = `Anthropic API error (${res.status})`
-    try {
-      const parsed = JSON.parse(body) as { error?: { message?: string } }
-      if (parsed?.error?.message) message = parsed.error.message
-    } catch {
-      if (body) message = body.slice(0, 200)
-    }
-    throw new Error(message)
+    throw new Error(await readApiError(res, 'Anthropic API error', MODEL_SONNET))
   }
 
   const json = await res.json()
@@ -342,15 +221,7 @@ export async function classifySubjectDirect(
   })
 
   if (!res.ok) {
-    const body = await res.text().catch(() => '')
-    let message = `Anthropic API error (${res.status})`
-    try {
-      const parsed = JSON.parse(body) as { error?: { message?: string } }
-      if (parsed?.error?.message) message = parsed.error.message
-    } catch {
-      if (body) message = body.slice(0, 200)
-    }
-    throw new Error(message)
+    throw new Error(await readApiError(res, 'Anthropic API error', MODEL_HAIKU))
   }
 
   const json = await res.json()

--- a/src/services/eventEnrichment.ts
+++ b/src/services/eventEnrichment.ts
@@ -1,18 +1,18 @@
 import { supabase } from '../lib/supabase'
 import { enrichEventDirect } from './anthropicDirect'
-import { getAnthropicKey } from './userApiKey'
+import { enrichEventOpenAIDirect } from './openaiDirect'
+import { readSseStream } from './llmShared'
+import { getActiveCredential, getCredentialFor } from './userApiKey'
 import { fetchWikipediaImage } from './wikipediaImage'
+import type { ByokProvider, EnrichmentStreamHandlers } from '@/types/ai'
 import type { EventSource, TimelineEvent } from '../types/event'
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string
 const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string
 
-export interface EnrichmentStreamHandlers {
-  onDelta: (text: string) => void
-  onSources: (sources: EventSource[]) => void
-  onDone: () => void
-  onError: (message: string) => void
-}
+// Moved to @/types/ai so both direct clients can import it without going
+// through this module. Re-exported so existing importers keep working.
+export type { EnrichmentStreamHandlers } from '@/types/ai'
 
 export async function fetchEventImage(title: string): Promise<{
   imageUrl: string | null
@@ -26,21 +26,45 @@ export async function fetchEventImage(title: string): Promise<{
  * Enrich an event with AI-generated description, sources, and image.
  *
  * Routing:
- *   - User has BYOK key set → call Anthropic directly from the browser.
+ *   - User has a BYOK key set → call that provider directly from the browser.
  *     Bypasses our edge function, our rate limit, and our billing.
  *   - Signed-in user, no key → edge function authenticated via JWT.
  *   - Logged out with no key → server-funded enrichment is not available;
  *     the UI gates this path behind sign-in-or-BYOK before it gets here.
+ *
+ * `providerOverride` targets one provider for a single call — the retry
+ * action after a provider failure. It deliberately does not change the
+ * stored default.
  */
 export async function enrichEvent(
   event: TimelineEvent,
   timelineTitle: string,
   handlers: EnrichmentStreamHandlers,
   signal?: AbortSignal,
+  providerOverride?: ByokProvider,
 ): Promise<void> {
-  const byokKey = getAnthropicKey()
-  if (byokKey) {
-    await enrichEventDirect(event, timelineTitle, handlers, byokKey, signal)
+  const credential = providerOverride
+    ? getCredentialFor(providerOverride)
+    : getActiveCredential()
+
+  if (credential) {
+    if (credential.provider === 'openai') {
+      await enrichEventOpenAIDirect(
+        event,
+        timelineTitle,
+        handlers,
+        credential.key,
+        signal,
+      )
+    } else {
+      await enrichEventDirect(
+        event,
+        timelineTitle,
+        handlers,
+        credential.key,
+        signal,
+      )
+    }
     return
   }
 
@@ -88,46 +112,23 @@ export async function enrichEvent(
     return
   }
 
-  const reader = res.body.getReader()
-  const decoder = new TextDecoder()
-  let buffer = ''
-
+  // Note: these are our own SSE event names from the edge function, not
+  // Anthropic's — the function translates the provider stream before it
+  // reaches the browser.
   try {
-    while (true) {
-      const { value, done } = await reader.read()
-      if (done) break
-      buffer += decoder.decode(value, { stream: true })
-      let idx
-      while ((idx = buffer.indexOf('\n\n')) !== -1) {
-        const rawEvent = buffer.slice(0, idx)
-        buffer = buffer.slice(idx + 2)
-        const lines = rawEvent.split('\n')
-        let eventName = ''
-        let dataStr = ''
-        for (const line of lines) {
-          if (line.startsWith('event: ')) eventName = line.slice(7).trim()
-          else if (line.startsWith('data: ')) dataStr += line.slice(6)
-        }
-        if (!dataStr) continue
-        let data: Record<string, unknown>
-        try {
-          data = JSON.parse(dataStr)
-        } catch {
-          continue
-        }
-        if (eventName === 'delta') {
-          const text = data.text as string | undefined
-          if (text) handlers.onDelta(text)
-        } else if (eventName === 'sources') {
-          const sources = (data.sources as EventSource[] | undefined) ?? []
-          handlers.onSources(sources)
-        } else if (eventName === 'done') {
-          handlers.onDone()
-        } else if (eventName === 'error') {
-          handlers.onError((data.message as string) || 'Generation failed')
-        }
+    await readSseStream(res.body, (eventName, data) => {
+      if (eventName === 'delta') {
+        const text = data.text as string | undefined
+        if (text) handlers.onDelta(text)
+      } else if (eventName === 'sources') {
+        const sources = (data.sources as EventSource[] | undefined) ?? []
+        handlers.onSources(sources)
+      } else if (eventName === 'done') {
+        handlers.onDone()
+      } else if (eventName === 'error') {
+        handlers.onError((data.message as string) || 'Generation failed')
       }
-    }
+    })
   } catch (err) {
     if ((err as Error).name === 'AbortError') return
     handlers.onError((err as Error).message || 'Stream interrupted')

--- a/src/services/llmPrompts.ts
+++ b/src/services/llmPrompts.ts
@@ -1,6 +1,17 @@
-// Browser-direct mirror of supabase/functions/_shared/prompts.ts.
-// Keep these two files identical so the BYOK client and the edge function
-// produce equivalent outputs. Source of truth: _shared/prompts.ts.
+// Prompts shared by both browser-direct BYOK clients.
+//
+// The timeline prompts below (getSystemPrompt / getUserPrompt) mirror
+// supabase/functions/_shared/prompts.ts — keep those identical so the BYOK
+// client and the edge function produce equivalent output. Source of truth:
+// _shared/prompts.ts.
+//
+// The classification and enrichment prompts are NOT part of that mirror:
+// CLASSIFICATION_PROMPT is duplicated in _shared/classify.ts, and the enrich
+// prompts below are duplicated in supabase/functions/enrich-event/index.ts.
+// The prompts are provider-neutral prose — no tool schemas, no provider-
+// specific structure — so both direct clients use them unchanged.
+
+import type { TimelineEvent } from '@/types/event'
 
 export interface CategoryDefinition {
   id: string
@@ -70,3 +81,29 @@ Types:
 Subject: "{subject}"
 
 Return ONLY valid JSON: {"type": "<type>"}`
+
+// ---------------------------------------------------------------------------
+// Event enrichment — mirrors supabase/functions/enrich-event/index.ts
+// ---------------------------------------------------------------------------
+
+export const ENRICH_SYSTEM_PROMPT = `You are writing a 1-2 paragraph description of a historical event for an educational timeline. Use the web_search tool to find authoritative sources before writing. Keep the description concise (max ~150 words for simple events, two short paragraphs for complex ones). Use a neutral encyclopedic tone. Do not include inline citations or footnotes — sources are listed separately. Do not invent facts that aren't in the search results.`
+
+export function buildEnrichUserPrompt(
+  event: TimelineEvent,
+  timelineTitle: string,
+): string {
+  const lines: string[] = []
+  lines.push(`Write a description for this event: "${event.title}"`)
+  if (event.startDate || event.endDate) {
+    if (event.startDate && event.endDate && event.startDate !== event.endDate) {
+      lines.push(`Date range: ${event.startDate} to ${event.endDate}`)
+    } else if (event.startDate) {
+      lines.push(`Date: ${event.startDate}`)
+    }
+  }
+  if (timelineTitle) lines.push(`Timeline context: ${timelineTitle}`)
+  lines.push(
+    'Use the web_search tool to find sources, then write the description. Output only the description text — no headings, no source lists.',
+  )
+  return lines.join('\n')
+}

--- a/src/services/llmShared.ts
+++ b/src/services/llmShared.ts
@@ -1,0 +1,181 @@
+// Provider-neutral helpers shared by anthropicDirect.ts and openaiDirect.ts.
+//
+// This module must not import either direct client — it sits below both.
+//
+// `parseTimelineJson` is a near-duplicate of `parseAndValidate` in
+// supabase/functions/_shared/llm-client.ts. The two runtimes cannot share a
+// module, so the duplication is deliberate; keep them behaviourally identical,
+// the same convention llmPrompts.ts follows for the prompt text.
+
+import type { ByokProvider, GeneratedTimeline } from '@/types/ai'
+
+/** An error that knows which BYOK provider produced it, so the UI can offer
+ *  a retry against the other one. */
+export class ProviderError extends Error {
+  provider: ByokProvider
+
+  constructor(message: string, provider: ByokProvider) {
+    super(message)
+    this.name = 'ProviderError'
+    this.provider = provider
+  }
+}
+
+/**
+ * Turn a non-OK provider response into a message worth showing a user.
+ *
+ * Both providers wrap errors in `{ error: { message } }`, so one reader covers
+ * them. Pass `model` to get a specific message for the access failures that
+ * look like app bugs otherwise: both providers gate models by account tier and
+ * spend history, so a brand-new key with no billing set up gets a 403/404 that
+ * would otherwise surface as a bare "API error (404)".
+ */
+export async function readApiError(
+  res: Response,
+  label: string,
+  model?: string,
+): Promise<string> {
+  let message = `${label} (${res.status})`
+  try {
+    const body = await res.text()
+    try {
+      const parsed = JSON.parse(body) as { error?: { message?: string } }
+      if (parsed?.error?.message) message = parsed.error.message
+    } catch {
+      if (body) message = body.slice(0, 200)
+    }
+  } catch {
+    // ignore — we still have the status-code fallback
+  }
+
+  if (model && (res.status === 403 || res.status === 404)) {
+    return `Your API key can't reach ${model}. The account may need billing set up, or may not have access to that model yet.`
+  }
+  return message
+}
+
+/**
+ * Read an SSE body and hand each complete frame to `onEvent`.
+ *
+ * Frames are separated by a blank line; `event:` names the frame and `data:`
+ * carries the JSON payload (repeated `data:` lines are concatenated).
+ * Un-parseable frames are skipped rather than thrown, because a single
+ * malformed frame should not abort a stream that is otherwise fine.
+ *
+ * Abort handling stays with the caller — an aborted read rejects here and the
+ * caller decides whether that is a user action or a real failure.
+ */
+export async function readSseStream(
+  body: ReadableStream<Uint8Array>,
+  onEvent: (name: string, data: Record<string, unknown>) => void,
+): Promise<void> {
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    let idx
+    while ((idx = buffer.indexOf('\n\n')) !== -1) {
+      const rawEvent = buffer.slice(0, idx)
+      buffer = buffer.slice(idx + 2)
+      const lines = rawEvent.split('\n')
+      let eventName = ''
+      let dataStr = ''
+      for (const line of lines) {
+        if (line.startsWith('event: ')) eventName = line.slice(7).trim()
+        else if (line.startsWith('data: ')) dataStr += line.slice(6)
+      }
+      if (!dataStr) continue
+      let data: Record<string, unknown>
+      try {
+        data = JSON.parse(dataStr)
+      } catch {
+        continue
+      }
+      onEvent(eventName, data)
+    }
+  }
+}
+
+export function stripCodeFence(text: string): string {
+  const t = text.trim()
+  if (!t.startsWith('```')) return t
+  return t.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '').trim()
+}
+
+export function parseTimelineJson(text: string): GeneratedTimeline {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(stripCodeFence(text))
+  } catch {
+    throw new Error('LLM returned invalid JSON')
+  }
+
+  const obj = parsed as Record<string, unknown>
+  if (typeof obj.timelineTitle !== 'string' || !obj.timelineTitle) {
+    throw new Error('Missing timelineTitle in LLM response')
+  }
+  if (typeof obj.timelineDescription !== 'string') {
+    throw new Error('Missing timelineDescription in LLM response')
+  }
+  if (!Array.isArray(obj.events) || obj.events.length === 0) {
+    throw new Error('Missing or empty events array in LLM response')
+  }
+
+  const validCategories = new Set([
+    'category_1',
+    'category_2',
+    'category_3',
+    'category_4',
+  ])
+
+  const events = (obj.events as Array<Record<string, unknown>>)
+    .filter(
+      (e) =>
+        typeof e.category === 'string' && validCategories.has(e.category),
+    )
+    .map((e, i) => {
+      if (typeof e.title !== 'string' || !e.title) {
+        throw new Error(`Event ${i}: missing title`)
+      }
+      if (typeof e.startDate !== 'string' || !e.startDate) {
+        throw new Error(`Event ${i}: missing startDate`)
+      }
+      if (typeof e.endDate !== 'string' || !e.endDate) {
+        throw new Error(`Event ${i}: missing endDate`)
+      }
+      return {
+        title: (e.title as string).slice(0, 55),
+        startDate: e.startDate as string,
+        endDate: e.endDate as string,
+        category: e.category as
+          | 'category_1'
+          | 'category_2'
+          | 'category_3'
+          | 'category_4',
+      }
+    })
+
+  if (events.length === 0) {
+    throw new Error('No valid events in LLM response')
+  }
+
+  let categoryMapping: Record<string, string> | undefined
+  if (
+    obj.categoryMapping &&
+    typeof obj.categoryMapping === 'object' &&
+    !Array.isArray(obj.categoryMapping)
+  ) {
+    categoryMapping = obj.categoryMapping as Record<string, string>
+  }
+
+  return {
+    timelineTitle: obj.timelineTitle as string,
+    timelineDescription: obj.timelineDescription as string,
+    categoryMapping,
+    events,
+  }
+}

--- a/src/services/openaiDirect.ts
+++ b/src/services/openaiDirect.ts
@@ -1,0 +1,290 @@
+// Browser-direct OpenAI client for BYOK ("Bring Your Own Key") mode.
+//
+// Mirrors anthropicDirect.ts in shape, with three deliberate differences:
+//
+//  1. No browser-access opt-in header. Anthropic requires
+//     `anthropic-dangerous-direct-browser-access`; OpenAI publishes no
+//     equivalent. Whether api.openai.com accepts browser-origin requests at
+//     all is a property of their CORS policy, not something we can assert
+//     from here — see the PRD for the verification this rests on.
+//  2. Generation and classification use /v1/chat/completions with
+//     `response_format: json_object`, which is what makes the prose-only
+//     "JSON ONLY" instruction in llmPrompts.ts reliable. Only enrichment
+//     needs /v1/responses, because that is where web search lives.
+//  3. No assistant prefill. Anthropic's classify call starts the reply with
+//     `{"type": "` to force shape; OpenAI has no equivalent, and structured
+//     output replaces it.
+
+import {
+  getSystemPrompt,
+  getUserPrompt,
+  buildEnrichUserPrompt,
+  CLASSIFICATION_PROMPT,
+  ENRICH_SYSTEM_PROMPT,
+  type CategoryDefinition,
+} from './llmPrompts'
+import { parseTimelineJson, readApiError, readSseStream } from './llmShared'
+import type { EnrichmentStreamHandlers, GeneratedTimeline } from '@/types/ai'
+import type { EventSource, TimelineEvent } from '@/types/event'
+
+const OPENAI_CHAT_URL = 'https://api.openai.com/v1/chat/completions'
+const OPENAI_RESPONSES_URL = 'https://api.openai.com/v1/responses'
+
+// Deliberately mid-tier and budget-tier, not frontier — same reasoning as the
+// Anthropic pins: this workload is bounded JSON and short prose, and BYOK
+// spend lands on the user's own account.
+const MODEL_MAIN = 'gpt-5.6-terra'
+const MODEL_CHEAP = 'gpt-5.6-luna'
+
+function headers(key: string): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${key}`,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Event enrichment (streaming, Responses API + web search)
+// ---------------------------------------------------------------------------
+
+/**
+ * Pull url_citation annotations out of the terminal `response.completed`
+ * payload.
+ *
+ * This is the authoritative source for the Sources list, not the streamed
+ * annotation events. Those arrive earlier and are a latency win, but the
+ * streamed event name has been renamed at least once in OpenAI SDK history —
+ * and if the list depended on it alone, a rename would produce an empty
+ * Sources section with no error anywhere: the description would still stream,
+ * the panel would still say loaded, and the only symptom would be missing
+ * links nobody notices.
+ */
+function harvestCompletedCitations(
+  data: Record<string, unknown>,
+  add: (url: string, title?: string) => void,
+): void {
+  const response = data.response as Record<string, unknown> | undefined
+  const output = response?.output as Array<Record<string, unknown>> | undefined
+  if (!Array.isArray(output)) return
+
+  for (const item of output) {
+    if (item.type !== 'message') continue
+    const content = item.content as Array<Record<string, unknown>> | undefined
+    if (!Array.isArray(content)) continue
+    for (const part of content) {
+      if (part.type !== 'output_text') continue
+      const annotations = part.annotations as
+        | Array<Record<string, unknown>>
+        | undefined
+      if (!Array.isArray(annotations)) continue
+      for (const a of annotations) {
+        if (a.type === 'url_citation' && typeof a.url === 'string') {
+          add(a.url, typeof a.title === 'string' ? a.title : undefined)
+        }
+      }
+    }
+  }
+}
+
+export async function enrichEventOpenAIDirect(
+  event: TimelineEvent,
+  timelineTitle: string,
+  handlers: EnrichmentStreamHandlers,
+  apiKey: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  let res: Response
+  try {
+    res = await fetch(OPENAI_RESPONSES_URL, {
+      method: 'POST',
+      headers: headers(apiKey),
+      body: JSON.stringify({
+        model: MODEL_MAIN,
+        // `instructions` is the Responses-API analogue of Anthropic's
+        // top-level `system`.
+        instructions: ENRICH_SYSTEM_PROMPT,
+        input: buildEnrichUserPrompt(event, timelineTitle),
+        tools: [{ type: 'web_search' }],
+        include: ['web_search_call.action.sources'],
+        // A ceiling, not a charge. Generous because reasoning-capable models
+        // spend part of the budget before the visible answer starts.
+        max_output_tokens: 4096,
+        // NOT cosmetic: the Responses API defaults to store: true, which
+        // persists the user's prompts and our outputs into THEIR OpenAI
+        // dashboard. The Anthropic path has no equivalent, and the privacy
+        // policy describes neither. Leave this false.
+        store: false,
+        stream: true,
+      }),
+      signal,
+    })
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') return
+    handlers.onError((err as Error).message || 'Network error', 'openai')
+    return
+  }
+
+  if (!res.ok || !res.body) {
+    handlers.onError(
+      await readApiError(res, 'OpenAI API error', MODEL_MAIN),
+      'openai',
+    )
+    return
+  }
+
+  const sources: EventSource[] = []
+  const seenUrls = new Set<string>()
+  const addSource = (url: string, title?: string) => {
+    if (!url || seenUrls.has(url)) return
+    seenUrls.add(url)
+    sources.push({ title: title || url, url })
+  }
+
+  let failure: string | null = null
+
+  try {
+    await readSseStream(res.body, (eventName, data) => {
+      switch (eventName) {
+        case 'response.output_text.delta': {
+          const text = data.delta as string | undefined
+          if (text) handlers.onDelta(text)
+          break
+        }
+        case 'response.output_text.annotation.added': {
+          const annotation = data.annotation as
+            | Record<string, unknown>
+            | undefined
+          if (annotation?.type === 'url_citation') {
+            const url = annotation.url as string | undefined
+            const title = annotation.title as string | undefined
+            if (url) addSource(url, title)
+          }
+          break
+        }
+        case 'response.completed':
+          harvestCompletedCitations(data, addSource)
+          break
+        case 'response.failed':
+        case 'response.incomplete': {
+          const response = data.response as Record<string, unknown> | undefined
+          const error = response?.error as Record<string, unknown> | undefined
+          failure = (error?.message as string) || 'Generation failed'
+          break
+        }
+        case 'error':
+          failure = (data.message as string) || 'Generation failed'
+          break
+        default:
+          // Every other event is progress noise we don't render
+          // (response.created, response.web_search_call.*, content_part.*,
+          // reasoning summaries). Deliberately ignored rather than logged —
+          // but if the Sources list ever comes back empty, log here first:
+          // an unhandled or renamed event is the likeliest cause.
+          break
+      }
+    })
+
+    if (failure) {
+      handlers.onError(failure, 'openai')
+      return
+    }
+
+    handlers.onSources(sources)
+    handlers.onDone()
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') return
+    handlers.onError((err as Error).message || 'Stream interrupted', 'openai')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Timeline generation (non-streaming JSON)
+// ---------------------------------------------------------------------------
+
+export async function generateTimelineOpenAIDirect(
+  subject: string,
+  categories: CategoryDefinition[] | undefined,
+  apiKey: string,
+): Promise<GeneratedTimeline> {
+  const userPrompt = categories
+    ? getUserPrompt(subject, categories)
+    : `Generate a biographical timeline for: ${subject}`
+
+  const res = await fetch(OPENAI_CHAT_URL, {
+    method: 'POST',
+    headers: headers(apiKey),
+    body: JSON.stringify({
+      model: MODEL_MAIN,
+      // `json_object` requires the literal word "JSON" somewhere in the
+      // messages. getSystemPrompt() satisfies that incidentally ("JSON ONLY",
+      // "RESPONSE SCHEMA"); a future prompt edit that removes the word would
+      // 400 every OpenAI generation while the Anthropic path kept working.
+      response_format: { type: 'json_object' },
+      messages: [
+        { role: 'system', content: getSystemPrompt() },
+        { role: 'user', content: userPrompt },
+      ],
+      // No `temperature`: newer reasoning-capable models reject non-default
+      // sampling parameters, and this is a schema-constrained emit anyway.
+      max_tokens: 8192,
+    }),
+  })
+
+  if (!res.ok) {
+    throw new Error(await readApiError(res, 'OpenAI API error', MODEL_MAIN))
+  }
+
+  const json = await res.json()
+  const text = json.choices?.[0]?.message?.content
+  if (!text) throw new Error('Empty response from OpenAI')
+
+  return parseTimelineJson(text as string)
+}
+
+// ---------------------------------------------------------------------------
+// Subject classification (cheap, non-streaming)
+// ---------------------------------------------------------------------------
+
+export async function classifySubjectOpenAIDirect(
+  subject: string,
+  apiKey: string,
+): Promise<string> {
+  const validTypes = new Set(['person', 'event', 'topic', 'organization'])
+
+  const res = await fetch(OPENAI_CHAT_URL, {
+    method: 'POST',
+    headers: headers(apiKey),
+    body: JSON.stringify({
+      model: MODEL_CHEAP,
+      response_format: { type: 'json_object' },
+      messages: [
+        {
+          role: 'user',
+          content: CLASSIFICATION_PROMPT.replace('{subject}', subject),
+        },
+      ],
+      // Anthropic's version caps this at 32 because an assistant prefill has
+      // already written most of the answer. There is no prefill here, and a
+      // reasoning-capable model may spend tokens before emitting, so the
+      // ceiling is looser. Still fractions of a cent on the budget tier.
+      max_tokens: 256,
+    }),
+  })
+
+  if (!res.ok) {
+    throw new Error(await readApiError(res, 'OpenAI API error', MODEL_CHEAP))
+  }
+
+  const json = await res.json()
+  const text = json.choices?.[0]?.message?.content
+  if (!text) throw new Error('Empty response from OpenAI')
+
+  let parsed: { type: string }
+  try {
+    parsed = JSON.parse(text as string)
+  } catch {
+    throw new Error('LLM returned invalid JSON for classification')
+  }
+
+  return validTypes.has(parsed.type) ? parsed.type : 'topic'
+}

--- a/src/services/userApiKey.ts
+++ b/src/services/userApiKey.ts
@@ -1,19 +1,39 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { supabase } from '@/lib/supabase'
+import type { ByokCredential, ByokProvider } from '@/types/ai'
 
-const STORAGE_KEY = 'timeline_byok_anthropic_key'
+// Storage slots, one per provider plus the user's preferred default.
+//
+// The Anthropic slot name predates multi-provider support and MUST NOT change.
+// Renaming it is silent data loss for every existing BYOK user: no error, no
+// migration, they simply drop to the trial tier with their key still sitting
+// in localStorage under the old name.
+const KEY_ANTHROPIC = 'timeline_byok_anthropic_key'
+const KEY_OPENAI = 'timeline_byok_openai_key'
+const KEY_PREFERRED = 'timeline_byok_provider'
 
-// Brings the server-side byok_enabled flag in sync with whether a BYOK key
+const SLOT: Record<ByokProvider, string> = {
+  anthropic: KEY_ANTHROPIC,
+  openai: KEY_OPENAI,
+}
+
+const WATCHED = new Set([KEY_ANTHROPIC, KEY_OPENAI, KEY_PREFERRED])
+
+// Brings the server-side byok_enabled flag in sync with whether ANY BYOK key
 // exists in localStorage. The flag lives in app_metadata (which the client
 // cannot write directly — plan limits are derived from it server-side), so
 // the sync goes through the set-byok-flag edge function. Idempotent and
 // best-effort: no-op when already in sync, no-op when logged out, errors are
 // logged not thrown.
+//
+// The flag stays a plain boolean: limits do not vary by provider, so recording
+// which provider a user brought would mean an app_metadata migration and an
+// SQL change for no behavioural gain.
 async function reconcileBYOKMetadata(): Promise<void> {
   try {
     const { data: { user } } = await supabase.auth.getUser()
     if (!user) return
-    const hasKey = !!getAnthropicKey()
+    const hasKey = hasAnyKey()
     const currentFlag = !!user.app_metadata?.byok_enabled
     if (hasKey === currentFlag) return
     await supabase.functions.invoke('set-byok-flag', {
@@ -28,43 +48,168 @@ supabase.auth.onAuthStateChange((event) => {
   if (event === 'SIGNED_IN') void reconcileBYOKMetadata()
 })
 
-function read(): string | null {
+function readSlot(name: string): string | null {
   try {
-    const v = localStorage.getItem(STORAGE_KEY)
+    const v = localStorage.getItem(name)
     return v && v.trim() ? v : null
   } catch {
     return null
   }
 }
 
-export function getAnthropicKey(): string | null {
-  return read()
+// Notify listeners in this tab — `storage` events only fire in OTHER tabs.
+// The event name is an unchecked string literal that lib/limits.ts also
+// subscribes to; renaming it here silently freezes plan limits at their
+// startup value.
+function notifyChanged(): void {
+  window.dispatchEvent(new Event('byok:changed'))
 }
 
-export function setAnthropicKey(key: string): void {
+// ---------------------------------------------------------------------------
+// Per-provider access
+// ---------------------------------------------------------------------------
+
+export function getKey(provider: ByokProvider): string | null {
+  return readSlot(SLOT[provider])
+}
+
+export function setKey(provider: ByokProvider, key: string): void {
   const trimmed = key.trim()
   if (!trimmed) {
-    clearAnthropicKey()
+    clearKey(provider)
     return
   }
   try {
-    localStorage.setItem(STORAGE_KEY, trimmed)
-    // Notify listeners in this tab — `storage` events only fire in OTHER tabs.
-    window.dispatchEvent(new Event('byok:changed'))
+    localStorage.setItem(SLOT[provider], trimmed)
+    notifyChanged()
   } catch {
     // ignore — quota or disabled storage
   }
+  // Must run after the write: reconcile reads storage to decide the flag.
   void reconcileBYOKMetadata()
 }
 
-export function clearAnthropicKey(): void {
+export function clearKey(provider: ByokProvider): void {
   try {
-    localStorage.removeItem(STORAGE_KEY)
-    window.dispatchEvent(new Event('byok:changed'))
+    localStorage.removeItem(SLOT[provider])
+    notifyChanged()
   } catch {
     // ignore
   }
   void reconcileBYOKMetadata()
+}
+
+export function hasAnyKey(): boolean {
+  return Boolean(readSlot(KEY_ANTHROPIC) || readSlot(KEY_OPENAI))
+}
+
+export function getCredentialFor(
+  provider: ByokProvider,
+): ByokCredential | null {
+  const key = getKey(provider)
+  return key ? { provider, key } : null
+}
+
+// ---------------------------------------------------------------------------
+// Preferred provider
+// ---------------------------------------------------------------------------
+
+export function getPreferredProvider(): ByokProvider | null {
+  const v = readSlot(KEY_PREFERRED)
+  return v === 'anthropic' || v === 'openai' ? v : null
+}
+
+export function setPreferredProvider(provider: ByokProvider): void {
+  try {
+    localStorage.setItem(KEY_PREFERRED, provider)
+    notifyChanged()
+  } catch {
+    // ignore
+  }
+  // Deliberately no reconcile call: a preference change cannot change whether
+  // a key exists, so byok_enabled cannot have moved. Skipping it saves a
+  // getUser() round-trip on every toggle.
+}
+
+// ---------------------------------------------------------------------------
+// Resolution — which credential a request should actually use
+// ---------------------------------------------------------------------------
+
+/**
+ * The single resolution rule, as a pure function so the hook and the
+ * imperative getter cannot drift apart.
+ */
+function resolveActive(
+  anthropic: string | null,
+  openai: string | null,
+  preferred: ByokProvider | null,
+): ByokCredential | null {
+  if (!anthropic && !openai) return null
+
+  // Exactly one key present: use it and ignore any stale preference.
+  //
+  // This branch is load-bearing, not an optimisation. A user whose preference
+  // says `openai` who then removes their OpenAI key would otherwise read as
+  // `byok` to the tier logic (a key exists) but as "no key" to the routing
+  // logic — a split brain that surfaces as a sign-in gate they should never
+  // see. The preference is deliberately NOT cleared when its provider's key
+  // is removed: this rule covers the gap, and re-adding that key restores the
+  // user's stated intent.
+  if (!openai) return { provider: 'anthropic', key: anthropic as string }
+  if (!anthropic) return { provider: 'openai', key: openai }
+
+  // Both present: honour the preference, defaulting to Anthropic so users who
+  // had a key before OpenAI support existed keep the behaviour they had.
+  const preference = preferred ?? 'anthropic'
+  return preference === 'openai'
+    ? { provider: 'openai', key: openai }
+    : { provider: 'anthropic', key: anthropic }
+}
+
+export function getActiveCredential(): ByokCredential | null {
+  return resolveActive(
+    readSlot(KEY_ANTHROPIC),
+    readSlot(KEY_OPENAI),
+    getPreferredProvider(),
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns an error message, or null when the key looks plausible.
+ *
+ * Deliberately loose — we check the provider prefix and nothing else, so a
+ * new key format from either provider still saves. OpenAI currently issues
+ * `sk-`, `sk-proj-`, `sk-svcacct-` and `sk-admin-` prefixes, all covered by
+ * the bare `sk-` check.
+ *
+ * Pasting a key into the wrong field is the likeliest mistake in a two-field
+ * form, so that case gets a message naming the mix-up rather than a generic
+ * format complaint.
+ */
+export function validateKeyFormat(
+  provider: ByokProvider,
+  key: string,
+): string | null {
+  const trimmed = key.trim()
+  if (!trimmed) return 'Paste a key first.'
+
+  if (provider === 'anthropic') {
+    if (trimmed.startsWith('sk-ant-')) return null
+    if (trimmed.startsWith('sk-')) {
+      return 'That looks like an OpenAI key — paste it in the OpenAI field.'
+    }
+    return 'Anthropic keys start with sk-ant-. Double-check and try again.'
+  }
+
+  if (trimmed.startsWith('sk-ant-')) {
+    return 'That looks like an Anthropic key — paste it in the Anthropic field.'
+  }
+  if (trimmed.startsWith('sk-')) return null
+  return 'OpenAI keys start with sk-. Double-check and try again.'
 }
 
 export function maskKey(key: string): string {
@@ -73,22 +218,74 @@ export function maskKey(key: string): string {
   return `${key.slice(0, 8)}…${key.slice(-4)}`
 }
 
-// React hook — re-renders when the key changes in this tab or any other.
-export function useAnthropicKey(): string | null {
-  const [key, setKey] = useState<string | null>(() => read())
+// ---------------------------------------------------------------------------
+// React hooks
+// ---------------------------------------------------------------------------
 
-  useEffect(() => {
-    const sync = () => setKey(read())
-    const onStorage = (e: StorageEvent) => {
-      if (e.key === STORAGE_KEY) sync()
-    }
-    window.addEventListener('storage', onStorage)
-    window.addEventListener('byok:changed', sync)
-    return () => {
-      window.removeEventListener('storage', onStorage)
-      window.removeEventListener('byok:changed', sync)
-    }
-  }, [])
+function subscribe(sync: () => void): () => void {
+  const onStorage = (e: StorageEvent) => {
+    // e.key is null when another tab calls localStorage.clear().
+    if (e.key === null || WATCHED.has(e.key)) sync()
+  }
+  window.addEventListener('storage', onStorage)
+  window.addEventListener('byok:changed', sync)
+  return () => {
+    window.removeEventListener('storage', onStorage)
+    window.removeEventListener('byok:changed', sync)
+  }
+}
 
-  return key
+interface ByokKeyState {
+  anthropic: string | null
+  openai: string | null
+  preferred: ByokProvider | null
+}
+
+function snapshot(): ByokKeyState {
+  return {
+    anthropic: readSlot(KEY_ANTHROPIC),
+    openai: readSlot(KEY_OPENAI),
+    preferred: getPreferredProvider(),
+  }
+}
+
+/** Both keys plus the stored preference. Re-renders on change in any tab. */
+export function useByokKeys(): ByokKeyState {
+  const [state, setState] = useState<ByokKeyState>(snapshot)
+
+  useEffect(
+    () =>
+      subscribe(() =>
+        setState((prev) => {
+          const next = snapshot()
+          // Return the previous object when nothing moved so React can bail
+          // out of the re-render — `byok:changed` fires on every write,
+          // including ones this consumer does not care about.
+          return prev.anthropic === next.anthropic &&
+            prev.openai === next.openai &&
+            prev.preferred === next.preferred
+            ? prev
+            : next
+        }),
+      ),
+    [],
+  )
+
+  return state
+}
+
+/** The credential a request would actually use right now, or null. */
+export function useByokCredential(): ByokCredential | null {
+  const { anthropic, openai, preferred } = useByokKeys()
+  return useMemo(
+    () => resolveActive(anthropic, openai, preferred),
+    [anthropic, openai, preferred],
+  )
+}
+
+/** Whether any BYOK key exists — the second axis of useAccountTier. */
+export function useHasByokKey(): boolean {
+  const [has, setHas] = useState<boolean>(hasAnyKey)
+  useEffect(() => subscribe(() => setHas(hasAnyKey())), [])
+  return has
 }

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -1,0 +1,46 @@
+// Provider-neutral AI types.
+//
+// These live here rather than beside either direct client so that
+// anthropicDirect.ts and openaiDirect.ts can both import them without
+// importing each other. Before this file existed, `EnrichmentStreamHandlers`
+// lived in eventEnrichment.ts and was imported *back* by anthropicDirect,
+// which itself exports enrichEventDirect to eventEnrichment — a type-only
+// cycle that a second provider would have doubled.
+
+import type { EventSource, TimelineCategory } from './event'
+import type { SubjectType } from '@/constants/pillDefinitions'
+
+/** The BYOK providers a user can bring a key for. */
+export type ByokProvider = 'anthropic' | 'openai'
+
+/** A resolved key plus the provider it belongs to. */
+export interface ByokCredential {
+  provider: ByokProvider
+  key: string
+}
+
+export interface EnrichmentStreamHandlers {
+  onDelta: (text: string) => void
+  onSources: (sources: EventSource[]) => void
+  onDone: () => void
+  /** `provider` is set when the failure came from a specific BYOK provider,
+   *  so the UI can offer a retry against the other one. It is absent on the
+   *  server-funded path, which has no user-chosen provider. */
+  onError: (message: string, provider?: ByokProvider) => void
+}
+
+export interface GeneratedTimeline {
+  timelineTitle: string
+  timelineDescription: string
+  categoryMapping?: Record<string, string>
+  events: Array<{
+    title: string
+    startDate: string
+    endDate: string
+    category: TimelineCategory
+  }>
+}
+
+export interface ClassificationResult {
+  type: SubjectType
+}

--- a/supabase/functions/_shared/classify.ts
+++ b/supabase/functions/_shared/classify.ts
@@ -30,7 +30,11 @@ async function classifyWithClaude(
       "anthropic-version": "2023-06-01",
     },
     body: JSON.stringify({
-      model: "claude-haiku-4-5-20251001",
+      // Alias, not a dated snapshot — the ID is complete as written.
+      // Haiku 4.5 still supports assistant prefill and `temperature`; the
+      // Sonnet-tier models reject both, so this call must stay on Haiku
+      // unless the prefill below is replaced with structured output.
+      model: "claude-haiku-4-5",
       max_tokens: 32,
       messages: [
         {
@@ -77,7 +81,12 @@ async function classifyWithOpenAI(
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: "gpt-4o-mini",
+      // Cheapest tier of the current family. NOTE: this path is only reached
+      // when ANTHROPIC_API_KEY is unset, so it is rarely exercised — confirm
+      // the parameter contract against live OpenAI docs before relying on it
+      // (reasoning-capable models have historically renamed `max_tokens` and
+      // tightened sampling parameters).
+      model: "gpt-5.6-luna",
       response_format: { type: "json_object" },
       messages: [
         {
@@ -85,7 +94,8 @@ async function classifyWithOpenAI(
           content: CLASSIFICATION_PROMPT.replace("{subject}", subject),
         },
       ],
-      temperature: 0,
+      // No `temperature`: newer reasoning-capable models reject non-default
+      // sampling parameters, and it bought nothing on a four-way enum.
       max_tokens: 32,
     }),
   });

--- a/supabase/functions/_shared/llm-client.ts
+++ b/supabase/functions/_shared/llm-client.ts
@@ -46,13 +46,24 @@ class OpenAIClient implements LLMClient {
         Authorization: `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify({
-        model: "gpt-4o",
+        // Mid-tier of the current family — deliberately not the frontier
+        // model, which costs several times as much for bounded JSON output.
+        // NOTE: this path only runs when DEFAULT_LLM_PROVIDER is "openai", so
+        // it is rarely exercised; confirm the parameter contract against live
+        // OpenAI docs before relying on it.
+        model: "gpt-5.6-terra",
+        // `response_format: json_object` requires the literal word "JSON" to
+        // appear somewhere in the messages. getSystemPrompt() satisfies that
+        // incidentally ("JSON ONLY", "RESPONSE SCHEMA") — an edit to the
+        // prompt that drops the word would 400 every OpenAI generation while
+        // the Claude path kept working.
         response_format: { type: "json_object" },
         messages: [
           { role: "system", content: getSystemPrompt() },
           { role: "user", content: userPrompt },
         ],
-        temperature: 0.4,
+        // No `temperature`: newer reasoning-capable models reject non-default
+        // sampling parameters.
         max_tokens: 4096,
       }),
     });
@@ -97,13 +108,20 @@ class ClaudeClient implements LLMClient {
         "anthropic-version": "2023-06-01",
       },
       body: JSON.stringify({
-        model: "claude-sonnet-4-6",
+        model: "claude-sonnet-5",
         max_tokens: 4096,
         system: getSystemPrompt(),
         messages: [
           { role: "user", content: userPrompt },
         ],
-        temperature: 0.4,
+        // No `temperature`: Sonnet 5 rejects a non-default value with a 400.
+        // This is the default server-funded path, so leaving the old 0.4 in
+        // place would have broken generation for every free-tier user.
+        //
+        // Thinking off: this call emits a fixed JSON schema with no tools, and
+        // Sonnet 5 otherwise spends part of the same max_tokens budget on
+        // reasoning the JSON does not need.
+        thinking: { type: "disabled" },
       }),
     });
 

--- a/supabase/functions/enrich-event/index.ts
+++ b/supabase/functions/enrich-event/index.ts
@@ -175,12 +175,22 @@ Deno.serve(async (req: Request) => {
               "anthropic-version": "2023-06-01",
             },
             body: JSON.stringify({
-              model: "claude-sonnet-4-6",
-              max_tokens: 1024,
+              model: "claude-sonnet-5",
+              // Sonnet 5 runs adaptive thinking by default and max_tokens caps
+              // thinking PLUS response text, so the old 1024 — sized for the
+              // description alone — would now truncate mid-sentence.
+              //
+              // Thinking stays on rather than being disabled to reclaim the
+              // budget: with it off, Sonnet 5 reaches for tools noticeably
+              // less often, and this call is only worth making if web_search
+              // actually fires. max_tokens is a ceiling, not a charge.
+              max_tokens: 4096,
               system: SYSTEM_PROMPT,
               tools: [
                 {
-                  type: "web_search_20250305",
+                  // Dynamic filtering — results are filtered before entering
+                  // the context window, which is where this call's cost lives.
+                  type: "web_search_20260209",
                   name: "web_search",
                   max_uses: 3,
                 },


### PR DESCRIPTION
Adds OpenAI alongside Anthropic in bring-your-own-key mode with full feature parity, collapses the key-entry modal to one screen, and refreshes model pins that were a generation behind on both providers.

Full product requirements and implementation record: [`docs/2026-08-12-openai-byok-prd.md`](docs/2026-08-12-openai-byok-prd.md).

## Provider support

- **New `src/services/openaiDirect.ts`** — generation and classification via chat completions with `json_object`, enrichment via the Responses API with web search feeding the same Sources list Anthropic produces.
- **Extracted the provider-neutral core first** (`src/types/ai.ts`, `src/services/llmShared.ts`). `anthropicDirect.ts` imported a type from `eventEnrichment.ts`, which imported a function back — a cycle that was harmless with one provider and would not have been with two.
- **`userApiKey.ts` rewritten** around per-provider slots. `timeline_byok_anthropic_key` keeps its exact name; renaming it is silent data loss for every existing BYOK user. The old exports were **deleted rather than shimmed** so the compiler had to visit all seven call sites — a same-named shim would let a stale site compile while reading the wrong slot.
- **`store: false` on OpenAI requests.** The Responses API defaults to storing prompts and outputs in the *user's own* OpenAI dashboard. The Anthropic path has no equivalent and the privacy policy described neither.

## Modal and settings

One screen, both fields visible, either key alone sufficient. Validation runs across all fields before anything is persisted — validating per field would leave someone who pasted one good key and one typo with the good key silently stored behind an error. The default-provider picker appears only when both keys are present: one component, two mount points, one persisted value.

## Model pins, and the three things refreshing them broke

`claude-sonnet-5` / `claude-haiku-4-5` on the client; `gpt-5.6-terra` / `gpt-5.6-luna` and `claude-sonnet-5` in the edge functions. All deliberately mid-tier, with the reasoning recorded beside the constants so nobody later "upgrades" to a frontier model thinking it's an improvement.

1. **`temperature` now returns a 400.** `_shared/llm-client.ts` set `temperature: 0.4` and is the default server-funded path — left in place this would have broken generation for every free-tier user on the first request after deploy.
2. **Adaptive thinking is on by default**, and `max_tokens` caps thinking *plus* output. Generation disables thinking (fixed JSON schema, no tools); enrichment leaves it on and raises `max_tokens`, because with thinking off the model reaches for `web_search` noticeably less often and an enrichment where search never fires yields an empty Sources list with no error anywhere.
3. **Assistant prefill 400s on Sonnet-tier.** Both prefill sites turned out to run on Haiku 4.5, so no change was needed — but the constraint is now commented at both so a future pin change doesn't break them silently.

Also upgraded to `web_search_20260209`, which filters results before they enter the context window — the dominant cost in enrichment.

## Cost honesty

The modal no longer calls BYOK *"free, no rate limits"* — true of *our* limits, and read by users as free. It was the only cost-adjacent string in the product. Regenerate now confirms before spending; the error-state "Try again" deliberately does not, since recovering from a failure isn't accidental repeat spend. No automatic failover between providers — an explicit retry action is offered instead, and it never rewrites the saved default.

## Verification

**Verified in a real browser** (Playwright against `npm run dev`): modal states and per-field errors, cross-paste rejection, the picker appearing live while typing, **back-compat for a pre-existing Anthropic-only key**, cross-tab sync including `localStorage.clear()`, the Settings panel with two keys, and no clipping at a 600px viewport. `tsc --noEmit` and `eslint` are clean — none of the repo's 16 pre-existing TS errors are in files this touches.

**Not verified, and called out in the PRD's shipped-vs-verified section** — all three were egress-blocked from the dev container:

1. **Whether `api.openai.com` accepts browser-origin requests at all.** Anthropic opts into this with a dedicated header; OpenAI publishes no equivalent. If it's blocked, the OpenAI path needs a pass-through edge function and the privacy copy must change to match. There's a one-line browser-console check in PRD §3 — `curl` cannot answer it.
2. **The OpenAI stream event names and `url_citation` shape.** From secondary sources. The Sources list is built from the terminal `response.completed` payload rather than the streamed annotation event precisely because that event name has been renamed before, and depending on it alone would produce an empty Sources section with no error.
3. **The GPT-5.6 parameter contract.** `temperature` was removed defensively on the OpenAI paths — if the model accepts it the cost is slightly more variance; if it rejects it, keeping it would 400 every request.

Worth knowing separately: **`npm run build` is `vite build` alone and does not type-check**, so those 16 pre-existing errors ship silently. `npx tsc --noEmit -p tsconfig.app.json` is the real gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_017o4QQVXr6hUo371wQPuQ5o)_