### PR TITLE
Make the side panels resizable within a 300–400px range

### DIFF
--- a/src/components/EventDetailPanel/EventDetailPanel.tsx
+++ b/src/components/EventDetailPanel/EventDetailPanel.tsx
@@ -2,6 +2,9 @@ import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { X } from 'lucide-react'
 import { ConfirmationModal } from '../Modal/ConfirmationModal'
+import { PanelResizeHandle } from '../ui/PanelResizeHandle'
+import { usePanelWidth } from '@/hooks/usePanelWidth'
+import { PANEL_DEFAULT_WIDTH } from '@/constants/panels'
 import { formatDateLong } from '@/utils/dateUtils'
 import {
   enrichEvent,
@@ -49,6 +52,14 @@ export function EventDetailPanel({
   const [errorProvider, setErrorProvider] = useState<ByokProvider | null>(null)
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false)
   const [showRegenerateConfirm, setShowRegenerateConfirm] = useState(false)
+  const [isResizing, setIsResizing] = useState(false)
+
+  // Shared by the editor and the viewer — this is one component mounted from
+  // two routes, so a resize on either follows the reader everywhere.
+  const { width, setWidth, resetWidth } = usePanelWidth(
+    'event_panel_width',
+    PANEL_DEFAULT_WIDTH
+  )
 
   // The other provider, offered only when the user has a key for it. No
   // automatic failover — spending on an account the user didn't pick for this
@@ -265,12 +276,26 @@ export function EventDetailPanel({
 
       <aside
         ref={panelRef}
-        className={`fixed inset-0 md:inset-y-0 md:right-0 md:left-auto md:w-[326px] md:pr-[6px] md:py-[6px] z-50 transition-transform duration-300 ease-out ${
-          open ? 'translate-x-0' : 'translate-x-full'
-        }`}
+        // Width goes through a custom property rather than an inline `width`
+        // so it stays behind the `md:` prefix — below that breakpoint the
+        // panel is full-screen off `inset-0` and must not be constrained.
+        style={{ '--event-panel-width': `${width}px` } as React.CSSProperties}
+        className={`fixed inset-0 md:inset-y-0 md:right-0 md:left-auto md:w-[var(--event-panel-width)] md:pr-[6px] md:py-[6px] z-50 ${
+          isResizing ? '' : 'transition-[transform,width] duration-300 ease-out'
+        } ${open ? 'translate-x-0' : 'translate-x-full'}`}
         aria-hidden={!open}
         aria-label="Event details"
       >
+        {open && (
+          <PanelResizeHandle
+            side="right"
+            width={width}
+            onWidthChange={setWidth}
+            onResizeStateChange={setIsResizing}
+            onReset={resetWidth}
+            label="Resize event details panel"
+          />
+        )}
         <div className="h-full w-full bg-[#171717] flex flex-col overflow-hidden border-0 md:border md:border-[#262626] rounded-none md:rounded-[6px]">
           <div className="flex flex-col items-stretch p-[24px_20px] gap-[16px] overflow-y-auto flex-1 min-h-0">
             {event && (
@@ -289,9 +314,10 @@ export function EventDetailPanel({
                   </button>
                 </div>
 
-                {/* Photo frame */}
+                {/* Photo frame. Fluid rather than a fixed 274px so it follows
+                    a resized panel; the 274/205 ratio is preserved. */}
                 <div
-                  className={`w-full md:w-[274px] aspect-[274/205] bg-[#0A0A0A] border border-[#525252] rounded-[8px] overflow-hidden ${
+                  className={`w-full aspect-[274/205] bg-[#0A0A0A] border border-[#525252] rounded-[8px] overflow-hidden ${
                     state === 'generating' && !displayImageUrl ? 'animate-pulse' : ''
                   }`}
                 >

--- a/src/components/FeedbackPanel/FeedbackPanel.tsx
+++ b/src/components/FeedbackPanel/FeedbackPanel.tsx
@@ -1,7 +1,10 @@
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { createPortal } from "react-dom"
 import { X } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { PanelResizeHandle } from "@/components/ui/PanelResizeHandle"
+import { usePanelWidth } from "@/hooks/usePanelWidth"
+import { PANEL_DEFAULT_WIDTH } from "@/constants/panels"
 
 interface FeedbackPanelProps {
   open: boolean
@@ -9,6 +12,12 @@ interface FeedbackPanelProps {
 }
 
 export function FeedbackPanel({ open, onOpenChange }: FeedbackPanelProps) {
+  const [isResizing, setIsResizing] = useState(false)
+  const { width, setWidth, resetWidth } = usePanelWidth(
+    "feedback_panel_width",
+    PANEL_DEFAULT_WIDTH
+  )
+
   const handleEmailClick = () => {
     const mailtoLink =
       "mailto:alex@timeline.academy?subject=" +
@@ -39,12 +48,23 @@ export function FeedbackPanel({ open, onOpenChange }: FeedbackPanelProps) {
         aria-hidden="true"
       />
       <aside
-        className={`fixed inset-y-0 right-0 z-50 w-[320px] pr-[6px] py-[6px] transition-transform duration-300 ease-out ${
-          open ? "translate-x-0" : "translate-x-full"
-        }`}
+        className={`fixed inset-y-0 right-0 z-50 pr-[6px] py-[6px] ${
+          isResizing ? "" : "transition-[transform,width] duration-300 ease-out"
+        } ${open ? "translate-x-0" : "translate-x-full"}`}
+        style={{ width: `${width}px` }}
         aria-hidden={!open}
         aria-label="Feedback side panel"
       >
+      {open && (
+        <PanelResizeHandle
+          side="right"
+          width={width}
+          onWidthChange={setWidth}
+          onResizeStateChange={setIsResizing}
+          onReset={resetWidth}
+          label="Resize feedback panel"
+        />
+      )}
       <div className="h-full w-full bg-[#171717] rounded-[6px] border border-[#262626] flex flex-col overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between gap-2 px-5 pt-4 pb-2 border-b border-[#404040] shrink-0">

--- a/src/components/FloatingToolbar/FloatingToolbar.tsx
+++ b/src/components/FloatingToolbar/FloatingToolbar.tsx
@@ -9,36 +9,37 @@ interface FloatingToolbarProps {
   activePanel: 'events' | 'settings' | null
 }
 
-// Width of the floating side panel (matches GlobalLayout). The desktop pill
-// recenters over the timeline area by shifting half this distance to the right
-// when the panel is open.
-const SIDE_PANEL_WIDTH = 320
-
 export function FloatingToolbar({
   onAddEventClick,
   onEventsClick,
   onSettingsClick,
   activePanel,
 }: FloatingToolbarProps) {
-  const { isOpen: isSidePanelOpen } = useSidePanel()
+  // The pill is centered on the viewport, then shifted by half the side
+  // panel's width to recenter over the visible timeline area. The width is
+  // user-resizable, so it has to be read live — a local copy of the constant
+  // would drift silently on the first drag.
+  const { isOpen: isSidePanelOpen, width: sidePanelWidth, isResizing } = useSidePanel()
   const desktopTranslateX = isSidePanelOpen
-    ? `calc(-50% + ${SIDE_PANEL_WIDTH / 2}px)`
+    ? `calc(-50% + ${sidePanelWidth / 2}px)`
     : '-50%'
 
   return (
     <>
       {/* Desktop: floating pill, centered over the visible timeline area.
-          Animates with the side panel's push transition (300ms ease-out). */}
+          Animates with the side panel's push transition (300ms ease-out), but
+          tracks the drag directly while the panel is being resized. */}
       <div
-        className="
+        className={`
           hidden md:flex
           fixed bottom-6 left-1/2 z-30
           flex-row items-start gap-1.5 p-2
           w-[373px] h-[58px]
           bg-[rgba(23,23,23,0.8)] border border-[#262626] backdrop-blur-[2px]
           rounded-[20px]
-          transition-transform duration-300 ease-out will-change-transform
-        "
+          will-change-transform
+          ${isResizing ? '' : 'transition-transform duration-300 ease-out'}
+        `}
         style={{ transform: `translateX(${desktopTranslateX})` }}
       >
         <Button variant="glass" size="none" onClick={onAddEventClick}>

--- a/src/components/Layout/GlobalLayout.tsx
+++ b/src/components/Layout/GlobalLayout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { GlobalSidePanel } from '@/components/SidePanel/GlobalSidePanel'
+import { PanelResizeHandle } from '@/components/ui/PanelResizeHandle'
 import { useSidePanel } from '@/hooks/useSidePanel'
 
 interface GlobalLayoutProps {
@@ -9,25 +10,44 @@ interface GlobalLayoutProps {
 /**
  * Push-layout with a viewport-pinned floating side panel:
  * - Panel is position: fixed with a 6px gap on left/top/bottom so it floats.
- * - Total horizontal footprint is 320px (314px panel + 6px gap), so main
- *   content padding-left stays at 320px when the panel is open.
+ * - Its footprint (`width`, gap included) is user-resizable and persisted; the
+ *   main content's padding-left tracks the same value so the two never drift.
+ *   `FloatingToolbar` is the third reader — see `SidePanelContext`.
+ *
+ * `-translate-x-full` is a percentage of the panel's own width, so the
+ * collapse animation follows a variable width for free. The width itself needs
+ * an explicit transition leg, dropped mid-drag so the edge tracks the cursor
+ * instead of easing 300ms behind it.
  */
 export function GlobalLayout({ children }: GlobalLayoutProps) {
-  const { isOpen } = useSidePanel()
+  const { isOpen, width, setWidth, resetWidth, isResizing, setIsResizing } = useSidePanel()
 
   return (
     <div className="min-h-screen">
       <aside
-        className={`fixed inset-y-0 left-0 z-40 w-[320px] pl-[6px] py-[6px] transition-transform duration-300 ease-out ${
-          isOpen ? 'translate-x-0' : '-translate-x-full'
-        }`}
+        className={`fixed inset-y-0 left-0 z-40 pl-[6px] py-[6px] ${
+          isResizing ? '' : 'transition-[transform,width] duration-300 ease-out'
+        } ${isOpen ? 'translate-x-0' : '-translate-x-full'}`}
+        style={{ width: `${width}px` }}
         aria-hidden={!isOpen}
       >
         <GlobalSidePanel />
+        {isOpen && (
+          <PanelResizeHandle
+            side="left"
+            width={width}
+            onWidthChange={setWidth}
+            onResizeStateChange={setIsResizing}
+            onReset={resetWidth}
+            label="Resize timelines panel"
+          />
+        )}
       </aside>
       <div
-        className="min-h-screen transition-[padding-left] duration-300 ease-out"
-        style={{ paddingLeft: isOpen ? '320px' : '0px' }}
+        className={`min-h-screen ${
+          isResizing ? '' : 'transition-[padding-left] duration-300 ease-out'
+        }`}
+        style={{ paddingLeft: isOpen ? `${width}px` : '0px' }}
       >
         {children}
       </div>

--- a/src/components/Settings/TimelineSettingsPanel.tsx
+++ b/src/components/Settings/TimelineSettingsPanel.tsx
@@ -9,6 +9,9 @@ import { ScaleSelector } from './ScaleSelector';
 import { VerticalScaleSelector } from './VerticalScaleSelector';
 import { ApiKeySection } from './ApiKeySection';
 import { SidePanelActionButton } from '../SidePanel/SidePanelActionButton';
+import { PanelResizeHandle } from '../ui/PanelResizeHandle';
+import { usePanelWidth } from '../../hooks/usePanelWidth';
+import { SETTINGS_PANEL_DEFAULT_WIDTH } from '../../constants/panels';
 import { DEFAULT_TIMELINE_DESCRIPTION } from '../../constants/defaults';
 import {
   isInstructionRow,
@@ -61,8 +64,16 @@ export function TimelineSettingsPanel({
   onDeleteTimeline,
 }: TimelineSettingsPanelProps) {
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
+  const [isResizing, setIsResizing] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const maxDescriptionLength = 260;
+
+  // Settings is the widest panel by default — its scale selectors and BYOK key
+  // rows were cramped at the 314px card the other panels use.
+  const { width, setWidth, resetWidth } = usePanelWidth(
+    'settings_panel_width',
+    SETTINGS_PANEL_DEFAULT_WIDTH
+  );
 
   useEffect(() => {
     if (isOpen && !timelineDescription) {
@@ -159,12 +170,23 @@ export function TimelineSettingsPanel({
             aria-hidden="true"
           />
           <aside
-            className={`fixed inset-y-0 right-0 z-50 w-[320px] pr-[6px] py-[6px] transition-transform duration-300 ease-out ${
-              isOpen ? 'translate-x-0' : 'translate-x-full'
-            }`}
+            className={`fixed inset-y-0 right-0 z-50 pr-[6px] py-[6px] ${
+              isResizing ? '' : 'transition-[transform,width] duration-300 ease-out'
+            } ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
+            style={{ width: `${width}px` }}
             aria-hidden={!isOpen}
             aria-label="Settings side panel"
           >
+            {isOpen && (
+              <PanelResizeHandle
+                side="right"
+                width={width}
+                onWidthChange={setWidth}
+                onResizeStateChange={setIsResizing}
+                onReset={resetWidth}
+                label="Resize settings panel"
+              />
+            )}
             <div className="h-full w-full bg-[#171717] rounded-[6px] border border-[#262626] flex flex-col overflow-hidden">
               {/* Header */}
               <div className="flex items-center justify-between gap-2 px-5 pt-4 pb-2 border-b border-[#404040] shrink-0">

--- a/src/components/ui/PanelResizeHandle.tsx
+++ b/src/components/ui/PanelResizeHandle.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { PANEL_MAX_WIDTH, PANEL_MIN_WIDTH } from '@/constants/panels'
+
+const KEYBOARD_STEP = 16
+
+interface PanelResizeHandleProps {
+  /** Viewport edge the panel is docked to. Drag direction inverts with it. */
+  side: 'left' | 'right'
+  width: number
+  onWidthChange: (width: number) => void
+  /** Lets the panel drop its width transition mid-drag so it tracks the cursor. */
+  onResizeStateChange?: (isResizing: boolean) => void
+  /** Double-click, and Home while focused, restore the panel's default width. */
+  onReset?: () => void
+  label: string
+}
+
+/**
+ * Drag strip on a panel's inner edge.
+ *
+ * Rendered as a direct child of the panel's `<aside>`, which is `position:
+ * fixed` and so is its own containing block — `right-0` lands on the card's
+ * inner edge for a left-docked panel because the aside's 6px gap sits on the
+ * far side, and vice versa. It deliberately sits outside the panel card, which
+ * is `overflow-hidden` and would clip it.
+ *
+ * Pointer handling follows `hooks/useEventDrag.ts`: listeners go on `window`
+ * for the duration of the drag so it survives the cursor leaving the 6px strip.
+ *
+ * Desktop only (`hidden md:block`) — on touch the strip would compete with
+ * scrolling, and the event details panel is full-screen there anyway.
+ */
+export function PanelResizeHandle({
+  side,
+  width,
+  onWidthChange,
+  onResizeStateChange,
+  onReset,
+  label,
+}: PanelResizeHandleProps) {
+  const dragRef = useRef({ startX: 0, startWidth: 0 })
+
+  const handlePointerMove = useCallback(
+    (e: PointerEvent) => {
+      const { startX, startWidth } = dragRef.current
+      const delta = e.clientX - startX
+      // A left-docked panel grows as the cursor moves right; a right-docked one
+      // grows as it moves left.
+      onWidthChange(side === 'left' ? startWidth + delta : startWidth - delta)
+    },
+    [onWidthChange, side]
+  )
+
+  const handlePointerUp = useCallback(() => {
+    window.removeEventListener('pointermove', handlePointerMove)
+    window.removeEventListener('pointerup', handlePointerUp)
+    window.removeEventListener('pointercancel', handlePointerUp)
+    window.removeEventListener('blur', handlePointerUp)
+
+    document.body.style.userSelect = ''
+    document.body.style.cursor = ''
+    onResizeStateChange?.(false)
+  }, [handlePointerMove, onResizeStateChange])
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.button !== 0) return
+      e.preventDefault()
+
+      dragRef.current = { startX: e.clientX, startWidth: width }
+
+      window.addEventListener('pointermove', handlePointerMove)
+      window.addEventListener('pointerup', handlePointerUp)
+      window.addEventListener('pointercancel', handlePointerUp)
+      window.addEventListener('blur', handlePointerUp)
+
+      // Without these the drag selects the panel's text, and the cursor snaps
+      // back to the default the moment it leaves the 6px strip.
+      document.body.style.userSelect = 'none'
+      document.body.style.cursor = 'col-resize'
+      onResizeStateChange?.(true)
+    },
+    [handlePointerMove, handlePointerUp, onResizeStateChange, width]
+  )
+
+  useEffect(() => {
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', handlePointerUp)
+      window.removeEventListener('pointercancel', handlePointerUp)
+      window.removeEventListener('blur', handlePointerUp)
+      document.body.style.userSelect = ''
+      document.body.style.cursor = ''
+    }
+  }, [handlePointerMove, handlePointerUp])
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Arrows grow and shrink in the same visual direction a drag would.
+    const growKey = side === 'left' ? 'ArrowRight' : 'ArrowLeft'
+    const shrinkKey = side === 'left' ? 'ArrowLeft' : 'ArrowRight'
+
+    if (e.key === growKey) {
+      e.preventDefault()
+      onWidthChange(width + KEYBOARD_STEP)
+    } else if (e.key === shrinkKey) {
+      e.preventDefault()
+      onWidthChange(width - KEYBOARD_STEP)
+    } else if (e.key === 'Home' && onReset) {
+      e.preventDefault()
+      onReset()
+    }
+  }
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={label}
+      aria-valuenow={width}
+      aria-valuemin={PANEL_MIN_WIDTH}
+      aria-valuemax={PANEL_MAX_WIDTH}
+      tabIndex={0}
+      onPointerDown={handlePointerDown}
+      onKeyDown={handleKeyDown}
+      onDoubleClick={onReset}
+      className={`group hidden md:block absolute inset-y-0 z-10 w-[6px] cursor-col-resize outline-none ${
+        side === 'left' ? 'right-0' : 'left-0'
+      }`}
+    >
+      {/* Hairline that only appears on hover or keyboard focus, so the panel
+          edge stays clean at rest. */}
+      <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-px bg-transparent transition-colors group-hover:bg-[#525252] group-focus:bg-[#c9ced4]" />
+    </div>
+  )
+}

--- a/src/constants/panels.ts
+++ b/src/constants/panels.ts
@@ -13,23 +13,26 @@
  * width again.
  */
 
-/** Gap between a panel's card and the viewport edge. */
-export const PANEL_GAP = 6
-
 /**
- * Narrowest a panel may be dragged. Below roughly 250px the usage table in
- * `SidePanel/UsageLimits.tsx` (a 140px wrapper around two 65px columns)
- * overflows its row, so this leaves a little margin above that floor.
+ * Narrowest a panel may be dragged. A deliberate floor rather than a content
+ * limit — the panels stay usable below this, but not usefully so. Desktop
+ * only; see `clampPanelWidth`.
  */
-export const PANEL_MIN_WIDTH = 260
+export const PANEL_MIN_WIDTH = 300
 
-/** Widest a panel may be dragged, before the viewport clamp below applies. */
-export const PANEL_MAX_WIDTH = 640
+/** Widest a panel may be dragged. */
+export const PANEL_MAX_WIDTH = 400
 
 /**
- * Content that must stay visible beside a panel. Small enough that phones keep
- * roughly the full-width panel they have today, large enough that a panel can
- * never swallow the viewport outright.
+ * Matches the `md:` breakpoint the resize handles appear at
+ * (`ui/PanelResizeHandle.tsx` is `hidden md:block`). Tailwind's default —
+ * `tailwind.config.js` does not override `theme.screens`.
+ */
+export const PANEL_RESIZE_BREAKPOINT = 768
+
+/**
+ * Content that must stay visible beside a panel below the breakpoint, so a
+ * stored desktop width can't leave a phone with nothing but panel.
  */
 export const MIN_CONTENT_GUTTER = 64
 
@@ -37,28 +40,26 @@ export const MIN_CONTENT_GUTTER = 64
 export const PANEL_DEFAULT_WIDTH = 320
 
 /**
- * Settings runs wider than its siblings — the scale selectors and the BYOK key
- * rows were cramped at 314px.
+ * Settings opens wider than its siblings — the scale selectors and the BYOK
+ * key rows were cramped at the 314px card. Kept below `PANEL_MAX_WIDTH` so it
+ * has room to move in both directions.
  */
-export const SETTINGS_PANEL_DEFAULT_WIDTH = 400
-
-/**
- * Widest a panel may actually go right now. `PANEL_MAX_WIDTH` is the ceiling;
- * on a narrow viewport the gutter wins instead, which is what keeps the 400px
- * Settings default from overflowing a ~390px phone.
- */
-export function maxPanelWidth(viewportWidth: number): number {
-  return Math.max(
-    PANEL_MIN_WIDTH,
-    Math.min(PANEL_MAX_WIDTH, viewportWidth - MIN_CONTENT_GUTTER)
-  )
-}
+export const SETTINGS_PANEL_DEFAULT_WIDTH = 360
 
 /**
  * Clamp a width into range. Applied to every source of one — a value read back
  * from storage, a live drag, and a window resize — so no path can strand a
- * panel wider than its viewport.
+ * panel outside its bounds.
  */
 export function clampPanelWidth(width: number, viewportWidth: number): number {
-  return Math.min(Math.max(width, PANEL_MIN_WIDTH), maxPanelWidth(viewportWidth))
+  // Below the breakpoint the handles are hidden, so there is no user-chosen
+  // width to honour and only the viewport fit matters. Applying the desktop
+  // floor here would force 300px onto a 320px phone.
+  if (viewportWidth < PANEL_RESIZE_BREAKPOINT) {
+    return Math.min(width, Math.max(0, viewportWidth - MIN_CONTENT_GUTTER))
+  }
+  // At or above the breakpoint the viewport always allows at least
+  // 768 - 64 = 704px, comfortably more than PANEL_MAX_WIDTH, so the gutter can
+  // never bind here and the bounds are the whole rule.
+  return Math.min(Math.max(width, PANEL_MIN_WIDTH), PANEL_MAX_WIDTH)
 }

--- a/src/constants/panels.ts
+++ b/src/constants/panels.ts
@@ -1,0 +1,64 @@
+/**
+ * Side panel geometry.
+ *
+ * Every panel — the left timelines panel, Settings, Feedback and Event details
+ * — is a fixed `<aside>` whose width *includes* a 6px gap that floats the
+ * visible card off the viewport edge. A panel of width 320 therefore renders a
+ * 314px card.
+ *
+ * Before panels became resizable this number was four independent literals
+ * (plus two more for the left panel's push layout: GlobalLayout's content
+ * padding and FloatingToolbar's recentering). Keeping them in sync by hand is
+ * exactly what this module exists to end — nothing should hard-code a panel
+ * width again.
+ */
+
+/** Gap between a panel's card and the viewport edge. */
+export const PANEL_GAP = 6
+
+/**
+ * Narrowest a panel may be dragged. Below roughly 250px the usage table in
+ * `SidePanel/UsageLimits.tsx` (a 140px wrapper around two 65px columns)
+ * overflows its row, so this leaves a little margin above that floor.
+ */
+export const PANEL_MIN_WIDTH = 260
+
+/** Widest a panel may be dragged, before the viewport clamp below applies. */
+export const PANEL_MAX_WIDTH = 640
+
+/**
+ * Content that must stay visible beside a panel. Small enough that phones keep
+ * roughly the full-width panel they have today, large enough that a panel can
+ * never swallow the viewport outright.
+ */
+export const MIN_CONTENT_GUTTER = 64
+
+/** Default footprint for the left timelines panel and the event details panel. */
+export const PANEL_DEFAULT_WIDTH = 320
+
+/**
+ * Settings runs wider than its siblings — the scale selectors and the BYOK key
+ * rows were cramped at 314px.
+ */
+export const SETTINGS_PANEL_DEFAULT_WIDTH = 400
+
+/**
+ * Widest a panel may actually go right now. `PANEL_MAX_WIDTH` is the ceiling;
+ * on a narrow viewport the gutter wins instead, which is what keeps the 400px
+ * Settings default from overflowing a ~390px phone.
+ */
+export function maxPanelWidth(viewportWidth: number): number {
+  return Math.max(
+    PANEL_MIN_WIDTH,
+    Math.min(PANEL_MAX_WIDTH, viewportWidth - MIN_CONTENT_GUTTER)
+  )
+}
+
+/**
+ * Clamp a width into range. Applied to every source of one — a value read back
+ * from storage, a live drag, and a window resize — so no path can strand a
+ * panel wider than its viewport.
+ */
+export function clampPanelWidth(width: number, viewportWidth: number): number {
+  return Math.min(Math.max(width, PANEL_MIN_WIDTH), maxPanelWidth(viewportWidth))
+}

--- a/src/contexts/SidePanelContext.tsx
+++ b/src/contexts/SidePanelContext.tsx
@@ -1,5 +1,7 @@
 import { createContext, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { usePanelWidth } from '@/hooks/usePanelWidth'
+import { PANEL_DEFAULT_WIDTH } from '@/constants/panels'
 
 type TimelineSelectHandler = (timelineId: string) => void
 type DraftSelectHandler = (draftId: string) => void
@@ -11,6 +13,17 @@ interface SidePanelContextValue {
   open: () => void
   close: () => void
   toggle: () => void
+  /**
+   * Panel footprint in px, gap included. Lives here rather than in
+   * `GlobalLayout` because the push layout has two other readers: the content
+   * wrapper's `padding-left` and `FloatingToolbar`'s recentering.
+   */
+  width: number
+  setWidth: (width: number) => void
+  resetWidth: () => void
+  /** True mid-drag, so readers can drop their width transitions and track the cursor. */
+  isResizing: boolean
+  setIsResizing: (isResizing: boolean) => void
   onTimelineSelect: TimelineSelectHandler
   setOnTimelineSelect: (handler: TimelineSelectHandler | null) => void
   onDraftSelect: DraftSelectHandler
@@ -39,6 +52,7 @@ interface SidePanelContextValue {
 export const SidePanelContext = createContext<SidePanelContextValue | null>(null)
 
 const STORAGE_KEY = 'side_panel_open'
+const WIDTH_STORAGE_KEY = 'side_panel_width'
 
 function readStoredIsOpen(): boolean {
   try {
@@ -52,6 +66,8 @@ function readStoredIsOpen(): boolean {
 
 export function SidePanelProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(readStoredIsOpen)
+  const { width, setWidth, resetWidth } = usePanelWidth(WIDTH_STORAGE_KEY, PANEL_DEFAULT_WIDTH)
+  const [isResizing, setIsResizing] = useState(false)
   const [activeTimelineId, setActiveTimelineId] = useState<string | null>(null)
   const [activeDraftId, setActiveDraftId] = useState<string | null>(null)
   const [activeTimelineTitle, setActiveTimelineTitle] = useState<string | null>(null)
@@ -120,6 +136,11 @@ export function SidePanelProvider({ children }: { children: ReactNode }) {
     open,
     close,
     toggle,
+    width,
+    setWidth,
+    resetWidth,
+    isResizing,
+    setIsResizing,
     onTimelineSelect,
     setOnTimelineSelect,
     onDraftSelect,
@@ -138,7 +159,7 @@ export function SidePanelProvider({ children }: { children: ReactNode }) {
     setActiveEventCount,
     activeDominantCategoryColor,
     setActiveDominantCategoryColor,
-  }), [isOpen, open, close, toggle, onTimelineSelect, setOnTimelineSelect, onDraftSelect, setOnDraftSelect, refreshTimelines, setRefreshTimelines, onOpenSettings, setOnOpenSettings, activeTimelineId, activeDraftId, activeTimelineTitle, activeEventCount, activeDominantCategoryColor])
+  }), [isOpen, open, close, toggle, width, setWidth, resetWidth, isResizing, onTimelineSelect, setOnTimelineSelect, onDraftSelect, setOnDraftSelect, refreshTimelines, setRefreshTimelines, onOpenSettings, setOnOpenSettings, activeTimelineId, activeDraftId, activeTimelineTitle, activeEventCount, activeDominantCategoryColor])
 
   return (
     <SidePanelContext.Provider value={value}>

--- a/src/hooks/usePanelWidth.ts
+++ b/src/hooks/usePanelWidth.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useState } from 'react'
+import { clampPanelWidth } from '@/constants/panels'
+
+/**
+ * A panel's user-chosen width, persisted per device.
+ *
+ * Mirrors the storage shape `SidePanelContext` uses for `side_panel_open`:
+ * lazy `useState` initializer reading localStorage, a `useEffect` writing it
+ * back, both wrapped in try/catch so a disabled or full store degrades to
+ * in-memory state rather than throwing.
+ */
+
+function currentViewportWidth(): number {
+  return typeof window === 'undefined' ? Infinity : window.innerWidth
+}
+
+function readStoredWidth(storageKey: string, fallback: number): number {
+  const viewport = currentViewportWidth()
+  try {
+    const raw = localStorage.getItem(storageKey)
+    if (raw === null) return clampPanelWidth(fallback, viewport)
+    const parsed = Number(raw)
+    // A hand-edited or corrupt value must not propagate NaN into a width style
+    // and collapse the layout — fall back to the default instead.
+    if (!Number.isFinite(parsed)) return clampPanelWidth(fallback, viewport)
+    return clampPanelWidth(parsed, viewport)
+  } catch {
+    return clampPanelWidth(fallback, viewport)
+  }
+}
+
+export function usePanelWidth(storageKey: string, defaultWidth: number) {
+  const [width, setWidthState] = useState(() => readStoredWidth(storageKey, defaultWidth))
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(storageKey, String(width))
+    } catch {
+      // storage full or disabled — silently ignore
+    }
+  }, [storageKey, width])
+
+  const setWidth = useCallback((next: number) => {
+    setWidthState(clampPanelWidth(next, currentViewportWidth()))
+  }, [])
+
+  const resetWidth = useCallback(() => {
+    setWidthState(clampPanelWidth(defaultWidth, currentViewportWidth()))
+  }, [defaultWidth])
+
+  // A window shrinking below the stored width would leave the panel wider than
+  // its viewport — re-clamp on resize rather than waiting for the next drag.
+  useEffect(() => {
+    const handleResize = () => {
+      setWidthState(prev => clampPanelWidth(prev, currentViewportWidth()))
+    }
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
+  return { width, setWidth, resetWidth }
+}

--- a/src/hooks/useTimelineScroll.ts
+++ b/src/hooks/useTimelineScroll.ts
@@ -54,18 +54,27 @@ export function useTimelineScroll(
     const debouncedScroll = debounce(handleScroll, 16); // ~60fps
 
     const container = scrollContainerRef.current;
+    let observer: ResizeObserver | undefined;
+
     if (container) {
       container.addEventListener('scroll', debouncedScroll);
       // Initial calculation
       handleScroll();
       // Recalculate on resize
       window.addEventListener('resize', debouncedScroll);
+      // The window listener alone is not enough: resizing the side panel
+      // changes this container's width (it is a push layout) without firing a
+      // window resize, which would leave containerWidth — and so the sticky
+      // year indicator driven by visibleRange — stale until the next scroll.
+      observer = new ResizeObserver(debouncedScroll);
+      observer.observe(container);
     }
 
     return () => {
       if (container) {
         container.removeEventListener('scroll', debouncedScroll);
         window.removeEventListener('resize', debouncedScroll);
+        observer?.disconnect();
       }
     };
   }, [scrollContainerRef, totalMonths]);


### PR DESCRIPTION
Lets users drag each side panel wider or narrower within a bounded range, with the choice persisted per device.

All four panels (left timelines, Settings, Event details, Feedback) clamp to **300–400px** on desktop. Settings opens at 360px; the rest at 320px.

## The width logic this replaces

There wasn't a width system — there were five independent literals, no shared constant, no CSS variable, no theme token:

| Location | Value |
|---|---|
| `GlobalLayout.tsx:21` | `w-[320px]` — the left panel's aside |
| `GlobalLayout.tsx:30` | `paddingLeft: '320px'` — the content offset compensating for it |
| `FloatingToolbar.tsx:15` | `SIDE_PANEL_WIDTH = 320` — its own copy, used to recenter the pill |
| `TimelineSettingsPanel.tsx:162` | `w-[320px]` |
| `EventDetailPanel.tsx:268` | `md:w-[326px]` |

The first two already had to be kept in sync by hand for the push layout to work. The `326` was a live inconsistency rather than a deliberate choice — it rendered a 320px card where its siblings rendered 314px.

## Approach

- **`src/constants/panels.ts`** — single source for bounds, breakpoint, and per-panel defaults.
- **`src/hooks/usePanelWidth.ts`** — persisted width per panel, mirroring the localStorage shape `SidePanelContext` already uses for `side_panel_open`: lazy `useState` initializer, `useEffect` writeback, both in try/catch so a disabled store degrades to in-memory rather than throwing.
- **`src/components/ui/PanelResizeHandle.tsx`** — a 6px drag strip on each panel's inner edge, following `useEventDrag`'s window-listener idiom so a drag survives the cursor leaving the strip. Double-click or `Home` resets; arrow keys step 16px.

The clamp runs on read, on drag, and on window resize, so neither a corrupt stored value nor a shrinking window can strand a panel out of range.

**The 300px floor is deliberately a desktop-only rule.** The handles are `hidden md:block`, so below 768px there is no user-chosen width to honour — only the viewport fit matters, and applying the floor there would force 300px onto a 320px phone. `clampPanelWidth` branches on that breakpoint rather than applying one floor everywhere.

## Three couplings this exposed

All fixed here; the second is the one that would have been easy to miss:

1. **`FloatingToolbar`** recentered off its own `SIDE_PANEL_WIDTH` copy — now reads the live width.
2. **`useTimelineScroll`** listened only to `window.resize`. The left panel is a push layout, so a drag changes the timeline container's width *without* firing one, leaving `visibleRange` — and the sticky year indicator it drives — stale until the next scroll. Added a `ResizeObserver`.
3. **The event details image frame** was a fixed `md:w-[274px]`; now fluid, `274/205` ratio preserved.

Event details keeps its width behind a CSS custom property (`md:w-[var(--event-panel-width)]`) so the `md:` prefix still applies and the panel stays full-screen on mobile.

## Verification

No test framework is configured, so this was checked by driving the real app in a browser. `npm run lint` and `npm run build` both clean.

| Check | Result |
|---|---|
| Fresh defaults | left 320px, Settings 360px, Event details 320px |
| Drag any panel past max | hard stop at 400px |
| Drag any panel past min | hard stop at 300px |
| Settings drags both directions from 360 | → 400px wider, → 300px narrower |
| Left panel content offset | `padding-left` tracks the width exactly at every size |
| Double-click handle | resets to default |
| Arrow keys on focused handle | 320 → 352px (2 × 16px step) |
| Corrupt `side_panel_width` value | falls back to default, rewrites storage |
| Stale out-of-range stored widths (640 / 260) | clamp to 400 / 300 on next load — no migration needed |
| 320px viewport | panels fit the viewport rather than the floor; Event details full-bleed; handles `display: none` |

## Note

`SETTINGS_PANEL_DEFAULT_WIDTH` is 360px rather than 400px specifically so Settings isn't pinned at its ceiling on open — at 400px the drag would only work in one direction.