### PR TITLE
Replace the side panel footer with an account row and menu

### DIFF
--- a/docs/2026-08-13-account-menu-prd.md
+++ b/docs/2026-08-13-account-menu-prd.md
@@ -49,6 +49,9 @@ part of the system that has historically drifted.
 | Legal links | New tab, with an `↗` affordance | `/privacy` and `/terms` render *outside* the layout — an in-tab link destroys editor state |
 | Delete Account | Stays in the menu, below a divider, on `text-destructive` | Where it was asked for. Separation and colour carry the weight the current text link does not |
 | Account modal surface | Radix Dialog, 720×560, with a **full-height rail** flush to its edges | Settings-dialog layout rather than the Events modal's inset card. Same 20px shell and `#171717` surface, so the two still read as one family |
+| Rail below 640px | Horizontal scrolling tab strip; modal goes full-screen | A 200px rail plus content plus padding needs ~570px. 640 rather than `PANEL_RESIZE_BREAKPOINT` (768) because that constant governs a different element |
+| Reflow mechanism | CSS grid, one DOM order, two placements | The header moves from beside the rail to above it — an L-shape flex cannot express. Duplicating it behind `sm:hidden` would mean two `DialogPrimitive.Title` ids |
+| Reordering on mobile | Off | The drag sensor activates at 5px, which is the scroll gesture. `restrictToHorizontalAxis` makes the two identical rather than distinguishing them |
 | Menu modality | `modal={false}` | Every item opens another Radix layer, and a modal menu strands `pointer-events: none` on `<body>` when that layer unmounts. See section 7 |
 | Settings item | **One entry**, opening the account modal | Was two adjacent entries — Settings (the editor's timeline panel) and Account Details. Merged; the modal's usage section links on to the timeline panel |
 | Settings visibility | Signed in only | The destination is an account modal, so it appears exactly when there is an account. This is where Account Details already sat |
@@ -192,6 +195,24 @@ shell — but laid out the way a settings dialog is rather than the way the Even
 
 The tab style lives in `ui/glassButton.ts` so the two modals' rails cannot drift apart.
 
+**Below `sm` (640px) the rail becomes a horizontal tab strip** under the heading, scrolling sideways, and
+the modal goes full-screen — edge to edge, no radius. 640 rather than the side panel's
+`PANEL_RESIZE_BREAKPOINT` (768) because that is where *this* layout stops fitting: a 200px rail plus
+~320px of content plus padding needs roughly 570px.
+
+That reflow is an L-shape — the header moves from beside the rail to above it — which flex cannot express
+from one DOM order. The Content is therefore a **grid**, placed one way below `sm` and another above it.
+Duplicating the header behind `sm:hidden` was the alternative and is worse: two `DialogPrimitive.Title`
+elements means two copies of the id Radix points `aria-labelledby` at.
+
+**Discoverability.** The strip uses the existing `.scrollbar-hide` utility, and
+`TIMELINE_ARCHITECTURE.md` §Discoverability already records what goes wrong when a hidden scrollbar is
+the only signal that more content exists. Here it is not: the strip is deliberately not padded to fit, so
+an overflowing tab stays visibly clipped — the reference's own affordance. On top of that, changing
+section scrolls the active tab into view, so selection moving without a click never strands it off-screen.
+
+`EventTableEditor` gets the same shell, plus the rail restructure in section 6a.
+
 The rail carries three sections — **Account details**, **Account usage**, **Account management** — and
 the active one's name *is* the `DialogPrimitive.Title`, so the dialog's accessible name always equals the
 heading on screen. Reopening always lands on the first section: a stale selection would otherwise open
@@ -221,12 +242,46 @@ Every value on this modal already exists. **There is no new query, no new table 
 
 ---
 
+## 6a. The Events modal, brought into line
+
+`EventTableEditor` had the same 200px inset rail and the same mobile problem, and its page navigation sat
+somewhere else entirely — a centred glass-pill band with an animated indicator, above the content.
+
+- **Its rail is now full-height and flush** on the same shell as the account modal, and responsive in the
+  same way.
+- **The Events / Categories page tabs moved into the top of that rail**, above a divider, with the
+  category filter below them. The pill band is gone; the content column shows the active page name where
+  it used to sit. On mobile the two groups are **two stacked strips**, not one flattened row —
+  collapsing them would imply they are the same kind of choice.
+- **No close X**, unlike the account modal: this one keeps its Cancel/Save footer, and an X that silently
+  discards edits is a worse affordance than the Cancel already there.
+
+**Drag-to-reorder stops below `sm`.** The category tabs use a `PointerSensor` with
+`activationConstraint: { distance: 5 }` — and in a horizontal strip those same 5px are the scroll
+gesture. `restrictToHorizontalAxis` does not resolve that; it makes the two gestures identical. So on
+narrow viewports the tabs render as plain buttons outside any `DndContext`, and the swipe scrolls.
+Reordering is a desktop refinement; scrolling is what a phone needs.
+
+This is the one place a CSS breakpoint is not enough — dnd-kit's strategy and modifiers are props, not
+classes — hence `useIsNarrow()` (`src/hooks/useIsNarrow.ts`), which follows the viewport-read pattern in
+`usePanelWidth.ts`. It also forced splitting `SortableTab` into a presentational `CategoryTab` plus a
+sortable wrapper, because `useSortable` is a hook and cannot be skipped conditionally.
+
+**A limitation worth stating rather than papering over**: the Events table's columns are fixed-width
+(240/90/90px plus selects) and total well over a phone's width. This work makes the modal's *navigation*
+usable on mobile; the table inside it still scrolls horizontally and is cramped. Separately, the side
+panel is 320px wide and open by default, so on a 375px viewport it covers the editor and the toolbar
+that opens this modal — pre-existing, and not something these modals control.
+
+---
+
 ## 7. What changes
 
 **New.** `ui/dropdown-menu.tsx` (the shadcn primitive, re-themed per section 5).
 `SidePanel/AccountRow.tsx` and `SidePanel/AccountMenu.tsx`. `Modal/AccountDetailsModal.tsx`. One constants
-module for the tier display strings, and `ui/glassButton.ts` for the modal-shell button and rail styles
-shared with `EventTableEditor`.
+module for the tier display strings; `ui/glassButton.ts` for the modal-shell button, rail and tab styles
+shared with `EventTableEditor`; and `hooks/useIsNarrow.ts` for the single case a media query cannot
+reach.
 
 **One non-obvious requirement.** The account menu must be `modal={false}`. As a modal layer a Radix
 DropdownMenu writes `pointer-events: none` onto `<body>` while open, and every item in this menu opens a
@@ -258,7 +313,7 @@ alignment is the point.
 
 Following the convention in `2026-08-07-verification-runbook.md`: shipped is not the same as verified.
 
-**Verified in a real browser** against `npm run dev`, driven by Playwright — 106 assertions across three
+**Verified in a real browser** against `npm run dev`, driven by Playwright — 80 assertions across two viewports and four
 suites, all passing:
 
 - **The menu escapes the panel.** At both ends of the resizable range — `PANEL_MIN_WIDTH` (300) and
@@ -284,6 +339,15 @@ suites, all passing:
   from the content column, and no corner radius. The close X sits in the content column's top-right and
   there is no footer button.
 - **The heading tracks the rail**, and is the dialog's accessible name.
+
+**Verified at 375×667** (29 further assertions): the account modal fills the viewport with no radius; the
+rail is a 57px band spanning the full width with the heading above it, inverting the desktop
+relationship; the strip overflows (424px of tabs in 375px), scrolls, keeps its tabs on one row rather
+than wrapping, and scrolls the active tab into view on selection. The Events modal fills the viewport,
+its rail is a 114px band of **two** stacked scrolling strips, and no drag handles render in it. On
+desktop the Events rail is full-height and flush, carries Events/Categories above the category filter,
+switches pages from the rail, hides the category filter on the Categories page, keeps its four drag
+handles, and the old pill band is gone.
 - **Account Details** shows the email, the passwordless explanation, the plan, usage, key status and the
   destructive footer; on `byok` it names Anthropic and masks the key to `sk-ant-v…0000`.
 - **No layer leak, on all three paths.** Closing Account Details, and cancelling either the Log Out or the

--- a/docs/2026-08-13-account-menu-prd.md
+++ b/docs/2026-08-13-account-menu-prd.md
@@ -1,8 +1,9 @@
 # The account menu — redesigning the bottom of the left panel — 13 August 2026
 
 Product requirements for replacing the side panel's footer strip with a single account row and a menu,
-modelled on the pattern Claude uses in the same position. Written before the implementation rather than
-alongside it, so section 8 is a list of things to prove rather than a record of things proven.
+modelled on the pattern Claude uses in the same position. Written before the implementation and then kept
+current through it, so section 8 records what was actually proven — including the two places the spec was
+wrong and what replaced it.
 
 ---
 
@@ -46,7 +47,8 @@ part of the system that has historically drifted.
 | Menu width | Wider than the panel, overlapping the canvas | Matches the reference. A menu capped at the panel's own width wraps its labels at `PANEL_MIN_WIDTH` |
 | Legal links | New tab, with an `↗` affordance | `/privacy` and `/terms` render *outside* the layout — an in-tab link destroys editor state |
 | Delete Account | Stays in the menu, below a divider, on `text-destructive` | Where it was asked for. Separation and colour carry the weight the current text link does not |
-| Account Details surface | **Modal**, on the existing `Modal` shell | It is a read-mostly summary, not a workspace, and the shell already portals and locks scroll |
+| Account Details surface | **Modal**, on the `EventTableEditor` shell with a section rail | A modal because it is a read-mostly summary, not a workspace; that shell because the product should not grow a second full-size modal design |
+| Menu modality | `modal={false}` | Every item opens another Radix layer, and a modal menu strands `pointer-events: none` on `<body>` when that layer unmounts. See section 7 |
 | Settings item | Existing `onOpenSettings()`; the panel is unchanged | No new surface and no edit to `TimelineSettingsPanel` |
 | Settings visibility | Hidden wherever no handler is registered | `SidePanelContext.tsx:126-128` calls through a ref only the editor registers. A present item that silently does nothing is worse than an absent one |
 | Signed-out row | Renders, with a reduced menu | `byok-anon` has drafts and limits, and the panel is its only sign-in entry point |
@@ -173,34 +175,36 @@ subtly and inexplicably blue against the panel unless it is overridden.
 
 ## 6. Account Details
 
-A **modal**, built on `src/components/Modal/Modal.tsx` — the shell `ApiKeyModal` and `TrialGateModal`
-already use. It portals to body, locks scroll via `lockScroll`/`unlockScroll`, renders a titled header with
-a close button, and offers three widths; `compact` (420px) or `default` (550px) both fit this content.
+A **modal on the `EventTableEditor` shell** — Radix Dialog rather than the `Modal` wrapper, 720px wide,
+20px radius on `#171717`, an Aleo 24px header band, a 200px left rail of sections, and a glass-button
+footer. The two full-size modals in the product should read as one surface, so the button and tab styles
+live in `ui/glassButton.ts` and `EventTableEditor` imports them rather than keeping its own copies.
 
-Four sections:
+The rail carries three sections — **Account details**, **Account usage**, **Account management** — and
+reopening always lands on the first, since the menu item that opens it is called "Account Details" and
+arriving on the delete screen is not what that promised.
 
-**Identity** — the email address, and how it authenticates: passwordless email OTP, six-digit codes. Worth
-stating plainly, because "there is no password" is a question this modal should answer before it is asked.
+Their contents:
 
-**Tier** — which state the visitor is in and what it grants, using the same strings as the row.
+**Account details** — the email address, how it authenticates (passwordless, a six-digit code each time —
+worth stating plainly, because "there is no password" is a question this pane should answer before it is
+asked), and the join date from `user.created_at`.
 
-**Usage** — events and timelines against their caps. `useEventUsage()` already returns
-`{eventCount, eventLimit, timelineCount, timelineLimit, isLoading, refetch}`, and `PLAN_LIMITS`
-(`plans.ts:15-20`) already holds the caps.
+There is **no name field**, and the pane does not pretend otherwise. Identity here is email-only by design:
+sign-up collects an address and nothing else, so a "Name" row would either sit permanently empty or invent
+a value the account does not have.
 
-**API key** — status only: which provider is active, the masked key, and a pointer to Settings. The
-management UI itself stays in `TimelineSettingsPanel:262` and is not moved or duplicated. `maskKey` and
-`useByokCredential` in `services/userApiKey` supply everything this section needs.
+**Account usage** — the tier and what it grants, using the same strings as the row; events and timelines
+against their caps; and API key *status* — which provider is active and the masked key. `useEventUsage()`
+supplies the counts and `PLAN_LIMITS` (`plans.ts:15-20`) the caps. Key management itself stays in
+`TimelineSettingsPanel:262`; this pane links to it rather than duplicating it.
 
-Delete Account repeats here as a destructive footer, below a rule. Two entry points to a destructive action
-is not redundancy — the menu item is for someone who knows what they want, the modal footer for someone who
-arrived to read what deletion means first.
+**Account management** — Delete Account, with room for the full warning the menu item cannot carry: what
+is lost, that it cannot be undone, and where to export first. Two entry points to a destructive action is
+not redundancy — the menu item is for someone who knows what they want, this pane for someone who arrived
+to read what deletion means.
 
 Every value on this modal already exists. **There is no new query, no new table and no new hook.**
-
-One note for implementation, not a requirement: the `Modal` shell's palette (`bg-gray-800`,
-`border-gray-700`) predates the current tokens and does not match the panel. Whether to bring it in line
-here or leave it consistent with the other two modals is a judgement call at build time.
 
 ---
 
@@ -208,7 +212,15 @@ here or leave it consistent with the other two modals is a judgement call at bui
 
 **New.** `ui/dropdown-menu.tsx` (the shadcn primitive, re-themed per section 5).
 `SidePanel/AccountRow.tsx` and `SidePanel/AccountMenu.tsx`. `Modal/AccountDetailsModal.tsx`. One constants
-module for the tier display strings.
+module for the tier display strings, and `ui/glassButton.ts` for the modal-shell button and rail styles
+shared with `EventTableEditor`.
+
+**One non-obvious requirement.** The account menu must be `modal={false}`. As a modal layer a Radix
+DropdownMenu writes `pointer-events: none` onto `<body>` while open, and every item in this menu opens a
+second Radix layer — the Account Details dialog, or a `ConfirmationModal` for Log Out and Delete Account.
+When that second layer unmounts it restores the style it found on mount, which is the menu's `none`: the
+page then looks normal and silently ignores every click. Non-modal means the menu never writes the style,
+so there is nothing stale to restore. Only inerting the page behind a small account menu is given up.
 
 **Modified.** `SidePanelBody.tsx`: the footer at 669-702 is deleted and replaced by the row. The three
 `ConfirmationModal`s at 704-735 and their handlers at 374-406 are **kept and re-pointed** — the copy in
@@ -233,7 +245,7 @@ alignment is the point.
 
 Following the convention in `2026-08-07-verification-runbook.md`: shipped is not the same as verified.
 
-**Verified in a real browser** against `npm run dev`, driven by Playwright — 55 assertions across two
+**Verified in a real browser** against `npm run dev`, driven by Playwright — 86 assertions across three
 suites, all passing:
 
 - **The menu escapes the panel.** At both ends of the resizable range — `PANEL_MIN_WIDTH` (300) and
@@ -257,8 +269,15 @@ suites, all passing:
   its job in both directions.
 - **Account Details** shows the email, the passwordless explanation, the plan, usage, key status and the
   destructive footer; on `byok` it names Anthropic and masks the key to `sk-ant-v…0000`.
-- **No layer leak.** Closing the modal leaves `body` at `pointer-events: auto` and the menu reopens — the
-  failure mode when a Radix menu and a dialog hand off badly.
+- **No layer leak, on all three paths.** Closing Account Details, and cancelling either the Log Out or the
+  Delete Account confirmation, each leave `body` at `pointer-events: auto` and the menu reopens
+  afterwards. This did fail before `modal={false}` — the page went inert with nothing on screen to
+  explain it — so it is asserted rather than assumed.
+- **Account Details** opens on its first section every time, and the three rail sections show what they
+  should: email / sign-in method / join date, tier / usage / key status, and the delete warning with a
+  destructive button. Usage reflects the tier's real caps (25 and 1200 on `byok`, 10 and 300 on `free`).
+- **`EventTableEditor` still renders with no page error** after its button styles moved to
+  `ui/glassButton.ts`.
 
 **Verified by the toolchain**: `npx tsc --noEmit -p tsconfig.app.json` reports 16 errors, the
 pre-existing count, none in any file this change touches. `npm run lint` is clean.

--- a/docs/2026-08-13-account-menu-prd.md
+++ b/docs/2026-08-13-account-menu-prd.md
@@ -50,6 +50,7 @@ part of the system that has historically drifted.
 | Delete Account | Stays in the menu, below a divider, on `text-destructive` | Where it was asked for. Separation and colour carry the weight the current text link does not |
 | Account modal surface | Radix Dialog, 720×560, with a **full-height rail** flush to its edges | Settings-dialog layout rather than the Events modal's inset card. Same 20px shell and `#171717` surface, so the two still read as one family |
 | Rail below 640px | Horizontal scrolling tab strip; modal goes full-screen | A 200px rail plus content plus padding needs ~570px. 640 rather than `PANEL_RESIZE_BREAKPOINT` (768) because that constant governs a different element |
+| Desktop centring | `inset-0 m-auto`, never a −50% translate | A transform-based centre is overwritten by `tailwindcss-animate`'s keyframe and drifts the modal in from a corner. See section 6b |
 | Reflow mechanism | CSS grid, one DOM order, two placements | The header moves from beside the rail to above it — an L-shape flex cannot express. Duplicating it behind `sm:hidden` would mean two `DialogPrimitive.Title` ids |
 | Reordering on mobile | Off | The drag sensor activates at 5px, which is the scroll gesture. `restrictToHorizontalAxis` makes the two identical rather than distinguishing them |
 | Menu modality | `modal={false}` | Every item opens another Radix layer, and a modal menu strands `pointer-events: none` on `<body>` when that layer unmounts. See section 7 |
@@ -275,6 +276,43 @@ that opens this modal — pre-existing, and not something these modals control.
 
 ---
 
+## 6b. Why these modals are centred with auto margins
+
+Both modals opened by sliding diagonally in from the bottom-right and closed the same way. Worth
+recording, because the cause is invisible in the class list — the classes that *prevent* it are the ones
+that look redundant.
+
+`tailwindcss-animate` builds one keyframe pair whose `from` sets the **entire** transform
+(`tailwindcss-animate/index.js:170-182`):
+
+```
+@keyframes enter { from {
+  opacity: var(--tw-enter-opacity, 1);
+  transform: translate3d(var(--tw-enter-translate-x, 0), var(--tw-enter-translate-y, 0), 0)
+             scale3d(var(--tw-enter-scale, 1), …) rotate(var(--tw-enter-rotate, 0));
+} }
+```
+
+The `slide-in-from-*` utilities do nothing except set those two custom properties. Without them both
+default to `0`, so frame 0 is `translate3d(0,0,0) scale(.95)` — and since animations outrank normal
+declarations, that **replaces** a static `translate(-50%,-50%)` centring for the animation's duration. A
+modal anchored at `left:50% top:50%` therefore starts with its top-left corner at the viewport centre,
+displaced by half its own size, and travels up-left into place.
+
+Shadcn's stock `ui/dialog.tsx` and `ui/alert-dialog.tsx` mask this by shipping `slide-in-from-left-1/2`
+and `slide-in-from-top-[48%]`, which re-supply the offsets. Those files are unaffected and unchanged.
+
+**These two modals centre with `inset-0 m-auto` instead.** Auto margins centre on both axes inside a
+fixed `inset-0` containing block when width and height are definite, which both have. With no static
+transform there is nothing for the keyframe to overwrite, `zoom-in-95` scales about the element's own
+centre, and no slide utilities are needed at all. Restoring them would also have worked, but they would
+exist purely to cancel a slide — one tidy-up away from bringing the drift back, which is exactly how it
+arrived.
+
+Mobile was never affected: below `sm` both are `inset-0` full-screen with no transform.
+
+---
+
 ## 7. What changes
 
 **New.** `ui/dropdown-menu.tsx` (the shadcn primitive, re-themed per section 5).
@@ -313,7 +351,7 @@ alignment is the point.
 
 Following the convention in `2026-08-07-verification-runbook.md`: shipped is not the same as verified.
 
-**Verified in a real browser** against `npm run dev`, driven by Playwright — 80 assertions across two viewports and four
+**Verified in a real browser** against `npm run dev`, driven by Playwright — 96 assertions across two viewports and five
 suites, all passing:
 
 - **The menu escapes the panel.** At both ends of the resizable range — `PANEL_MIN_WIDTH` (300) and
@@ -339,6 +377,12 @@ suites, all passing:
   from the content column, and no corner radius. The close X sits in the content column's top-right and
   there is no footer button.
 - **The heading tracks the rail**, and is the dialog's accessible name.
+- **Neither modal drifts when opening or closing** (16 assertions). Sampling the bounding box every
+  frame across the transition, the centre holds to 0.0px on both axes, on open and on close, and the
+  frame-0 transform is a pure scale with no offset — while opacity still runs 0.11 → 1 and the width
+  still runs 688 → 720, so the drift is gone without flattening the animation. These assertions were
+  confirmed to fail against the pre-fix code (319px and 480px of drift), which matters: every other
+  geometry check in the suite measures at rest and passes happily on a modal that flies in from a corner.
 
 **Verified at 375×667** (29 further assertions): the account modal fills the viewport with no radius; the
 rail is a 57px band spanning the full width with the heading above it, inverting the desktop

--- a/docs/2026-08-13-account-menu-prd.md
+++ b/docs/2026-08-13-account-menu-prd.md
@@ -1,0 +1,300 @@
+# The account menu — redesigning the bottom of the left panel — 13 August 2026
+
+Product requirements for replacing the side panel's footer strip with a single account row and a menu,
+modelled on the pattern Claude uses in the same position. Written before the implementation rather than
+alongside it, so section 8 is a list of things to prove rather than a record of things proven.
+
+---
+
+## 1. Summary
+
+The bottom of the left side panel (`SidePanelBody.tsx:664-702`) has accumulated rather than been
+designed. Below the `UsageLimits` card sits a footer holding the signed-in user's email beside an
+unlabelled `LogOut` glyph, and under that a row of three 12px text links: **Privacy**, **Terms**, and —
+pushed to the right edge with `ml-auto` — **Delete account**.
+
+Three problems, in descending order of how much they matter:
+
+- **Account deletion is styled as a link to the privacy policy.** It is one click from a confirmation
+  dialog, rendered at the same size, weight and colour as the two navigational links beside it. The only
+  thing separating the irreversible action from the legal boilerplate is a `hover:text-destructive`.
+- **Sign-out is an unlabelled icon.** A 16px `LogOut` glyph carrying a `title` attribute — a tooltip on
+  desktop, nothing at all on touch.
+- **The tier is invisible next to the identity.** `useAccountTier()` already knows whether the visitor is
+  on `free` or `byok`, and the panel already renders an entire card about limits, but the line naming the
+  user says nothing about what they are on.
+
+What replaces it: **one row, pinned to the bottom**, showing an avatar, the user's name and their tier,
+and a chevron. Clicking it opens a menu upward carrying **Settings**, **Account Details**, **Learn more**
+(a submenu holding Privacy Policy and Terms & Conditions), **Log Out** and **Delete Account**. The row
+renders for signed-out visitors too, with a reduced menu, because `byok-anon` is a real tier with real
+drafts and the panel is its only route to sign-in.
+
+Two things this deliberately does not touch: **the Settings panel**, which keeps its current contents and
+its current entry points, and **`UsageLimits`**, which is phase 2 (section 9). The tier model is unchanged.
+No SQL, no migration, no edge function — which is the main reason this can land without going near the
+part of the system that has historically drifted.
+
+---
+
+## 2. Product decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Menu mechanism | Add `@radix-ui/react-dropdown-menu`; new `ui/dropdown-menu.tsx` | The submenu, roving focus, typeahead and Escape handling all come with it. The alternative is re-deriving four behaviours by hand |
+| Positioning | Portal, `side="top"`, `align="start"`, anchored to the row | `GlobalSidePanel.tsx:11` sets `overflow-hidden`; anything positioned in-flow is clipped |
+| Menu width | Wider than the panel, overlapping the canvas | Matches the reference. A menu capped at the panel's own width wraps its labels at `PANEL_MIN_WIDTH` |
+| Legal links | New tab, with an `↗` affordance | `/privacy` and `/terms` render *outside* the layout — an in-tab link destroys editor state |
+| Delete Account | Stays in the menu, below a divider, on `text-destructive` | Where it was asked for. Separation and colour carry the weight the current text link does not |
+| Account Details surface | **Modal**, on the existing `Modal` shell | It is a read-mostly summary, not a workspace, and the shell already portals and locks scroll |
+| Settings item | Existing `onOpenSettings()`; the panel is unchanged | No new surface and no edit to `TimelineSettingsPanel` |
+| Settings visibility | Hidden wherever no handler is registered | `SidePanelContext.tsx:126-128` calls through a ref only the editor registers. A present item that silently does nothing is worse than an absent one |
+| Signed-out row | Renders, with a reduced menu | `byok-anon` has drafts and limits, and the panel is its only sign-in entry point |
+| Tier label | `·`-separated suffix on the row | The reference pattern. After identity, the tier is the most useful thing that line can say |
+| `loading` tier | Skeleton row, menu not openable | `useAccountTier` returns `'loading'` before auth answers; rendering "Guest" in that window mislabels a signed-in user |
+| Identity string | Email local-part on the row, full address in the menu header | What both reference screenshots do, and a full address does not fit the narrowest card |
+
+**Rejected: building the menu on `popover.tsx`.** It is already installed and already portalled, so the
+saving is one dependency. But `Popover` is a positioned surface, not a menu: no submenu, no arrow-key
+traversal, no typeahead, no `role="menu"` semantics. That is one package weighed against a menu's entire
+keyboard contract — and the hand-rolled menu already in this file shows how that trade ends.
+`TileMenuButton` (`SidePanelBody.tsx:45-151`) closes on a `document` click listener, traps no focus, and
+cannot be reached from the keyboard at all.
+
+**Rejected: extending `TileMenuButton` into a shared menu component.** The same reasoning from the other
+side. It is fine for a five-item flyout nobody tabs to; the account menu needs a submenu on the first day.
+
+---
+
+## 3. Four constraints the panel imposes
+
+These are properties of the code as it stands, not preferences. Each one rules out an implementation that
+would otherwise look obvious.
+
+**The panel clips its own children.** `GlobalSidePanel.tsx:11` is
+`h-full w-full bg-[#171717] rounded-[6px] border … flex flex-col overflow-hidden`. A menu rendered inside
+the panel's DOM cannot exceed the panel's bounds, and the reference design is explicitly wider than the
+panel and overlaps the canvas to its right. The menu must go through a portal — which is half the
+argument for the Radix dependency, since `DropdownMenu.Portal` does it by default.
+
+`Modal.tsx:33-36` already documents the same hazard from the other direction, and its comment is worth
+quoting because it names a second trap this work will meet:
+
+> Portal to body so we escape any ancestor with a `transform` (e.g. the sliding side panel), which would
+> otherwise become the containing block for `position: fixed` and trap us inside the panel.
+
+**The legal routes are outside the layout.** `Router.tsx:20-41` puts `/` and `/editor` inside
+`LayoutRoute` — which owns `SidePanelProvider` and `GlobalLayout` — and mounts `/privacy` and `/terms` as
+siblings of it, not children. Navigating to either through the footer's current `<Link>` therefore unmounts
+the editor entirely. Opening them in a new tab is both the fix and a match for the `↗` affordance in the
+reference.
+
+**`onOpenSettings()` is a no-op outside the editor.** `SidePanelContext.tsx:126-128` calls through a ref
+that only the editor route registers. On `/` and in the viewer the ref is null and the call does nothing,
+silently. The menu must be able to tell — hence `hasSettingsHandler` in section 7.
+
+**Sign-out from this panel skips the cache purge.** `handleSignOut` (`SidePanelBody.tsx:374-384`) calls
+`supabase.auth.signOut()` directly. `AuthContext`'s own `signOut` (`AuthContext.tsx:26-39`) wraps the same
+call in a `finally` that runs `clearAllCachedEvents()`, with the comment "Don't leave a browsing record of
+viewed shared timelines behind after the account signs out." So events cached from shared timelines survive
+a sign-out taken from the side panel, but not one taken elsewhere. Small, real, and free to fix while this
+code is being rewritten anyway.
+
+---
+
+## 4. The row
+
+Anatomy, left to right: a 24px avatar circle, the identity string, a `·`, the tier label, and a chevron
+pushed to the right edge. The whole row is one button; the chevron is decoration, not a second target.
+
+| `useAccountTier()` | Avatar | Identity | After the `·` |
+|---|---|---|---|
+| `loading` | skeleton | skeleton | — |
+| `trial` | `User` icon | Guest | Not saved |
+| `byok-anon` | `User` icon | Guest | Your API key |
+| `free` | first alphanumeric of the local-part, uppercased | local-part, truncated | Free |
+| `byok` | same | local-part, truncated | Your API key |
+
+The identity string is the **local-part** of the email — everything before the `@` — truncated with an
+ellipsis. The full address appears as the menu's header instead, which is what both reference screenshots
+do. It is deliberately **not** capitalised or otherwise prettified: the transformations that make `alex`
+look right make `o'brien` and `van der berg` look wrong, and there is no display-name field to fall back
+on. Identity here is email-only by design (`CLAUDE.md`, "Access & data model").
+
+`loading` gets a skeleton rather than a guess. `user` is null both before the session lookup answers and
+when genuinely signed out, so a row that renders "Guest" in that window tells a signed-in user they have no
+account — the exact trap `authReady` exists to close, and the reason `useAccountTier` exposes a `'loading'`
+state at all rather than collapsing it into `trial`.
+
+The two BYOK states share a label because they share everything that label describes: limits do not vary by
+provider, and the provider is deliberately not a tier axis. Which key is in use is a detail for Account
+Details, not for a 300px row.
+
+**All display strings live in one exported map**, beside `PLAN_LIMITS`. The row, the Account Details modal
+and `UsageLimits` all name these states, and three files inventing their own wording is how "Your API key"
+becomes "BYOK" in one place and "API Key Connected" in another. This is the pattern
+`src/constants/byokProviders.ts` already establishes for provider names, and it exists for the same reason.
+
+---
+
+## 5. The menu
+
+Opens upward, anchored to the row, portalled to the body.
+
+**Signed in** (`free`, `byok`):
+
+| Item | Action |
+|---|---|
+| *header* — full email address | not interactive |
+| Settings | `onOpenSettings()` — hidden where unregistered |
+| Account Details | opens the modal in section 6 |
+| — divider — | |
+| Learn more → | submenu: **Privacy Policy ↗**, **Terms & Conditions ↗** |
+| — divider — | |
+| Log Out | `ConfirmationModal`, then `AuthContext.signOut()` |
+| Delete Account | `ConfirmationModal`, then the `delete-account` function |
+
+**Signed out** (`trial`, `byok-anon`): Settings, Learn more, a divider, then **Sign in** in place of Log
+Out. No Account Details, no Delete Account — there is no account to detail or delete. Sign-in reuses
+`AuthModal`, already imported at `SidePanelBody.tsx:25`.
+
+Both legal items are anchors with `target="_blank"` and `rel="noopener noreferrer"`, for the routing reason
+in section 3. They are the only items in the menu that leave the app, and the `↗` says so.
+
+Visually the menu inherits from the one that already exists in this file rather than from the shadcn
+defaults: `bg-[#171717]`, `border-[#404040]`, `rounded-md`, the
+`drop-shadow(0 4px 6px rgba(0, 0, 0, 0.3))` at `SidePanelBody.tsx:84`, 14px items on `text-[#c9ced4]`,
+`hover:bg-white/5`, destructive items on `text-destructive`. Worth flagging before it is generated rather
+than after: the shadcn `--popover` token (`index.css:21`, `217 33% 17%`) is a **blue-tinted slate**, not
+the panel's neutral grey. `ui/dropdown-menu.tsx` will reach for it by default, and the result will be
+subtly and inexplicably blue against the panel unless it is overridden.
+
+---
+
+## 6. Account Details
+
+A **modal**, built on `src/components/Modal/Modal.tsx` — the shell `ApiKeyModal` and `TrialGateModal`
+already use. It portals to body, locks scroll via `lockScroll`/`unlockScroll`, renders a titled header with
+a close button, and offers three widths; `compact` (420px) or `default` (550px) both fit this content.
+
+Four sections:
+
+**Identity** — the email address, and how it authenticates: passwordless email OTP, six-digit codes. Worth
+stating plainly, because "there is no password" is a question this modal should answer before it is asked.
+
+**Tier** — which state the visitor is in and what it grants, using the same strings as the row.
+
+**Usage** — events and timelines against their caps. `useEventUsage()` already returns
+`{eventCount, eventLimit, timelineCount, timelineLimit, isLoading, refetch}`, and `PLAN_LIMITS`
+(`plans.ts:15-20`) already holds the caps.
+
+**API key** — status only: which provider is active, the masked key, and a pointer to Settings. The
+management UI itself stays in `TimelineSettingsPanel:262` and is not moved or duplicated. `maskKey` and
+`useByokCredential` in `services/userApiKey` supply everything this section needs.
+
+Delete Account repeats here as a destructive footer, below a rule. Two entry points to a destructive action
+is not redundancy — the menu item is for someone who knows what they want, the modal footer for someone who
+arrived to read what deletion means first.
+
+Every value on this modal already exists. **There is no new query, no new table and no new hook.**
+
+One note for implementation, not a requirement: the `Modal` shell's palette (`bg-gray-800`,
+`border-gray-700`) predates the current tokens and does not match the panel. Whether to bring it in line
+here or leave it consistent with the other two modals is a judgement call at build time.
+
+---
+
+## 7. What changes
+
+**New.** `ui/dropdown-menu.tsx` (the shadcn primitive, re-themed per section 5).
+`SidePanel/AccountRow.tsx` and `SidePanel/AccountMenu.tsx`. `Modal/AccountDetailsModal.tsx`. One constants
+module for the tier display strings.
+
+**Modified.** `SidePanelBody.tsx`: the footer at 669-702 is deleted and replaced by the row. The three
+`ConfirmationModal`s at 704-735 and their handlers at 374-406 are **kept and re-pointed** — the copy in
+them is already correct, particularly the deletion warning, and rewriting correct copy while relocating it
+is how it stops being correct. `SidePanelContext.tsx` gains a `hasSettingsHandler` boolean so the menu can
+tell whether the Settings item has anywhere to go. `package.json` gains one dependency.
+
+**Fixed.** `handleSignOut` switches to `AuthContext.signOut()`, so `clearAllCachedEvents()` runs. See
+section 3.
+
+**Untouched, by decision.** `TimelineSettingsPanel.tsx`, `ApiKeySection.tsx`, `UsageLimits.tsx`.
+
+---
+
+## 8. Verified vs. unverified
+
+Following the convention in `2026-08-07-verification-runbook.md`: shipped is not the same as verified.
+This is a PRD, so everything below is unverified by definition. The list is what the implementation pass has
+to prove.
+
+1. **The menu escapes the panel.** At both ends of the resizable range — `PANEL_MIN_WIDTH` (300) and
+   `PANEL_MAX_WIDTH` (400), so cards of 294px and 394px once the 6px float gap is taken out — the menu
+   renders wider than the panel and overlaps the canvas without clipping. This is the single most likely
+   thing to be wrong, because it fails only visually and the `overflow-hidden` causing it is three files
+   away from the menu.
+2. **The submenu opens sideways and stays open** while the pointer crosses the gap to it.
+3. **Keyboard traversal end to end**: open with Enter, arrow through items, into and out of the submenu,
+   Escape closes one level at a time, focus returns to the row.
+4. **The `loading` window never renders "Guest".** Hard-reload as a signed-in user on a throttled connection
+   and watch the row. This is the failure that looks like a logout bug.
+5. **Legal links open new tabs with editor state intact** — make an unsaved edit, open Privacy, return to
+   the original tab, confirm the edit is still there.
+6. **Sign-out clears the viewer cache.** View a shared timeline, sign out from the menu, confirm the cached
+   events are gone.
+7. **All four tier states render the right row and the right menu**, including `byok-anon`, which is the
+   state most easily forgotten because it requires a key and no account.
+
+**A correction to carry forward.** `CLAUDE.md` lists account deletion among paths "deployed but never
+exercised". **That is stale.** `2026-08-07-verification-runbook.md` records `delete-account` as **VERIFIED
+end-to-end on 7 August**, against a real account: eight columns confirmed at zero afterwards, both cascades
+observed firing, and the `timeline_categories` row inserted by hand beforehand precisely so the test was
+real rather than an empty table matching an empty table. So the function is not the risk here.
+
+What *is* thin is the reporting around it. `handleDeleteAccount` announces both success and failure through
+`alert()` (`SidePanelBody.tsx:398,401`) — browser chrome standing in for the confirmation of an irreversible
+action. Making that action more discoverable is a reason to improve the reporting, not a reason to hide the
+action.
+
+**The type-check gate.** `npm run build` is `vite build` alone and does not type-check.
+`npx tsc --noEmit -p tsconfig.app.json` is the real gate. There are 16 pre-existing errors in the
+repository; none should be in files this change touches.
+
+---
+
+## 9. Phase 2 — the usage card
+
+`UsageLimits` sits directly above this footer and is the other half of the bottom of the panel. It is
+untouched here on purpose: it is a carefully-built surface with four tier-dependent variants, and folding it
+into the same change would make the diff hard to review for no gain in either.
+
+The follow-up is to reduce it to a single compact line above the account row, and move the tier comparison
+table into the Account Details modal, where there is room for it.
+
+The constraint that governs that work: the CTAs in `renderHeaderCta` (`UsageLimits.tsx:190-222`) — "Log In"
+for `byok-anon`, "Add API Key" for `free` — are the product's entire upgrade path, and `TrialStatus`
+(`UsageLimits.tsx:236-273`) is the only sign-in entry point a trial visitor has anywhere in the panel. Its
+own comment records that hiding it until the visitor had made something left first-time visitors with no way
+to log in at all. Neither may end up two clicks deep.
+
+---
+
+## 10. Decisions worth not re-litigating
+
+- **The portal is mandatory, not stylistic.** `GlobalSidePanel`'s `overflow-hidden` is what makes the
+  floating panel frame work, and the panel's `transform` would capture a `position: fixed` menu even without
+  it. The menu goes through a portal; the panel does not change.
+- **The legal links open new tabs because of the router**, not because external-link styling looks nice.
+  `/privacy` and `/terms` are mounted outside `LayoutRoute` and an in-tab navigation unmounts the editor. If
+  they ever move inside the layout, revisit — until then this is load-bearing.
+- **The Settings panel and `ApiKeySection` are untouched by decision**, not by omission. Account Details
+  shows key *status* and points at Settings; it does not duplicate the management UI.
+- **The email local-part is not capitalised or prettified.** There is no display-name field, and every
+  transformation that flatters one name mangles another.
+- **Trial is still not a tier.** It gets a row and a label, not a plan. `plans.ts:4-8` holds the three
+  durable tiers and this change does not add a fourth.
+- **The existing confirmation copy is kept**, particularly the deletion warning, which already names what is
+  lost and suggests exporting first.
+- **The tier strings live in one module.** Three surfaces name these states; three surfaces inventing their
+  own wording is the drift this repo has been bitten by before.

--- a/docs/2026-08-13-account-menu-prd.md
+++ b/docs/2026-08-13-account-menu-prd.md
@@ -26,13 +26,14 @@ Three problems, in descending order of how much they matter:
   user says nothing about what they are on.
 
 What replaces it: **one row, pinned to the bottom**, showing an avatar, the user's name and their tier,
-and a chevron. Clicking it opens a menu upward carrying **Settings**, **Account Details**, **Learn more**
-(a submenu holding Privacy Policy and Terms & Conditions), **Log Out** and **Delete Account**. The row
-renders for signed-out visitors too, with a reduced menu, because `byok-anon` is a real tier with real
-drafts and the panel is its only route to sign-in.
+and a chevron. Clicking it opens a menu upward carrying **Settings** (the account modal in section 6),
+**Learn more** (a submenu holding Privacy Policy and Terms & Conditions), **Log Out** and **Delete
+Account**. The row renders for signed-out visitors too, with a reduced menu, because `byok-anon` is a
+real tier with real drafts and the panel is its only route to sign-in.
 
-Two things this deliberately does not touch: **the Settings panel**, which keeps its current contents and
-its current entry points, and **`UsageLimits`**, which is phase 2 (section 9). The tier model is unchanged.
+Two things this deliberately does not touch: **the Settings panel**, whose contents are unchanged — it
+loses only its account-menu entry, keeping the editor's header gear and gaining a link from the account
+modal — and **`UsageLimits`**, which is phase 2 (section 9). The tier model is unchanged.
 No SQL, no migration, no edge function — which is the main reason this can land without going near the
 part of the system that has historically drifted.
 
@@ -47,10 +48,10 @@ part of the system that has historically drifted.
 | Menu width | Wider than the panel, overlapping the canvas | Matches the reference. A menu capped at the panel's own width wraps its labels at `PANEL_MIN_WIDTH` |
 | Legal links | New tab, with an `↗` affordance | `/privacy` and `/terms` render *outside* the layout — an in-tab link destroys editor state |
 | Delete Account | Stays in the menu, below a divider, on `text-destructive` | Where it was asked for. Separation and colour carry the weight the current text link does not |
-| Account Details surface | **Modal**, on the `EventTableEditor` shell with a section rail | A modal because it is a read-mostly summary, not a workspace; that shell because the product should not grow a second full-size modal design |
+| Account modal surface | Radix Dialog, 720×560, with a **full-height rail** flush to its edges | Settings-dialog layout rather than the Events modal's inset card. Same 20px shell and `#171717` surface, so the two still read as one family |
 | Menu modality | `modal={false}` | Every item opens another Radix layer, and a modal menu strands `pointer-events: none` on `<body>` when that layer unmounts. See section 7 |
-| Settings item | Existing `onOpenSettings()`; the panel is unchanged | No new surface and no edit to `TimelineSettingsPanel` |
-| Settings visibility | Hidden wherever no handler is registered | `SidePanelContext.tsx:126-128` calls through a ref only the editor registers. A present item that silently does nothing is worse than an absent one |
+| Settings item | **One entry**, opening the account modal | Was two adjacent entries — Settings (the editor's timeline panel) and Account Details. Merged; the modal's usage section links on to the timeline panel |
+| Settings visibility | Signed in only | The destination is an account modal, so it appears exactly when there is an account. This is where Account Details already sat |
 | Signed-out row | Renders, with a reduced menu | `byok-anon` has drafts and limits, and the panel is its only sign-in entry point |
 | Tier label | `·`-separated suffix on the row | The reference pattern. After identity, the tier is the most useful thing that line can say |
 | `loading` tier | Skeleton row, menu not openable | `useAccountTier` returns `'loading'` before auth answers; rendering "Guest" in that window mislabels a signed-in user |
@@ -93,7 +94,8 @@ reference.
 
 **`onOpenSettings()` is a no-op outside the editor.** `SidePanelContext.tsx:126-128` calls through a ref
 that only the editor route registers. On `/` and in the viewer the ref is null and the call does nothing,
-silently. The menu must be able to tell — hence `hasSettingsHandler` in section 7.
+silently. This is why the menu does not point at it at all, and why the account modal's "keys are managed
+in Settings" line is conditional on `hasSettingsHandler` (section 7) rather than always offered.
 
 **Sign-out from this panel skips the cache purge.** `handleSignOut` (`SidePanelBody.tsx:374-384`) calls
 `supabase.auth.signOut()` directly. `AuthContext`'s own `signOut` (`AuthContext.tsx:26-39`) wraps the same
@@ -148,17 +150,19 @@ Opens upward, anchored to the row, portalled to the body.
 | Item | Action |
 |---|---|
 | *header* — full email address | not interactive |
-| Settings | `onOpenSettings()` — hidden where unregistered |
-| Account Details | opens the modal in section 6 |
+| Settings | opens the account modal in section 6 |
 | — divider — | |
 | Learn more → | submenu: **Privacy Policy ↗**, **Terms & Conditions ↗** |
 | — divider — | |
 | Log Out | `ConfirmationModal`, then `AuthContext.signOut()` |
 | Delete Account | `ConfirmationModal`, then the `delete-account` function |
 
-**Signed out** (`trial`, `byok-anon`): Settings, Learn more, a divider, then **Sign in** in place of Log
-Out. No Account Details, no Delete Account — there is no account to detail or delete. Sign-in reuses
-`AuthModal`, already imported at `SidePanelBody.tsx:25`.
+**Signed out** (`trial`, `byok-anon`): Learn more, a divider, then **Sign in**. No Settings and no Delete
+Account — there is no account to configure or delete. Sign-in reuses `AuthModal`, already imported at
+`SidePanelBody.tsx:25`.
+
+The menu no longer changes shape by route. It used to: Settings appeared only on `/editor`, where a
+handler was registered. Now the one item it carries has a destination that exists everywhere.
 
 Both legal items are anchors with `target="_blank"` and `rel="noopener noreferrer"`, for the routing reason
 in section 3. They are the only items in the menu that leave the app, and the `↗` says so.
@@ -173,16 +177,25 @@ subtly and inexplicably blue against the panel unless it is overridden.
 
 ---
 
-## 6. Account Details
+## 6. The account modal
 
-A **modal on the `EventTableEditor` shell** — Radix Dialog rather than the `Modal` wrapper, 720px wide,
-20px radius on `#171717`, an Aleo 24px header band, a 200px left rail of sections, and a glass-button
-footer. The two full-size modals in the product should read as one surface, so the button and tab styles
-live in `ui/glassButton.ts` and `EventTableEditor` imports them rather than keeping its own copies.
+Radix Dialog rather than the `Modal` wrapper, 720×560, 20px radius on `#171717` — the `EventTableEditor`
+shell — but laid out the way a settings dialog is rather than the way the Events modal is:
+
+- **The rail spans the full height**, flush to the modal's edges, on a darker `#141415` with a 1px right
+  divider. Not an inset rounded card floating inside a gap. This requires `p-0` and `overflow-hidden` on
+  the Content and the height set there rather than on an inner wrapper — a full-height rail needs the
+  dialog itself to have a height to fill.
+- **The heading and close X live in the content column**, and there is no footer.
+- **The active item keeps the brand blue** (`rgba(37,99,235,0.4)`), tying it to the Events modal's rail
+  rather than to the reference's grey. Text labels, no icons.
+
+The tab style lives in `ui/glassButton.ts` so the two modals' rails cannot drift apart.
 
 The rail carries three sections — **Account details**, **Account usage**, **Account management** — and
-reopening always lands on the first, since the menu item that opens it is called "Account Details" and
-arriving on the delete screen is not what that promised.
+the active one's name *is* the `DialogPrimitive.Title`, so the dialog's accessible name always equals the
+heading on screen. Reopening always lands on the first section: a stale selection would otherwise open
+Settings directly on the delete screen with nothing to indicate that is unusual.
 
 Their contents:
 
@@ -245,7 +258,7 @@ alignment is the point.
 
 Following the convention in `2026-08-07-verification-runbook.md`: shipped is not the same as verified.
 
-**Verified in a real browser** against `npm run dev`, driven by Playwright — 86 assertions across three
+**Verified in a real browser** against `npm run dev`, driven by Playwright — 106 assertions across three
 suites, all passing:
 
 - **The menu escapes the panel.** At both ends of the resizable range — `PANEL_MIN_WIDTH` (300) and
@@ -262,11 +275,15 @@ suites, all passing:
   route.
 - **All four tier states** render the right row and the right menu: `trial` → "Guest · Not saved" with
   Sign in and no account items; `byok-anon` → "Guest · Your API key", still offering Sign in;
-  `free` → "nourani1alex · Free" with Account Details, Log Out and Delete Account; `byok` → "· Your API
-  key". Local-parts are left unprettified — `a.o-brien@example.com` renders as `a.o-brien`.
+  `free` → "nourani1alex · Free" with Settings, Log Out and Delete Account; `byok` → "· Your API key". Local-parts are left unprettified — `a.o-brien@example.com` renders as `a.o-brien`.
 - **Delete Account is visually distinct**: `rgb(174, 41, 41)` against Log Out's `rgb(201, 206, 212)`.
-- **The Settings item appears on `/editor` and is absent on `/`**, which is `hasSettingsHandler` doing
-  its job in both directions.
+- **The menu carries exactly one Settings item and no Account Details**, identical on `/` and `/editor`,
+  and it opens the account modal from both. Signed out, Settings is absent and Sign in remains.
+- **The rail spans the full modal height**, flush top, bottom and left to the dialog's content box
+  (558px against a 560px dialog — the 2px is its border), with a 1px right divider, a surface distinct
+  from the content column, and no corner radius. The close X sits in the content column's top-right and
+  there is no footer button.
+- **The heading tracks the rail**, and is the dialog's accessible name.
 - **Account Details** shows the email, the passwordless explanation, the plan, usage, key status and the
   destructive footer; on `byok` it names Anthropic and masks the key to `sk-ant-v…0000`.
 - **No layer leak, on all three paths.** Closing Account Details, and cancelling either the Log Out or the

--- a/docs/2026-08-13-account-menu-prd.md
+++ b/docs/2026-08-13-account-menu-prd.md
@@ -226,40 +226,75 @@ section 3.
 ## 8. Verified vs. unverified
 
 Following the convention in `2026-08-07-verification-runbook.md`: shipped is not the same as verified.
-This is a PRD, so everything below is unverified by definition. The list is what the implementation pass has
-to prove.
 
-1. **The menu escapes the panel.** At both ends of the resizable range — `PANEL_MIN_WIDTH` (300) and
-   `PANEL_MAX_WIDTH` (400), so cards of 294px and 394px once the 6px float gap is taken out — the menu
-   renders wider than the panel and overlaps the canvas without clipping. This is the single most likely
-   thing to be wrong, because it fails only visually and the `overflow-hidden` causing it is three files
-   away from the menu.
-2. **The submenu opens sideways and stays open** while the pointer crosses the gap to it.
-3. **Keyboard traversal end to end**: open with Enter, arrow through items, into and out of the submenu,
-   Escape closes one level at a time, focus returns to the row.
-4. **The `loading` window never renders "Guest".** Hard-reload as a signed-in user on a throttled connection
-   and watch the row. This is the failure that looks like a logout bug.
-5. **Legal links open new tabs with editor state intact** — make an unsaved edit, open Privacy, return to
-   the original tab, confirm the edit is still there.
-6. **Sign-out clears the viewer cache.** View a shared timeline, sign out from the menu, confirm the cached
-   events are gone.
-7. **All four tier states render the right row and the right menu**, including `byok-anon`, which is the
-   state most easily forgotten because it requires a key and no account.
+**Verified in a real browser** against `npm run dev`, driven by Playwright — 55 assertions across two
+suites, all passing:
 
-**A correction to carry forward.** `CLAUDE.md` lists account deletion among paths "deployed but never
+- **The menu escapes the panel.** At both ends of the resizable range — `PANEL_MIN_WIDTH` (300) and
+  `PANEL_MAX_WIDTH` (400), cards of 294px and 394px once the 6px float gap is out — the menu renders
+  312px and 411px wide respectively and its right edge clears the panel's. This was the flagged risk and
+  it did fail first time round, though not in the predicted direction: nothing was clipped, the menu was
+  simply *narrower* than the card. See the width note below.
+- **The submenu opens sideways** on hover, holds while the pointer crosses the gap, and its own right edge
+  (x=569) clears the panel by a wide margin — the portal works at both levels.
+- **Keyboard traversal**: Enter opens, ArrowDown moves onto the first item, Escape closes, and focus
+  returns to the row.
+- **Legal links are real new tabs.** Both carry `target="_blank" rel="noopener noreferrer"`; opening
+  Privacy loads `/privacy` in a second tab, renders its heading, and leaves the original tab on its
+  route.
+- **All four tier states** render the right row and the right menu: `trial` → "Guest · Not saved" with
+  Sign in and no account items; `byok-anon` → "Guest · Your API key", still offering Sign in;
+  `free` → "nourani1alex · Free" with Account Details, Log Out and Delete Account; `byok` → "· Your API
+  key". Local-parts are left unprettified — `a.o-brien@example.com` renders as `a.o-brien`.
+- **Delete Account is visually distinct**: `rgb(174, 41, 41)` against Log Out's `rgb(201, 206, 212)`.
+- **The Settings item appears on `/editor` and is absent on `/`**, which is `hasSettingsHandler` doing
+  its job in both directions.
+- **Account Details** shows the email, the passwordless explanation, the plan, usage, key status and the
+  destructive footer; on `byok` it names Anthropic and masks the key to `sk-ant-v…0000`.
+- **No layer leak.** Closing the modal leaves `body` at `pointer-events: auto` and the menu reopens — the
+  failure mode when a Radix menu and a dialog hand off badly.
+
+**Verified by the toolchain**: `npx tsc --noEmit -p tsconfig.app.json` reports 16 errors, the
+pre-existing count, none in any file this change touches. `npm run lint` is clean.
+
+**Two things the implementation changed from this spec, both for the better:**
+
+1. **The menu width is `calc(var(--radix-dropdown-menu-trigger-width) + 48px)`, not a literal.** A fixed
+   width cannot satisfy "wider than the panel" across a 300–400px resize range — 260px was narrower than
+   the 314px default card, and any number large enough for the top of the range is oversized at the
+   bottom. Measuring off the trigger keeps the overhang constant instead.
+2. **Account Details reads its caps from `PLAN_LIMITS[tier]`, not from `useEventUsage`.** The hook sources
+   limits from `getCurrentLimits()`, a module-level cache refreshed by an async `auth.getUser()`; it lags
+   auth and key transitions by a frame and holds its `'byok-anon'` initial value if that call never lands,
+   which is exactly what surfaced in testing — the modal showed a `byok` account 3 and 150 while the card
+   beside it showed 25. Counts still come from the hook. This is the split `UsageLimits.tsx:45-49` already
+   makes, and for the reason its comment gives.
+
+**NOT verified — do these before trusting the feature:**
+
+1. **The `loading` window never renders "Guest".** Needs a real session against a reachable Supabase;
+   the stub environment resolves auth too fast to observe the window. Hard-reload as a signed-in user on
+   a throttled connection and watch the row. This is the failure that looks like a logout bug.
+2. **Sign-out clears the viewer cache.** The `AuthContext.signOut()` switch is verified by reading, not by
+   running: view a shared timeline, sign out from the menu, confirm the cached events are gone.
+3. **Delete Account end to end from the new entry point.** The function itself is verified (below); what
+   is unexercised is this menu item reaching it.
+4. **Unsaved editor state surviving a legal-link click.** Verified that the original tab keeps its route;
+   not verified with actual unsaved work in the editor, which needs a working backend.
+
+**A note on Delete Account.** `CLAUDE.md` lists account deletion among paths "deployed but never
 exercised". **That is stale.** `2026-08-07-verification-runbook.md` records `delete-account` as **VERIFIED
 end-to-end on 7 August**, against a real account: eight columns confirmed at zero afterwards, both cascades
 observed firing, and the `timeline_categories` row inserted by hand beforehand precisely so the test was
 real rather than an empty table matching an empty table. So the function is not the risk here.
 
 What *is* thin is the reporting around it. `handleDeleteAccount` announces both success and failure through
-`alert()` (`SidePanelBody.tsx:398,401`) — browser chrome standing in for the confirmation of an irreversible
-action. Making that action more discoverable is a reason to improve the reporting, not a reason to hide the
-action.
+`alert()` — browser chrome standing in for the confirmation of an irreversible action. Making that action
+more discoverable is a reason to improve the reporting, not a reason to hide the action.
 
 **The type-check gate.** `npm run build` is `vite build` alone and does not type-check.
-`npx tsc --noEmit -p tsconfig.app.json` is the real gate. There are 16 pre-existing errors in the
-repository; none should be in files this change touches.
+`npx tsc --noEmit -p tsconfig.app.json` is the real gate — which is how the 16-error baseline above was
+established.
 
 ---
 

--- a/docs/2026-08-13-account-menu-prd.md
+++ b/docs/2026-08-13-account-menu-prd.md
@@ -219,7 +219,13 @@ tell whether the Settings item has anywhere to go. `package.json` gains one depe
 **Fixed.** `handleSignOut` switches to `AuthContext.signOut()`, so `clearAllCachedEvents()` runs. See
 section 3.
 
-**Untouched, by decision.** `TimelineSettingsPanel.tsx`, `ApiKeySection.tsx`, `UsageLimits.tsx`.
+**Untouched, by decision.** `TimelineSettingsPanel.tsx`, `ApiKeySection.tsx`.
+
+`UsageLimits.tsx` keeps its structure and every tier variant — the phase 2 in section 9 is still
+outstanding — but its two numeric styles moved from JetBrains Mono to Avenir, so the counts read as part
+of the labels beside them rather than as a second typeface inside one card. Monospace stays wherever a
+key is shown: `ApiKeySection`, `ApiKeyModal` and the masked key in Account Details, where character
+alignment is the point.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.24",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
@@ -1409,6 +1410,183 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.24.tgz",
+      "integrity": "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -1512,6 +1690,494 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
+      "integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+      "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-direction": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-popper": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-rect": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4",
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+      "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/rect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/react-popover": {
       "version": "1.1.15",
@@ -1941,6 +2607,21 @@
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -7200,6 +7881,87 @@
         "@radix-ui/react-use-escape-keydown": "1.1.1"
       }
     },
+    "@radix-ui/react-dropdown-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.24.tgz",
+      "integrity": "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==",
+      "requires": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "dependencies": {
+        "@radix-ui/primitive": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+          "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q=="
+        },
+        "@radix-ui/react-compose-refs": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+          "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+          "requires": {}
+        },
+        "@radix-ui/react-context": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+          "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+          "requires": {}
+        },
+        "@radix-ui/react-id": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+          "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+          "requires": {
+            "@radix-ui/react-use-layout-effect": "1.1.4"
+          }
+        },
+        "@radix-ui/react-primitive": {
+          "version": "2.1.10",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+          "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+          "requires": {
+            "@radix-ui/react-slot": "1.3.3"
+          }
+        },
+        "@radix-ui/react-slot": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+          "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+          "requires": {
+            "@radix-ui/react-compose-refs": "1.1.5"
+          }
+        },
+        "@radix-ui/react-use-controllable-state": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+          "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+          "requires": {
+            "@radix-ui/primitive": "1.1.7",
+            "@radix-ui/react-use-effect-event": "0.0.5",
+            "@radix-ui/react-use-layout-effect": "1.1.4"
+          }
+        },
+        "@radix-ui/react-use-effect-event": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+          "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+          "requires": {
+            "@radix-ui/react-use-layout-effect": "1.1.4"
+          }
+        },
+        "@radix-ui/react-use-layout-effect": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+          "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+          "requires": {}
+        }
+      }
+    },
     "@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -7239,6 +8001,230 @@
           "requires": {
             "@radix-ui/react-slot": "1.2.4"
           }
+        }
+      }
+    },
+    "@radix-ui/react-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
+      "integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
+      "requires": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "dependencies": {
+        "@radix-ui/primitive": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+          "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q=="
+        },
+        "@radix-ui/react-arrow": {
+          "version": "1.1.15",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+          "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+          "requires": {
+            "@radix-ui/react-primitive": "2.1.10"
+          }
+        },
+        "@radix-ui/react-collection": {
+          "version": "1.1.15",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+          "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+          "requires": {
+            "@radix-ui/react-compose-refs": "1.1.5",
+            "@radix-ui/react-context": "1.2.2",
+            "@radix-ui/react-primitive": "2.1.10",
+            "@radix-ui/react-slot": "1.3.3"
+          }
+        },
+        "@radix-ui/react-compose-refs": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+          "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+          "requires": {}
+        },
+        "@radix-ui/react-context": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+          "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+          "requires": {}
+        },
+        "@radix-ui/react-direction": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+          "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+          "requires": {}
+        },
+        "@radix-ui/react-dismissable-layer": {
+          "version": "1.1.19",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+          "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+          "requires": {
+            "@radix-ui/primitive": "1.1.7",
+            "@radix-ui/react-compose-refs": "1.1.5",
+            "@radix-ui/react-primitive": "2.1.10",
+            "@radix-ui/react-use-callback-ref": "1.1.4",
+            "@radix-ui/react-use-effect-event": "0.0.5"
+          }
+        },
+        "@radix-ui/react-focus-guards": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+          "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+          "requires": {}
+        },
+        "@radix-ui/react-focus-scope": {
+          "version": "1.1.16",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+          "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+          "requires": {
+            "@radix-ui/react-compose-refs": "1.1.5",
+            "@radix-ui/react-primitive": "2.1.10",
+            "@radix-ui/react-use-callback-ref": "1.1.4"
+          }
+        },
+        "@radix-ui/react-id": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+          "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+          "requires": {
+            "@radix-ui/react-use-layout-effect": "1.1.4"
+          }
+        },
+        "@radix-ui/react-popper": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+          "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+          "requires": {
+            "@floating-ui/react-dom": "^2.0.0",
+            "@radix-ui/react-arrow": "1.1.15",
+            "@radix-ui/react-compose-refs": "1.1.5",
+            "@radix-ui/react-context": "1.2.2",
+            "@radix-ui/react-primitive": "2.1.10",
+            "@radix-ui/react-use-callback-ref": "1.1.4",
+            "@radix-ui/react-use-layout-effect": "1.1.4",
+            "@radix-ui/react-use-rect": "1.1.4",
+            "@radix-ui/react-use-size": "1.1.4",
+            "@radix-ui/rect": "1.1.3"
+          }
+        },
+        "@radix-ui/react-portal": {
+          "version": "1.1.17",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+          "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+          "requires": {
+            "@radix-ui/react-primitive": "2.1.10",
+            "@radix-ui/react-use-layout-effect": "1.1.4"
+          }
+        },
+        "@radix-ui/react-presence": {
+          "version": "1.1.10",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+          "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+          "requires": {
+            "@radix-ui/react-use-layout-effect": "1.1.4"
+          }
+        },
+        "@radix-ui/react-primitive": {
+          "version": "2.1.10",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+          "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+          "requires": {
+            "@radix-ui/react-slot": "1.3.3"
+          }
+        },
+        "@radix-ui/react-roving-focus": {
+          "version": "1.1.19",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+          "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+          "requires": {
+            "@radix-ui/primitive": "1.1.7",
+            "@radix-ui/react-collection": "1.1.15",
+            "@radix-ui/react-compose-refs": "1.1.5",
+            "@radix-ui/react-context": "1.2.2",
+            "@radix-ui/react-direction": "1.1.4",
+            "@radix-ui/react-id": "1.1.4",
+            "@radix-ui/react-primitive": "2.1.10",
+            "@radix-ui/react-use-callback-ref": "1.1.4",
+            "@radix-ui/react-use-controllable-state": "1.2.6",
+            "@radix-ui/react-use-is-hydrated": "0.1.3",
+            "@radix-ui/react-use-layout-effect": "1.1.4"
+          }
+        },
+        "@radix-ui/react-slot": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+          "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+          "requires": {
+            "@radix-ui/react-compose-refs": "1.1.5"
+          }
+        },
+        "@radix-ui/react-use-callback-ref": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+          "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+          "requires": {}
+        },
+        "@radix-ui/react-use-controllable-state": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+          "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+          "requires": {
+            "@radix-ui/primitive": "1.1.7",
+            "@radix-ui/react-use-effect-event": "0.0.5",
+            "@radix-ui/react-use-layout-effect": "1.1.4"
+          }
+        },
+        "@radix-ui/react-use-effect-event": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+          "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+          "requires": {
+            "@radix-ui/react-use-layout-effect": "1.1.4"
+          }
+        },
+        "@radix-ui/react-use-layout-effect": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+          "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+          "requires": {}
+        },
+        "@radix-ui/react-use-rect": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+          "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+          "requires": {
+            "@radix-ui/rect": "1.1.3"
+          }
+        },
+        "@radix-ui/react-use-size": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+          "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+          "requires": {
+            "@radix-ui/react-use-layout-effect": "1.1.4"
+          }
+        },
+        "@radix-ui/rect": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+          "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw=="
         }
       }
     },
@@ -7463,6 +8449,12 @@
       "requires": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
       }
+    },
+    "@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+      "requires": {}
     },
     "@radix-ui/react-use-layout-effect": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.24",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",

--- a/src/components/EventTableEditor/EventTableEditor.tsx
+++ b/src/components/EventTableEditor/EventTableEditor.tsx
@@ -571,11 +571,13 @@ export function EventTableEditor({
         <DialogOverlay />
         {/*
           Same grid shell as `AccountDetailsModal` — see the comment there for
-          why the two layouts cannot be expressed with flex from one DOM order.
-          One extra row here, because this modal keeps a Cancel/Save footer.
+          why the two layouts cannot be expressed with flex from one DOM order,
+          and for why centring is `inset-0 m-auto` rather than a −50% translate
+          (the translate fights `zoom-in-95` and drifts the modal in from the
+          bottom-right corner). One extra row here, for the Cancel/Save footer.
         */}
         <DialogPrimitive.Content
-          className="fixed z-50 inset-0 w-screen h-[100dvh] max-w-none rounded-none border-0 grid grid-cols-1 grid-rows-[auto_auto_minmax(0,1fr)_auto] overflow-hidden bg-[#171717] shadow-lg duration-200 sm:inset-auto sm:left-[50%] sm:top-[50%] sm:w-full sm:max-w-[960px] sm:h-[min(640px,calc(100vh-120px))] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:grid-cols-[200px_minmax(0,1fr)] sm:grid-rows-[auto_minmax(0,1fr)_auto] sm:rounded-[20px] sm:border sm:border-[rgba(210,210,210,0.2)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95"
+          className="fixed z-50 inset-0 w-screen h-[100dvh] max-w-none rounded-none border-0 grid grid-cols-1 grid-rows-[auto_auto_minmax(0,1fr)_auto] overflow-hidden bg-[#171717] shadow-lg duration-200 sm:w-full sm:max-w-[960px] sm:h-[min(640px,calc(100vh-120px))] sm:m-auto sm:grid-cols-[200px_minmax(0,1fr)] sm:grid-rows-[auto_minmax(0,1fr)_auto] sm:rounded-[20px] sm:border sm:border-[rgba(210,210,210,0.2)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95"
         >
           {/* The active page name, where the centred glass-pill tab band used to
               sit. The tabs themselves are in the rail now. */}

--- a/src/components/EventTableEditor/EventTableEditor.tsx
+++ b/src/components/EventTableEditor/EventTableEditor.tsx
@@ -16,6 +16,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { glassButtonClass, primaryGlassButtonClass } from '@/components/ui/glassButton'
 import { Calendar } from '@/components/ui/calendar'
 import {
   DndContext,
@@ -307,15 +308,6 @@ function ColorBar({
     </button>
   )
 }
-
-// Glass button used in category rows
-const glassButtonClass = `
-  relative min-w-[80px] px-[11px] py-[6px] rounded-[10px]
-  backdrop-blur-[12px] bg-white/10 border border-white/[0.15]
-  shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
-  font-['Avenir',sans-serif] font-medium text-[14px] text-[#c9ced4]
-  hover:bg-white/20 hover:text-[#dadee5] transition-all
-`
 
 export function EventTableEditor({
   isOpen,
@@ -805,14 +797,7 @@ export function EventTableEditor({
               <button
                 onClick={handleApplyChanges}
                 disabled={!canApplyChanges}
-                className="
-                  relative min-w-[80px] px-[11px] py-[6px] rounded-[10px]
-                  backdrop-blur-[12px] bg-[rgba(37,99,235,0.8)] border border-white/[0.15]
-                  shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
-                  font-['Avenir',sans-serif] font-medium text-[14px] text-[#dadee5]
-                  hover:bg-[rgba(37,99,235,0.9)] transition-all
-                  disabled:opacity-50 disabled:pointer-events-none
-                "
+                className={`${primaryGlassButtonClass} disabled:opacity-50 disabled:pointer-events-none`}
               >
                 Save
               </button>

--- a/src/components/EventTableEditor/EventTableEditor.tsx
+++ b/src/components/EventTableEditor/EventTableEditor.tsx
@@ -16,7 +16,15 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { glassButtonClass, primaryGlassButtonClass } from '@/components/ui/glassButton'
+import {
+  glassButtonClass,
+  modalRailClass,
+  modalRailDividerClass,
+  modalRailGroupClass,
+  modalSidebarTabClass,
+  primaryGlassButtonClass,
+} from '@/components/ui/glassButton'
+import { useIsNarrow } from '@/hooks/useIsNarrow'
 import { Calendar } from '@/components/ui/calendar'
 import {
   DndContext,
@@ -26,7 +34,11 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core'
-import type { DragEndEvent } from '@dnd-kit/core'
+import type {
+  DragEndEvent,
+  DraggableAttributes,
+  DraggableSyntheticListeners,
+} from '@dnd-kit/core'
 import {
   arrayMove,
   SortableContext,
@@ -48,6 +60,73 @@ interface EventTableEditorProps {
 
 interface DraftEvent extends Omit<TimelineEvent, 'id'> {
   id: string
+}
+
+// The tab itself, with no dragging in it.
+//
+// Split out from `SortableTab` because `useSortable` is a hook and therefore
+// cannot be skipped conditionally — and below `sm` these render outside any
+// `SortableContext`, where calling it would be an error rather than a no-op.
+//
+// Width is `auto` in the horizontal strip and `full` in the vertical rail, for
+// the reason `modalSidebarTabClass` documents: a strip tab that fills its
+// container, or shrinks to fit, cannot overflow, and overflow is what makes the
+// strip scroll.
+function CategoryTab({
+  category,
+  isActive,
+  onClick,
+  innerRef,
+  style,
+  attributes,
+  listeners,
+  isDragging,
+}: {
+  category: CategoryConfig
+  isActive: boolean
+  onClick: () => void
+  innerRef?: (node: HTMLElement | null) => void
+  style?: React.CSSProperties
+  attributes?: DraggableAttributes
+  listeners?: DraggableSyntheticListeners
+  isDragging?: boolean
+}) {
+  return (
+    <button
+      ref={innerRef}
+      style={style}
+      onClick={onClick}
+      aria-current={isActive ? 'page' : undefined}
+      className={`
+        group relative flex items-center justify-between gap-1
+        w-auto shrink-0 whitespace-nowrap sm:w-full sm:min-w-[184px]
+        py-[9px] pl-[11px] pr-[3px] rounded-[10px] text-left
+        font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-colors
+        border border-transparent
+        ${isActive
+          ? 'bg-[rgba(37,99,235,0.4)] text-[#dadee5]'
+          : 'bg-transparent text-[#c9ced4] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
+        }
+        ${isDragging ? 'shadow-[0px_12px_40px_rgba(0,0,0,0.6)]' : ''}
+      `}
+      {...attributes}
+    >
+      <span className="sm:truncate">{category.label}</span>
+      {listeners && (
+        <span
+          {...listeners}
+          className={`
+            hidden sm:flex items-center justify-center w-[18px] h-[18px] cursor-grab active:cursor-grabbing
+            opacity-0 group-hover:opacity-100 transition-opacity
+            ${isDragging ? 'opacity-100' : ''}
+          `}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <GripVertical size={18} className="text-[#9b9ea3]" />
+        </span>
+      )}
+    </button>
+  )
 }
 
 // Sortable Tab component
@@ -76,35 +155,16 @@ function SortableTab({
   }
 
   return (
-    <button
-      ref={setNodeRef}
-      style={style}
+    <CategoryTab
+      category={category}
+      isActive={isActive}
       onClick={onClick}
-      className={`
-        group relative flex items-center justify-between w-full min-w-[184px] py-[9px] pl-[11px] pr-[3px] rounded-[10px]
-        text-left
-        font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-colors
-        ${isActive
-          ? 'border border-transparent bg-[rgba(37,99,235,0.4)] text-[#dadee5]'
-          : 'border border-transparent bg-transparent text-[#c9ced4] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
-        }
-        ${isDragging ? 'shadow-[0px_12px_40px_rgba(0,0,0,0.6)]' : ''}
-      `}
-      {...attributes}
-    >
-      <span className="truncate">{category.label}</span>
-      <span
-        {...listeners}
-        className={`
-          flex items-center justify-center w-[18px] h-[18px] cursor-grab active:cursor-grabbing
-          opacity-0 group-hover:opacity-100 transition-opacity
-          ${isDragging ? 'opacity-100' : ''}
-        `}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <GripVertical size={18} className="text-[#9b9ea3]" />
-      </span>
-    </button>
+      innerRef={setNodeRef}
+      style={style}
+      attributes={attributes}
+      listeners={listeners}
+      isDragging={isDragging}
+    />
   )
 }
 
@@ -405,6 +465,10 @@ export function EventTableEditor({
     onClose()
   }
 
+  // The one thing the `sm:` breakpoint cannot express: dnd-kit's sorting
+  // strategy and modifiers are props, not classes.
+  const isNarrow = useIsNarrow()
+
   // Drag-to-reorder sensors
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -505,92 +569,108 @@ export function EventTableEditor({
     <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose() }}>
       <DialogPortal>
         <DialogOverlay />
+        {/*
+          Same grid shell as `AccountDetailsModal` — see the comment there for
+          why the two layouts cannot be expressed with flex from one DOM order.
+          One extra row here, because this modal keeps a Cancel/Save footer.
+        */}
         <DialogPrimitive.Content
-          className="fixed left-[50%] top-[50%] z-50 w-full max-w-[960px] translate-x-[-50%] translate-y-[-50%] bg-[#171717] border border-[rgba(210,210,210,0.2)] rounded-[20px] p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]"
+          className="fixed z-50 inset-0 w-screen h-[100dvh] max-w-none rounded-none border-0 grid grid-cols-1 grid-rows-[auto_auto_minmax(0,1fr)_auto] overflow-hidden bg-[#171717] shadow-lg duration-200 sm:inset-auto sm:left-[50%] sm:top-[50%] sm:w-full sm:max-w-[960px] sm:h-[min(640px,calc(100vh-120px))] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:grid-cols-[200px_minmax(0,1fr)] sm:grid-rows-[auto_minmax(0,1fr)_auto] sm:rounded-[20px] sm:border sm:border-[rgba(210,210,210,0.2)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95"
         >
-          {/* Accessible title (sr-only) */}
-          <DialogPrimitive.Title className="sr-only">Events</DialogPrimitive.Title>
+          {/* The active page name, where the centred glass-pill tab band used to
+              sit. The tabs themselves are in the rail now. */}
+          <div className="sm:col-start-2 sm:row-start-1 flex items-start justify-between gap-4 px-6 pt-5 pb-4">
+            <DialogPrimitive.Title className="m-0 font-['Aleo',serif] font-normal text-[20px] leading-[1.4] text-[#dadee5]">
+              {activePageTab === 'events' ? 'Events' : 'Categories'}
+            </DialogPrimitive.Title>
+          </div>
 
-          {/* Page Tabs */}
-          <div className="flex items-center justify-center h-[48px]">
-            <div className="relative flex items-center">
-              {/* Glass pill indicator */}
-              <div
-                className="absolute top-1/2 -translate-y-1/2 h-[44px] border border-[rgba(255,255,255,0.15)] rounded-[12px] shadow-[0px_8px_32px_rgba(0,0,0,0.4)] pointer-events-none"
-                style={{
-                  left: activePageTab === 'events' ? '0px' : '99px',
-                  width: activePageTab === 'events' ? '99px' : '139px',
-                  transition: 'left 320ms ease-out, width 320ms ease-out',
-                }}
-              >
-                <div className="absolute inset-0 backdrop-blur-[12px] bg-[rgba(255,255,255,0.1)] rounded-[12px]" />
-                <div className="absolute inset-0 rounded-[inherit] shadow-[inset_0px_1px_0px_rgba(255,255,255,0.1)]" />
-              </div>
+          {/* Rail: pages on top, then the category filter — which belongs to the
+              Events page and is absent on the Categories one. */}
+          <nav
+            aria-label="Editor sections"
+            className={`sm:col-start-1 sm:row-start-1 sm:row-span-3 ${modalRailClass}`}
+          >
+            <div className={modalRailGroupClass}>
               <button
                 onClick={() => setActivePageTab('events')}
-                className="relative flex items-start h-[44px] px-[12px] py-[5px] rounded-[4px]"
+                aria-current={activePageTab === 'events' ? 'page' : undefined}
+                className={modalSidebarTabClass(activePageTab === 'events')}
               >
-                <span className={`font-['Aleo',serif] font-normal text-[24px] leading-[1.4] whitespace-nowrap transition-colors ${activePageTab === 'events' ? 'text-[#dadee5]' : 'text-[#9b9ea3]'}`}>
-                  Events
-                </span>
+                Events
               </button>
               <button
                 onClick={() => setActivePageTab('categories')}
-                className="relative flex items-start h-[44px] px-[12px] py-[5px] rounded-[4px] cursor-pointer"
+                aria-current={activePageTab === 'categories' ? 'page' : undefined}
+                className={modalSidebarTabClass(activePageTab === 'categories')}
               >
-                <span className={`font-['Aleo',serif] font-normal text-[24px] leading-[1.4] whitespace-nowrap transition-colors ${activePageTab === 'categories' ? 'text-[#dadee5]' : 'text-[#9b9ea3]'}`}>
-                  Categories
-                </span>
+                Categories
               </button>
             </div>
-          </div>
 
-          {/* Content Area */}
-          <div className="mt-8" style={{ height: 'min(520px, calc(100vh - 280px))' }}>
-            {activePageTab === 'events' ? (
-              /* Events Tab Content */
-              <div className="flex gap-[16px] h-full">
-                {/* Category Sidebar */}
-                <div className="w-[200px] shrink-0 bg-[#242526] rounded-[12px] p-2 flex flex-col gap-[2px] overflow-y-auto">
-                  {/* All Categories tab (pinned, not draggable) */}
+            {activePageTab === 'events' && (
+              <>
+                <div className={modalRailDividerClass} />
+                <div className={`${modalRailGroupClass} border-t border-[rgba(210,210,210,0.12)] sm:border-t-0`}>
                   <button
                     onClick={() => setActiveCategory(null)}
-                    className={`
-                      w-full min-w-[184px] py-[9px] pl-[11px] pr-[3px] rounded-[10px]
-                      text-left
-                      font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-colors
-                      ${activeCategory === null
-                        ? 'border border-transparent bg-[rgba(37,99,235,0.4)] text-[#dadee5]'
-                        : 'border border-transparent bg-transparent text-[#c9ced4] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
-                      }
-                    `}
+                    aria-current={activeCategory === null ? 'page' : undefined}
+                    className={modalSidebarTabClass(activeCategory === null)}
                   >
                     All Categories
                   </button>
 
-                  {/* Draggable category tabs */}
-                  <DndContext
-                    sensors={sensors}
-                    collisionDetection={closestCenter}
-                    onDragEnd={handleDragEnd}
-                    modifiers={[restrictToVerticalAxis, restrictToParentElement]}
-                  >
-                    <SortableContext
-                      items={draftCategories.map(c => c.id)}
-                      strategy={verticalListSortingStrategy}
+                  {/*
+                    Reordering is a pointer gesture on a list that is a
+                    horizontally scrolling strip below `sm`. The PointerSensor
+                    activates after 5px of movement — the same 5px that means
+                    "scroll this strip" on a touch screen — so on narrow
+                    viewports the tabs render as plain buttons and the swipe
+                    scrolls. Switching to `restrictToHorizontalAxis` would not
+                    help: it makes the two gestures identical rather than
+                    distinguishing them.
+                  */}
+                  {isNarrow ? (
+                    draftCategories.map(cat => (
+                      <CategoryTab
+                        key={cat.id}
+                        category={cat}
+                        isActive={activeCategory === cat.id}
+                        onClick={() => setActiveCategory(cat.id)}
+                      />
+                    ))
+                  ) : (
+                    <DndContext
+                      sensors={sensors}
+                      collisionDetection={closestCenter}
+                      onDragEnd={handleDragEnd}
+                      modifiers={[restrictToVerticalAxis, restrictToParentElement]}
                     >
-                      {draftCategories.map(cat => (
-                        <SortableTab
-                          key={cat.id}
-                          category={cat}
-                          isActive={activeCategory === cat.id}
-                          onClick={() => setActiveCategory(cat.id)}
-                        />
-                      ))}
-                    </SortableContext>
-                  </DndContext>
+                      <SortableContext
+                        items={draftCategories.map(c => c.id)}
+                        strategy={verticalListSortingStrategy}
+                      >
+                        {draftCategories.map(cat => (
+                          <SortableTab
+                            key={cat.id}
+                            category={cat}
+                            isActive={activeCategory === cat.id}
+                            onClick={() => setActiveCategory(cat.id)}
+                          />
+                        ))}
+                      </SortableContext>
+                    </DndContext>
+                  )}
                 </div>
+              </>
+            )}
+          </nav>
 
+          {/* Content Area */}
+          <div className="sm:col-start-2 sm:row-start-2 min-w-0 min-h-0 px-6 pb-2 overflow-hidden">
+            {activePageTab === 'events' ? (
+              /* Events Tab Content */
+              <div className="flex h-full">
                 {/* Table Area */}
                 <div className="flex-1 flex flex-col min-w-0">
                   {/* Header Row */}
@@ -768,7 +848,7 @@ export function EventTableEditor({
           </div>
 
           {/* Footer */}
-          <div className="flex justify-between items-center mt-8">
+          <div className="sm:col-start-2 sm:row-start-3 flex justify-between items-center gap-3 px-6 pt-2 pb-5">
             {/* Add button (left) — context-dependent */}
             {activePageTab === 'events' ? (
               <button

--- a/src/components/Modal/AccountDetailsModal.tsx
+++ b/src/components/Modal/AccountDetailsModal.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
 import { Dialog, DialogOverlay, DialogPortal } from '@/components/ui/dialog'
 import {
   destructiveGlassButtonClass,
-  glassButtonClass,
   modalSidebarTabClass,
 } from '@/components/ui/glassButton'
 import { useAuth } from '@/hooks/useAuth'
@@ -32,10 +32,12 @@ type SectionId = (typeof SECTIONS)[number]['id']
 /**
  * What the account is, in one place.
  *
- * Built on the same shell as `EventTableEditor` — Radix Dialog rather than the
- * `Modal` wrapper, 20px radius, a left rail of tabs and a glass-button footer —
- * so the two full-size modals in the product read as one surface. The shared
- * button and tab styles live in `ui/glassButton.ts` for the same reason.
+ * Radix Dialog rather than the `Modal` wrapper, 20px radius on the same surface
+ * as `EventTableEditor`, but laid out the way a settings dialog is: a rail that
+ * runs the full height of the modal, flush to its edges and divided from the
+ * content by a rule rather than a gap, with the heading and close control in
+ * the content column. The tab styles live in `ui/glassButton.ts` so the two
+ * modals' rails cannot drift apart.
  *
  * Every value here already existed somewhere. This adds no query, no table and
  * no hook; it exists because the facts were scattered across a footer, a usage
@@ -50,9 +52,10 @@ export function AccountDetailsModal({
   const tier = useAccountTier()
   const [section, setSection] = useState<SectionId>('details')
 
-  // Reopening should land on the first section rather than wherever the last
-  // visit ended — the entry point is a menu item called "Account Details", and
-  // arriving on "Account management" would not be what it promised.
+  // Reopening lands on the first section rather than wherever the last visit
+  // ended. The section name doubles as the dialog's heading, so a stale
+  // selection would open this on "Account management" — the delete screen —
+  // with no indication that it is not where Settings normally starts.
   useEffect(() => {
     if (isOpen) setSection('details')
   }, [isOpen])
@@ -63,58 +66,66 @@ export function AccountDetailsModal({
     <Dialog open={isOpen} onOpenChange={open => { if (!open) onClose() }}>
       <DialogPortal>
         <DialogOverlay />
+        {/*
+          `p-0` and `overflow-hidden` are what let the rail run edge to edge and
+          clip to the 20px radius, and the height lives here rather than on an
+          inner wrapper — a full-height rail needs the dialog itself to have a
+          height to fill.
+        */}
         <DialogPrimitive.Content
           aria-describedby={undefined}
-          className="fixed left-[50%] top-[50%] z-50 w-full max-w-[720px] translate-x-[-50%] translate-y-[-50%] bg-[#171717] border border-[rgba(210,210,210,0.2)] rounded-[20px] p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]"
+          className="fixed left-[50%] top-[50%] z-50 w-full max-w-[720px] h-[min(560px,calc(100vh-120px))] translate-x-[-50%] translate-y-[-50%] flex overflow-hidden bg-[#171717] border border-[rgba(210,210,210,0.2)] rounded-[20px] shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]"
         >
-          {/* Header — the Events modal's tab band, with one destination. */}
-          <div className="flex items-center justify-center h-[48px]">
-            <DialogPrimitive.Title className="m-0 font-['Aleo',serif] font-normal text-[24px] leading-[1.4] text-[#dadee5]">
-              Account
-            </DialogPrimitive.Title>
-          </div>
-
-          <div className="mt-8" style={{ height: 'min(420px, calc(100vh - 280px))' }}>
-            <div className="flex gap-[16px] h-full">
-              {/* Section rail */}
-              <nav
-                aria-label="Account sections"
-                className="w-[200px] shrink-0 bg-[#242526] rounded-[12px] p-2 flex flex-col gap-[2px] overflow-y-auto"
+          {/* Full-height rail: flush to the modal's edges, its own surface, and
+              a divider instead of a gap. */}
+          <nav
+            aria-label="Account sections"
+            className="w-[200px] shrink-0 h-full bg-[#141415] border-r border-[rgba(210,210,210,0.2)] p-3 flex flex-col gap-[2px] overflow-y-auto"
+          >
+            {SECTIONS.map(s => (
+              <button
+                key={s.id}
+                type="button"
+                onClick={() => setSection(s.id)}
+                aria-current={section === s.id ? 'page' : undefined}
+                className={modalSidebarTabClass(section === s.id)}
               >
-                {SECTIONS.map(s => (
-                  <button
-                    key={s.id}
-                    type="button"
-                    onClick={() => setSection(s.id)}
-                    aria-current={section === s.id ? 'page' : undefined}
-                    className={modalSidebarTabClass(section === s.id)}
-                  >
-                    {s.label}
-                  </button>
-                ))}
-              </nav>
+                {s.label}
+              </button>
+            ))}
+          </nav>
 
-              {/* Pane */}
-              <div className="flex-1 min-w-0 overflow-y-auto pr-1">
-                {section === 'details' && <DetailsPane />}
-                {section === 'usage' && <UsagePane />}
-                {section === 'management' && (
-                  <ManagementPane
-                    onDelete={() => {
-                      onClose()
-                      onDeleteAccount()
-                    }}
-                    signedIn={Boolean(user)}
-                  />
-                )}
-              </div>
+          <div className="flex-1 min-w-0 flex flex-col">
+            <div className="flex items-start justify-between gap-4 px-6 pt-5 pb-4">
+              {/*
+                The section name *is* the dialog's title, so the accessible name
+                always matches the heading on screen. It changes as you move
+                through the rail, which is what the reference does too.
+              */}
+              <DialogPrimitive.Title className="m-0 font-['Aleo',serif] font-normal text-[20px] leading-[1.4] text-[#dadee5]">
+                {SECTIONS.find(s => s.id === section)?.label}
+              </DialogPrimitive.Title>
+              <DialogPrimitive.Close
+                aria-label="Close"
+                className="shrink-0 -mr-1 -mt-0.5 p-1 rounded text-[#9b9ea3] hover:text-[#dadee5] outline-none focus-visible:ring-1 focus-visible:ring-white/40 transition-colors"
+              >
+                <X size={20} />
+              </DialogPrimitive.Close>
             </div>
-          </div>
 
-          <div className="flex justify-end items-center mt-8">
-            <button type="button" onClick={onClose} className={glassButtonClass}>
-              Close
-            </button>
+            <div className="flex-1 min-h-0 overflow-y-auto px-6 pb-6">
+              {section === 'details' && <DetailsPane />}
+              {section === 'usage' && <UsagePane />}
+              {section === 'management' && (
+                <ManagementPane
+                  onDelete={() => {
+                    onClose()
+                    onDeleteAccount()
+                  }}
+                  signedIn={Boolean(user)}
+                />
+              )}
+            </div>
           </div>
         </DialogPrimitive.Content>
       </DialogPortal>
@@ -129,7 +140,7 @@ function DetailsPane() {
   // sign-up collects an address and nothing else — so a "Name" row would either
   // sit permanently empty or invent a value the account does not have.
   return (
-    <Pane title="Account details">
+    <Pane>
       <Field label="Email" value={user?.email ?? 'Not signed in'} />
       <Field
         label="Sign-in method"
@@ -156,7 +167,7 @@ function UsagePane() {
   const caps = tier === 'trial' ? null : PLAN_LIMITS[tier]
 
   return (
-    <Pane title="Account usage">
+    <Pane>
       <Field label="Tier" value={TIER_LABELS[tier]} hint={TIER_DESCRIPTIONS[tier]} />
 
       {/* Trial has no caps to report against — it is a state, not a tier, and a
@@ -215,7 +226,7 @@ function ManagementPane({
   signedIn: boolean
 }) {
   return (
-    <Pane title="Account management">
+    <Pane>
       <div>
         <FieldLabel>Delete account</FieldLabel>
         <p className="mt-1 text-[14px] leading-[20px] text-[#c9ced4]">
@@ -236,13 +247,10 @@ function ManagementPane({
   )
 }
 
-function Pane({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <div className="flex flex-col gap-5">
-      <h3 className="sr-only">{title}</h3>
-      {children}
-    </div>
-  )
+// The section name is rendered once, as the dialog's title in the header. A
+// heading here as well — even a visually hidden one — would announce it twice.
+function Pane({ children }: { children: ReactNode }) {
+  return <div className="flex flex-col gap-5">{children}</div>
 }
 
 function FieldLabel({ children }: { children: ReactNode }) {

--- a/src/components/Modal/AccountDetailsModal.tsx
+++ b/src/components/Modal/AccountDetailsModal.tsx
@@ -1,0 +1,173 @@
+import type { ReactNode } from 'react'
+import { Modal } from './Modal'
+import { useAuth } from '@/hooks/useAuth'
+import { useAccountTier } from '@/hooks/useAccountTier'
+import { useEventUsage } from '@/hooks/useEventUsage'
+import { useSidePanel } from '@/hooks/useSidePanel'
+import { useByokCredential } from '@/services/userApiKey'
+import { maskKey } from '@/services/userApiKey'
+import { PLAN_LIMITS } from '@/constants/plans'
+import { PROVIDER_META } from '@/constants/byokProviders'
+import { TIER_DESCRIPTIONS, TIER_LABELS } from '@/constants/tierLabels'
+
+interface AccountDetailsModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onDeleteAccount: () => void
+}
+
+/**
+ * What the account is, in one place.
+ *
+ * Every value here already existed somewhere — this adds no query, no table and
+ * no hook. It exists because the facts were scattered across a footer, a usage
+ * card and a settings panel, and none of them answered "what am I actually on".
+ *
+ * Key *management* deliberately stays in the Settings panel. This shows status
+ * and points at it, rather than becoming a second place to edit the same value.
+ */
+export function AccountDetailsModal({
+  isOpen,
+  onClose,
+  onDeleteAccount,
+}: AccountDetailsModalProps) {
+  const { user } = useAuth()
+  const tier = useAccountTier()
+  // Counts from the hook, caps from the tier — the split `UsageLimits` already
+  // makes. `useEventUsage` sources its limits from `getCurrentLimits()`, which
+  // reads a module-level cache refreshed by an async `auth.getUser()`; it lags
+  // an auth or key transition by a frame and holds its 'byok-anon' initial
+  // value if that call never lands. Reading PLAN_LIMITS off the tier we already
+  // have cannot disagree with the row above it.
+  const { eventCount, timelineCount } = useEventUsage()
+  const credential = useByokCredential()
+  const { onOpenSettings, hasSettingsHandler } = useSidePanel()
+
+  if (tier === 'loading') return null
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Account Details" size="compact">
+      <div className="flex flex-col gap-5 py-1">
+        <Section label="Signed in as">
+          <p className="text-[14px] leading-[20px] text-[#dadee5] break-all">
+            {user?.email ?? 'Not signed in'}
+          </p>
+          <p className="text-[12px] leading-[18px] text-[#6b6e73] mt-1">
+            {user
+              ? 'Sign-in is passwordless — we email a 6-digit code. There is no password to change.'
+              : 'Sign in to save timelines to an account and reach them from any browser.'}
+          </p>
+        </Section>
+
+        <Section label="Plan">
+          <p className="text-[14px] leading-[20px] text-[#dadee5]">{TIER_LABELS[tier]}</p>
+          <p className="text-[12px] leading-[18px] text-[#6b6e73] mt-1">
+            {TIER_DESCRIPTIONS[tier]}
+          </p>
+        </Section>
+
+        {/* Trial has no caps to report against — it is a state, not a tier, and
+            a usage table implies limits it does not have. */}
+        {tier !== 'trial' && (
+          <Section label="Usage">
+            <div className="flex flex-col gap-1.5">
+              <UsageRow
+                label="Timelines"
+                count={timelineCount}
+                limit={PLAN_LIMITS[tier].timelineLimit}
+              />
+              <UsageRow
+                label="Events"
+                count={eventCount}
+                limit={PLAN_LIMITS[tier].eventLimit}
+              />
+            </div>
+          </Section>
+        )}
+
+        <Section label="API key">
+          {credential ? (
+            <p className="text-[14px] leading-[20px] text-[#dadee5]">
+              {PROVIDER_META[credential.provider].label}
+              <span className="text-[#6b6e73] font-['JetBrains_Mono',monospace] text-[12px] ml-2">
+                {maskKey(credential.key)}
+              </span>
+            </p>
+          ) : (
+            <p className="text-[14px] leading-[20px] text-[#9b9ea3]">No key connected</p>
+          )}
+          <p className="text-[12px] leading-[18px] text-[#6b6e73] mt-1">
+            {hasSettingsHandler ? (
+              <>
+                Keys are added and removed in{' '}
+                <button
+                  type="button"
+                  onClick={() => {
+                    onClose()
+                    onOpenSettings()
+                  }}
+                  className="underline hover:text-[#9b9ea3] transition-colors"
+                >
+                  Settings
+                </button>
+                .
+              </>
+            ) : (
+              'Keys are added and removed in a timeline’s Settings panel.'
+            )}
+          </p>
+        </Section>
+
+        {user && (
+          <div className="border-t border-[#404040] pt-4">
+            <button
+              type="button"
+              onClick={() => {
+                onClose()
+                onDeleteAccount()
+              }}
+              className="text-[14px] leading-[20px] text-destructive hover:underline"
+            >
+              Delete account
+            </button>
+            <p className="text-[12px] leading-[18px] text-[#6b6e73] mt-1">
+              Permanently deletes your account and every timeline on it. Export anything you
+              want to keep first.
+            </p>
+          </div>
+        )}
+      </div>
+    </Modal>
+  )
+}
+
+function Section({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div>
+      <h3 className="m-0 mb-1.5 font-['Aleo',serif] text-[12px] leading-[140%] font-normal text-[#9b9ea3]">
+        {label}
+      </h3>
+      {children}
+    </div>
+  )
+}
+
+function UsageRow({
+  label,
+  count,
+  limit,
+}: {
+  label: string
+  count: number
+  limit: number | null
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="text-[13px] leading-[18px] text-[#c9ced4]">{label}</span>
+      <span className="font-['JetBrains_Mono',monospace] text-[13px] leading-[18px] text-[#9b9ea3]">
+        {count}
+        {limit == null ? '' : ` / ${limit}`}
+      </span>
+    </div>
+  )
+}

--- a/src/components/Modal/AccountDetailsModal.tsx
+++ b/src/components/Modal/AccountDetailsModal.tsx
@@ -1,11 +1,16 @@
-import type { ReactNode } from 'react'
-import { Modal } from './Modal'
+import { useEffect, useState, type ReactNode } from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { Dialog, DialogOverlay, DialogPortal } from '@/components/ui/dialog'
+import {
+  destructiveGlassButtonClass,
+  glassButtonClass,
+  modalSidebarTabClass,
+} from '@/components/ui/glassButton'
 import { useAuth } from '@/hooks/useAuth'
 import { useAccountTier } from '@/hooks/useAccountTier'
 import { useEventUsage } from '@/hooks/useEventUsage'
 import { useSidePanel } from '@/hooks/useSidePanel'
-import { useByokCredential } from '@/services/userApiKey'
-import { maskKey } from '@/services/userApiKey'
+import { maskKey, useByokCredential } from '@/services/userApiKey'
 import { PLAN_LIMITS } from '@/constants/plans'
 import { PROVIDER_META } from '@/constants/byokProviders'
 import { TIER_DESCRIPTIONS, TIER_LABELS } from '@/constants/tierLabels'
@@ -16,15 +21,25 @@ interface AccountDetailsModalProps {
   onDeleteAccount: () => void
 }
 
+const SECTIONS = [
+  { id: 'details', label: 'Account details' },
+  { id: 'usage', label: 'Account usage' },
+  { id: 'management', label: 'Account management' },
+] as const
+
+type SectionId = (typeof SECTIONS)[number]['id']
+
 /**
  * What the account is, in one place.
  *
- * Every value here already existed somewhere — this adds no query, no table and
- * no hook. It exists because the facts were scattered across a footer, a usage
- * card and a settings panel, and none of them answered "what am I actually on".
+ * Built on the same shell as `EventTableEditor` — Radix Dialog rather than the
+ * `Modal` wrapper, 20px radius, a left rail of tabs and a glass-button footer —
+ * so the two full-size modals in the product read as one surface. The shared
+ * button and tab styles live in `ui/glassButton.ts` for the same reason.
  *
- * Key *management* deliberately stays in the Settings panel. This shows status
- * and points at it, rather than becoming a second place to edit the same value.
+ * Every value here already existed somewhere. This adds no query, no table and
+ * no hook; it exists because the facts were scattered across a footer, a usage
+ * card and a settings panel, and none of them answered "what am I actually on".
  */
 export function AccountDetailsModal({
   isOpen,
@@ -33,121 +48,225 @@ export function AccountDetailsModal({
 }: AccountDetailsModalProps) {
   const { user } = useAuth()
   const tier = useAccountTier()
+  const [section, setSection] = useState<SectionId>('details')
+
+  // Reopening should land on the first section rather than wherever the last
+  // visit ended — the entry point is a menu item called "Account Details", and
+  // arriving on "Account management" would not be what it promised.
+  useEffect(() => {
+    if (isOpen) setSection('details')
+  }, [isOpen])
+
+  if (tier === 'loading') return null
+
+  return (
+    <Dialog open={isOpen} onOpenChange={open => { if (!open) onClose() }}>
+      <DialogPortal>
+        <DialogOverlay />
+        <DialogPrimitive.Content
+          aria-describedby={undefined}
+          className="fixed left-[50%] top-[50%] z-50 w-full max-w-[720px] translate-x-[-50%] translate-y-[-50%] bg-[#171717] border border-[rgba(210,210,210,0.2)] rounded-[20px] p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]"
+        >
+          {/* Header — the Events modal's tab band, with one destination. */}
+          <div className="flex items-center justify-center h-[48px]">
+            <DialogPrimitive.Title className="m-0 font-['Aleo',serif] font-normal text-[24px] leading-[1.4] text-[#dadee5]">
+              Account
+            </DialogPrimitive.Title>
+          </div>
+
+          <div className="mt-8" style={{ height: 'min(420px, calc(100vh - 280px))' }}>
+            <div className="flex gap-[16px] h-full">
+              {/* Section rail */}
+              <nav
+                aria-label="Account sections"
+                className="w-[200px] shrink-0 bg-[#242526] rounded-[12px] p-2 flex flex-col gap-[2px] overflow-y-auto"
+              >
+                {SECTIONS.map(s => (
+                  <button
+                    key={s.id}
+                    type="button"
+                    onClick={() => setSection(s.id)}
+                    aria-current={section === s.id ? 'page' : undefined}
+                    className={modalSidebarTabClass(section === s.id)}
+                  >
+                    {s.label}
+                  </button>
+                ))}
+              </nav>
+
+              {/* Pane */}
+              <div className="flex-1 min-w-0 overflow-y-auto pr-1">
+                {section === 'details' && <DetailsPane />}
+                {section === 'usage' && <UsagePane />}
+                {section === 'management' && (
+                  <ManagementPane
+                    onDelete={() => {
+                      onClose()
+                      onDeleteAccount()
+                    }}
+                    signedIn={Boolean(user)}
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex justify-end items-center mt-8">
+            <button type="button" onClick={onClose} className={glassButtonClass}>
+              Close
+            </button>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPortal>
+    </Dialog>
+  )
+}
+
+function DetailsPane() {
+  const { user } = useAuth()
+
+  // There is no name field to show. Identity here is email-only by design —
+  // sign-up collects an address and nothing else — so a "Name" row would either
+  // sit permanently empty or invent a value the account does not have.
+  return (
+    <Pane title="Account details">
+      <Field label="Email" value={user?.email ?? 'Not signed in'} />
+      <Field
+        label="Sign-in method"
+        value="Email code"
+        hint="Passwordless — we email a 6-digit code each time. There is no password to change."
+      />
+      <Field label="Member since" value={formatJoined(user?.created_at)} />
+    </Pane>
+  )
+}
+
+function UsagePane() {
+  const tier = useAccountTier()
   // Counts from the hook, caps from the tier — the split `UsageLimits` already
   // makes. `useEventUsage` sources its limits from `getCurrentLimits()`, which
   // reads a module-level cache refreshed by an async `auth.getUser()`; it lags
   // an auth or key transition by a frame and holds its 'byok-anon' initial
-  // value if that call never lands. Reading PLAN_LIMITS off the tier we already
-  // have cannot disagree with the row above it.
+  // value if that call never lands.
   const { eventCount, timelineCount } = useEventUsage()
   const credential = useByokCredential()
   const { onOpenSettings, hasSettingsHandler } = useSidePanel()
 
   if (tier === 'loading') return null
+  const caps = tier === 'trial' ? null : PLAN_LIMITS[tier]
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Account Details" size="compact">
-      <div className="flex flex-col gap-5 py-1">
-        <Section label="Signed in as">
-          <p className="text-[14px] leading-[20px] text-[#dadee5] break-all">
-            {user?.email ?? 'Not signed in'}
-          </p>
-          <p className="text-[12px] leading-[18px] text-[#6b6e73] mt-1">
-            {user
-              ? 'Sign-in is passwordless — we email a 6-digit code. There is no password to change.'
-              : 'Sign in to save timelines to an account and reach them from any browser.'}
-          </p>
-        </Section>
+    <Pane title="Account usage">
+      <Field label="Tier" value={TIER_LABELS[tier]} hint={TIER_DESCRIPTIONS[tier]} />
 
-        <Section label="Plan">
-          <p className="text-[14px] leading-[20px] text-[#dadee5]">{TIER_LABELS[tier]}</p>
-          <p className="text-[12px] leading-[18px] text-[#6b6e73] mt-1">
-            {TIER_DESCRIPTIONS[tier]}
-          </p>
-        </Section>
+      {/* Trial has no caps to report against — it is a state, not a tier, and a
+          usage table implies limits it does not have. */}
+      {caps && (
+        <div>
+          <FieldLabel>Usage</FieldLabel>
+          <div className="flex flex-col gap-1.5 mt-1.5">
+            <UsageRow label="Timelines" count={timelineCount} limit={caps.timelineLimit} />
+            <UsageRow label="Events" count={eventCount} limit={caps.eventLimit} />
+          </div>
+        </div>
+      )}
 
-        {/* Trial has no caps to report against — it is a state, not a tier, and
-            a usage table implies limits it does not have. */}
-        {tier !== 'trial' && (
-          <Section label="Usage">
-            <div className="flex flex-col gap-1.5">
-              <UsageRow
-                label="Timelines"
-                count={timelineCount}
-                limit={PLAN_LIMITS[tier].timelineLimit}
-              />
-              <UsageRow
-                label="Events"
-                count={eventCount}
-                limit={PLAN_LIMITS[tier].eventLimit}
-              />
-            </div>
-          </Section>
-        )}
-
-        <Section label="API key">
+      <div>
+        <FieldLabel>API key</FieldLabel>
+        <p className="mt-1 text-[14px] leading-[20px] text-[#dadee5]">
           {credential ? (
-            <p className="text-[14px] leading-[20px] text-[#dadee5]">
+            <>
               {PROVIDER_META[credential.provider].label}
               <span className="text-[#6b6e73] font-['JetBrains_Mono',monospace] text-[12px] ml-2">
                 {maskKey(credential.key)}
               </span>
-            </p>
+            </>
           ) : (
-            <p className="text-[14px] leading-[20px] text-[#9b9ea3]">No key connected</p>
+            <span className="text-[#9b9ea3]">No key connected</span>
           )}
-          <p className="text-[12px] leading-[18px] text-[#6b6e73] mt-1">
-            {hasSettingsHandler ? (
-              <>
-                Keys are added and removed in{' '}
-                <button
-                  type="button"
-                  onClick={() => {
-                    onClose()
-                    onOpenSettings()
-                  }}
-                  className="underline hover:text-[#9b9ea3] transition-colors"
-                >
-                  Settings
-                </button>
-                .
-              </>
-            ) : (
-              'Keys are added and removed in a timeline’s Settings panel.'
-            )}
-          </p>
-        </Section>
-
-        {user && (
-          <div className="border-t border-[#404040] pt-4">
-            <button
-              type="button"
-              onClick={() => {
-                onClose()
-                onDeleteAccount()
-              }}
-              className="text-[14px] leading-[20px] text-destructive hover:underline"
-            >
-              Delete account
-            </button>
-            <p className="text-[12px] leading-[18px] text-[#6b6e73] mt-1">
-              Permanently deletes your account and every timeline on it. Export anything you
-              want to keep first.
-            </p>
-          </div>
-        )}
+        </p>
+        <p className="text-[12px] leading-[18px] text-[#6b6e73] mt-1">
+          {hasSettingsHandler ? (
+            <>
+              Keys are added and removed in{' '}
+              <button
+                type="button"
+                onClick={onOpenSettings}
+                className="underline hover:text-[#9b9ea3] transition-colors"
+              >
+                Settings
+              </button>
+              .
+            </>
+          ) : (
+            'Keys are added and removed in a timeline’s Settings panel.'
+          )}
+        </p>
       </div>
-    </Modal>
+    </Pane>
   )
 }
 
-function Section({ label, children }: { label: string; children: ReactNode }) {
+function ManagementPane({
+  onDelete,
+  signedIn,
+}: {
+  onDelete: () => void
+  signedIn: boolean
+}) {
+  return (
+    <Pane title="Account management">
+      <div>
+        <FieldLabel>Delete account</FieldLabel>
+        <p className="mt-1 text-[14px] leading-[20px] text-[#c9ced4]">
+          This permanently deletes your account, your email address, and every timeline
+          you have saved. It cannot be undone, and we cannot recover the data afterwards.
+        </p>
+        <p className="text-[12px] leading-[18px] text-[#6b6e73] mt-2">
+          Export anything you want to keep first — each timeline’s menu in the side panel
+          has an Export data option.
+        </p>
+        {signedIn && (
+          <button type="button" onClick={onDelete} className={`${destructiveGlassButtonClass} mt-4`}>
+            Delete account
+          </button>
+        )}
+      </div>
+    </Pane>
+  )
+}
+
+function Pane({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-5">
+      <h3 className="sr-only">{title}</h3>
+      {children}
+    </div>
+  )
+}
+
+function FieldLabel({ children }: { children: ReactNode }) {
+  return (
+    <span className="font-['Avenir',sans-serif] text-[12px] leading-[140%] font-medium text-[#9b9ea3]">
+      {children}
+    </span>
+  )
+}
+
+function Field({
+  label,
+  value,
+  hint,
+}: {
+  label: string
+  value: string
+  hint?: string
+}) {
   return (
     <div>
-      <h3 className="m-0 mb-1.5 font-['Aleo',serif] text-[12px] leading-[140%] font-normal text-[#9b9ea3]">
-        {label}
-      </h3>
-      {children}
+      <FieldLabel>{label}</FieldLabel>
+      <p className="mt-1 text-[14px] leading-[20px] text-[#dadee5] break-all">{value}</p>
+      {hint && <p className="text-[12px] leading-[18px] text-[#6b6e73] mt-1">{hint}</p>}
     </div>
   )
 }
@@ -162,12 +281,25 @@ function UsageRow({
   limit: number | null
 }) {
   return (
-    <div className="flex items-center justify-between gap-2">
-      <span className="text-[13px] leading-[18px] text-[#c9ced4]">{label}</span>
+    <div className="flex items-center justify-between gap-2 bg-[#0A0A0A] rounded-md px-3 py-1.5">
+      <span className="font-['Avenir',sans-serif] text-[13px] leading-[18px] text-[#c9ced4]">
+        {label}
+      </span>
       <span className="font-['Avenir',sans-serif] text-[13px] leading-[18px] text-[#9b9ea3]">
         {count}
         {limit == null ? '' : ` / ${limit}`}
       </span>
     </div>
   )
+}
+
+function formatJoined(createdAt: string | undefined): string {
+  if (!createdAt) return 'Unknown'
+  const date = new Date(createdAt)
+  if (Number.isNaN(date.getTime())) return 'Unknown'
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
 }

--- a/src/components/Modal/AccountDetailsModal.tsx
+++ b/src/components/Modal/AccountDetailsModal.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { X } from 'lucide-react'
 import { Dialog, DialogOverlay, DialogPortal } from '@/components/ui/dialog'
 import {
   destructiveGlassButtonClass,
+  modalRailClass,
+  modalRailGroupClass,
   modalSidebarTabClass,
 } from '@/components/ui/glassButton'
 import { useAuth } from '@/hooks/useAuth'
@@ -51,6 +53,17 @@ export function AccountDetailsModal({
   const { user } = useAuth()
   const tier = useAccountTier()
   const [section, setSection] = useState<SectionId>('details')
+  const railRef = useRef<HTMLElement | null>(null)
+
+  // Keep the active tab visible in the horizontal strip. The scrollbar is
+  // hidden there, so a tab scrolled off the edge has no affordance saying where
+  // it went — and selection can move without a click (reopening resets to the
+  // first section, and arrow keys move focus). Inert on the vertical rail,
+  // where nothing overflows.
+  useEffect(() => {
+    const active = railRef.current?.querySelector(`[data-section="${section}"]`)
+    active?.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+  }, [section, isOpen])
 
   // Reopening lands on the first section rather than wherever the last visit
   // ended. The section name doubles as the dialog's heading, so a stale
@@ -67,65 +80,77 @@ export function AccountDetailsModal({
       <DialogPortal>
         <DialogOverlay />
         {/*
-          `p-0` and `overflow-hidden` are what let the rail run edge to edge and
-          clip to the 20px radius, and the height lives here rather than on an
-          inner wrapper — a full-height rail needs the dialog itself to have a
-          height to fill.
+          A grid rather than a flex row, because the two layouts are an L-shape
+          reflow of each other:
+
+            below sm   header / strip / body stacked in one column
+            sm and up  rail down the left spanning both rows, header and body
+                       stacked to its right
+
+          Flex cannot express that from one DOM order, and duplicating the
+          header behind `sm:hidden` would mean two `DialogPrimitive.Title`
+          elements — two copies of the id Radix points `aria-labelledby` at.
+
+          `p-0` and `overflow-hidden` let the rail run edge to edge, and the
+          height lives here rather than on an inner wrapper: a full-height rail
+          needs the dialog itself to have a height to fill.
         */}
         <DialogPrimitive.Content
           aria-describedby={undefined}
-          className="fixed left-[50%] top-[50%] z-50 w-full max-w-[720px] h-[min(560px,calc(100vh-120px))] translate-x-[-50%] translate-y-[-50%] flex overflow-hidden bg-[#171717] border border-[rgba(210,210,210,0.2)] rounded-[20px] shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]"
+          className="fixed z-50 inset-0 w-screen h-[100dvh] max-w-none rounded-none border-0 grid grid-cols-1 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden bg-[#171717] shadow-lg duration-200 sm:inset-auto sm:left-[50%] sm:top-[50%] sm:w-full sm:max-w-[720px] sm:h-[min(560px,calc(100vh-120px))] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:grid-cols-[200px_minmax(0,1fr)] sm:grid-rows-[auto_minmax(0,1fr)] sm:rounded-[20px] sm:border sm:border-[rgba(210,210,210,0.2)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95"
         >
-          {/* Full-height rail: flush to the modal's edges, its own surface, and
-              a divider instead of a gap. */}
+          <div className="sm:col-start-2 sm:row-start-1 flex items-start justify-between gap-4 px-6 pt-5 pb-4">
+            {/*
+              The section name *is* the dialog's title, so the accessible name
+              always matches the heading on screen. It changes as you move
+              through the rail, which is what the reference does too.
+            */}
+            <DialogPrimitive.Title className="m-0 font-['Aleo',serif] font-normal text-[20px] leading-[1.4] text-[#dadee5]">
+              {SECTIONS.find(s => s.id === section)?.label}
+            </DialogPrimitive.Title>
+            <DialogPrimitive.Close
+              aria-label="Close"
+              className="shrink-0 -mr-1 -mt-0.5 p-1 rounded text-[#9b9ea3] hover:text-[#dadee5] outline-none focus-visible:ring-1 focus-visible:ring-white/40 transition-colors"
+            >
+              <X size={20} />
+            </DialogPrimitive.Close>
+          </div>
+
+          {/* Full-height rail at sm and up; a horizontally scrolling strip below
+              it. Both orientations come from `modalRailClass`. */}
           <nav
+            ref={railRef}
             aria-label="Account sections"
-            className="w-[200px] shrink-0 h-full bg-[#141415] border-r border-[rgba(210,210,210,0.2)] p-3 flex flex-col gap-[2px] overflow-y-auto"
+            className={`sm:col-start-1 sm:row-start-1 sm:row-span-2 ${modalRailClass}`}
           >
-            {SECTIONS.map(s => (
-              <button
-                key={s.id}
-                type="button"
-                onClick={() => setSection(s.id)}
-                aria-current={section === s.id ? 'page' : undefined}
-                className={modalSidebarTabClass(section === s.id)}
-              >
-                {s.label}
-              </button>
-            ))}
+            <div className={modalRailGroupClass}>
+              {SECTIONS.map(s => (
+                <button
+                  key={s.id}
+                  type="button"
+                  data-section={s.id}
+                  onClick={() => setSection(s.id)}
+                  aria-current={section === s.id ? 'page' : undefined}
+                  className={modalSidebarTabClass(section === s.id)}
+                >
+                  {s.label}
+                </button>
+              ))}
+            </div>
           </nav>
 
-          <div className="flex-1 min-w-0 flex flex-col">
-            <div className="flex items-start justify-between gap-4 px-6 pt-5 pb-4">
-              {/*
-                The section name *is* the dialog's title, so the accessible name
-                always matches the heading on screen. It changes as you move
-                through the rail, which is what the reference does too.
-              */}
-              <DialogPrimitive.Title className="m-0 font-['Aleo',serif] font-normal text-[20px] leading-[1.4] text-[#dadee5]">
-                {SECTIONS.find(s => s.id === section)?.label}
-              </DialogPrimitive.Title>
-              <DialogPrimitive.Close
-                aria-label="Close"
-                className="shrink-0 -mr-1 -mt-0.5 p-1 rounded text-[#9b9ea3] hover:text-[#dadee5] outline-none focus-visible:ring-1 focus-visible:ring-white/40 transition-colors"
-              >
-                <X size={20} />
-              </DialogPrimitive.Close>
-            </div>
-
-            <div className="flex-1 min-h-0 overflow-y-auto px-6 pb-6">
-              {section === 'details' && <DetailsPane />}
-              {section === 'usage' && <UsagePane />}
-              {section === 'management' && (
-                <ManagementPane
-                  onDelete={() => {
-                    onClose()
-                    onDeleteAccount()
-                  }}
-                  signedIn={Boolean(user)}
-                />
-              )}
-            </div>
+          <div className="sm:col-start-2 sm:row-start-2 min-w-0 min-h-0 overflow-y-auto px-6 pb-6">
+            {section === 'details' && <DetailsPane />}
+            {section === 'usage' && <UsagePane />}
+            {section === 'management' && (
+              <ManagementPane
+                onDelete={() => {
+                  onClose()
+                  onDeleteAccount()
+                }}
+                signedIn={Boolean(user)}
+              />
+            )}
           </div>
         </DialogPrimitive.Content>
       </DialogPortal>

--- a/src/components/Modal/AccountDetailsModal.tsx
+++ b/src/components/Modal/AccountDetailsModal.tsx
@@ -94,10 +94,27 @@ export function AccountDetailsModal({
           `p-0` and `overflow-hidden` let the rail run edge to edge, and the
           height lives here rather than on an inner wrapper: a full-height rail
           needs the dialog itself to have a height to fill.
+
+          Centred with `inset-0 m-auto`, deliberately NOT `left-1/2 top-1/2`
+          plus a −50% translate. `tailwindcss-animate` builds one keyframe whose
+          `from` sets the entire transform — translate, scale and rotate
+          together — so with `zoom-in-95` and no `slide-in-from-*` to re-supply
+          the offsets, frame 0 is `translate3d(0,0,0) scale(.95)`. Animations
+          outrank normal declarations, so that *replaces* the centring translate
+          and the modal starts with its top-left corner at the viewport centre,
+          then travels up and left into place — a diagonal drift in from the
+          bottom right, and back out the same way.
+
+          Auto margins centre it without a transform (both axes, because the
+          width and height here are definite), leaving the keyframe nothing to
+          clobber. `zoom-in-95` then scales about the element's own centre,
+          which is the whole intent. Restoring the slide utilities would also
+          work, but they would exist solely to cancel a slide — one tidy-up away
+          from bringing this back.
         */}
         <DialogPrimitive.Content
           aria-describedby={undefined}
-          className="fixed z-50 inset-0 w-screen h-[100dvh] max-w-none rounded-none border-0 grid grid-cols-1 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden bg-[#171717] shadow-lg duration-200 sm:inset-auto sm:left-[50%] sm:top-[50%] sm:w-full sm:max-w-[720px] sm:h-[min(560px,calc(100vh-120px))] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:grid-cols-[200px_minmax(0,1fr)] sm:grid-rows-[auto_minmax(0,1fr)] sm:rounded-[20px] sm:border sm:border-[rgba(210,210,210,0.2)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95"
+          className="fixed z-50 inset-0 w-screen h-[100dvh] max-w-none rounded-none border-0 grid grid-cols-1 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden bg-[#171717] shadow-lg duration-200 sm:w-full sm:max-w-[720px] sm:h-[min(560px,calc(100vh-120px))] sm:m-auto sm:grid-cols-[200px_minmax(0,1fr)] sm:grid-rows-[auto_minmax(0,1fr)] sm:rounded-[20px] sm:border sm:border-[rgba(210,210,210,0.2)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95"
         >
           <div className="sm:col-start-2 sm:row-start-1 flex items-start justify-between gap-4 px-6 pt-5 pb-4">
             {/*

--- a/src/components/Modal/AccountDetailsModal.tsx
+++ b/src/components/Modal/AccountDetailsModal.tsx
@@ -164,7 +164,7 @@ function UsageRow({
   return (
     <div className="flex items-center justify-between gap-2">
       <span className="text-[13px] leading-[18px] text-[#c9ced4]">{label}</span>
-      <span className="font-['JetBrains_Mono',monospace] text-[13px] leading-[18px] text-[#9b9ea3]">
+      <span className="font-['Avenir',sans-serif] text-[13px] leading-[18px] text-[#9b9ea3]">
         {count}
         {limit == null ? '' : ` / ${limit}`}
       </span>

--- a/src/components/SidePanel/AccountMenu.tsx
+++ b/src/components/SidePanel/AccountMenu.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react'
 import {
-  CircleUserRound,
   ExternalLink,
   Info,
   LogIn,
@@ -9,7 +8,6 @@ import {
   Trash2,
 } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
-import { useSidePanel } from '@/hooks/useSidePanel'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -25,7 +23,8 @@ import {
 
 interface AccountMenuProps {
   trigger: ReactNode
-  onOpenAccountDetails: () => void
+  /** Opens the account modal — the destination of the single Settings item. */
+  onOpenSettings: () => void
   onSignIn: () => void
   onSignOut: () => void
   onDeleteAccount: () => void
@@ -38,27 +37,20 @@ interface AccountMenuProps {
  */
 export function AccountMenu({
   trigger,
-  onOpenAccountDetails,
+  onOpenSettings,
   onSignIn,
   onSignOut,
   onDeleteAccount,
 }: AccountMenuProps) {
   const { user } = useAuth()
-  const { onOpenSettings, hasSettingsHandler } = useSidePanel()
-
-  // Only the editor route registers a settings handler, so everywhere else the
-  // call is a silent no-op. Hidden rather than disabled: a greyed row invites a
-  // click and then explains nothing.
-  const showSettings = hasSettingsHandler
-  const hasTopGroup = Boolean(user) || showSettings
 
   return (
     /*
       `modal={false}` is load bearing, not a preference.
 
       As a modal layer the menu writes `pointer-events: none` onto <body> while
-      open. Every item here opens another Radix layer — the Account Details
-      dialog, or a ConfirmationModal for Log Out and Delete Account — and when
+      open. Every item here opens another Radix layer — the account modal, or a
+      ConfirmationModal for Log Out and Delete Account — and when
       that second layer tears down it restores the style it found on mount,
       which is the menu's `none`. The page then looks fine and ignores every
       click, with nothing on screen to explain why.
@@ -88,21 +80,25 @@ export function AccountMenu({
       >
         {user && <DropdownMenuLabel className="truncate">{user.email}</DropdownMenuLabel>}
 
-        {showSettings && (
-          <DropdownMenuItem onSelect={() => onOpenSettings()}>
+        {/*
+          One entry, not two. This used to be Settings — which opened the
+          editor's timeline settings panel and silently did nothing on every
+          other route — sitting directly above Account Details. Both now
+          resolve here, to the account modal, whose own usage section links on
+          to the timeline panel where that panel is actually available.
+
+          Signed-in only, which is where Account Details already sat: the
+          destination is an account modal, so it appears exactly when there is
+          an account.
+        */}
+        {user && (
+          <DropdownMenuItem onSelect={onOpenSettings}>
             <Settings size={14} />
             Settings
           </DropdownMenuItem>
         )}
 
-        {user && (
-          <DropdownMenuItem onSelect={onOpenAccountDetails}>
-            <CircleUserRound size={14} />
-            Account Details
-          </DropdownMenuItem>
-        )}
-
-        {hasTopGroup && <DropdownMenuSeparator />}
+        {user && <DropdownMenuSeparator />}
 
         <DropdownMenuSub>
           <DropdownMenuSubTrigger>

--- a/src/components/SidePanel/AccountMenu.tsx
+++ b/src/components/SidePanel/AccountMenu.tsx
@@ -1,0 +1,140 @@
+import type { ReactNode } from 'react'
+import {
+  CircleUserRound,
+  ExternalLink,
+  Info,
+  LogIn,
+  LogOut,
+  Settings,
+  Trash2,
+} from 'lucide-react'
+import { useAuth } from '@/hooks/useAuth'
+import { useSidePanel } from '@/hooks/useSidePanel'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+interface AccountMenuProps {
+  trigger: ReactNode
+  onOpenAccountDetails: () => void
+  onSignIn: () => void
+  onSignOut: () => void
+  onDeleteAccount: () => void
+}
+
+/**
+ * The menu behind the account row. Opens upward, and through a portal — the
+ * panel frame is `overflow-hidden` and carries a transform, so neither an
+ * in-flow nor a `position: fixed` menu can escape it.
+ */
+export function AccountMenu({
+  trigger,
+  onOpenAccountDetails,
+  onSignIn,
+  onSignOut,
+  onDeleteAccount,
+}: AccountMenuProps) {
+  const { user } = useAuth()
+  const { onOpenSettings, hasSettingsHandler } = useSidePanel()
+
+  // Only the editor route registers a settings handler, so everywhere else the
+  // call is a silent no-op. Hidden rather than disabled: a greyed row invites a
+  // click and then explains nothing.
+  const showSettings = hasSettingsHandler
+  const hasTopGroup = Boolean(user) || showSettings
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+      {/*
+        Wider than the row by a fixed overhang, so the menu overlaps the canvas
+        at every panel width rather than at one of them. A literal width can't
+        do this: the panel is resizable from 300 to 400, so any number is either
+        narrower than the card at the top of that range or wider than it needs
+        to be at the bottom. Radix publishes the trigger's measured width, so
+        the overhang stays constant instead.
+
+        Overflowing the panel at all is only possible because the content
+        portals — `GlobalSidePanel` is `overflow-hidden`.
+      */}
+      <DropdownMenuContent
+        side="top"
+        align="start"
+        className="w-[calc(var(--radix-dropdown-menu-trigger-width)+48px)]"
+      >
+        {user && <DropdownMenuLabel className="truncate">{user.email}</DropdownMenuLabel>}
+
+        {showSettings && (
+          <DropdownMenuItem onSelect={() => onOpenSettings()}>
+            <Settings size={14} />
+            Settings
+          </DropdownMenuItem>
+        )}
+
+        {user && (
+          <DropdownMenuItem onSelect={onOpenAccountDetails}>
+            <CircleUserRound size={14} />
+            Account Details
+          </DropdownMenuItem>
+        )}
+
+        {hasTopGroup && <DropdownMenuSeparator />}
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <Info size={14} />
+            Learn more
+          </DropdownMenuSubTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuSubContent className="w-[220px]">
+              {/* New tabs, not <Link>s. `/privacy` and `/terms` mount outside
+                  LayoutRoute, so navigating in-tab unmounts the editor and
+                  takes unsaved work with it. */}
+              <DropdownMenuItem asChild>
+                <a href="/privacy" target="_blank" rel="noopener noreferrer">
+                  Privacy Policy
+                  <ExternalLink size={13} className="ml-auto shrink-0 text-[#6b6e73]" />
+                </a>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <a href="/terms" target="_blank" rel="noopener noreferrer">
+                  Terms &amp; Conditions
+                  <ExternalLink size={13} className="ml-auto shrink-0 text-[#6b6e73]" />
+                </a>
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuPortal>
+        </DropdownMenuSub>
+
+        <DropdownMenuSeparator />
+
+        {user ? (
+          <>
+            <DropdownMenuItem onSelect={onSignOut}>
+              <LogOut size={14} />
+              Log Out
+            </DropdownMenuItem>
+            <DropdownMenuItem destructive onSelect={onDeleteAccount}>
+              <Trash2 size={14} />
+              Delete Account
+            </DropdownMenuItem>
+          </>
+        ) : (
+          <DropdownMenuItem onSelect={onSignIn}>
+            <LogIn size={14} />
+            Sign in
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/components/SidePanel/AccountMenu.tsx
+++ b/src/components/SidePanel/AccountMenu.tsx
@@ -53,7 +53,22 @@ export function AccountMenu({
   const hasTopGroup = Boolean(user) || showSettings
 
   return (
-    <DropdownMenu>
+    /*
+      `modal={false}` is load bearing, not a preference.
+
+      As a modal layer the menu writes `pointer-events: none` onto <body> while
+      open. Every item here opens another Radix layer — the Account Details
+      dialog, or a ConfirmationModal for Log Out and Delete Account — and when
+      that second layer tears down it restores the style it found on mount,
+      which is the menu's `none`. The page then looks fine and ignores every
+      click, with nothing on screen to explain why.
+
+      Turning the menu non-modal means it never writes the style, so there is
+      nothing stale to restore. Click-outside and Escape still dismiss it; the
+      only thing given up is inerting the page behind a small account menu,
+      which was never worth having.
+    */
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
       {/*
         Wider than the row by a fixed overhang, so the menu overlaps the canvas

--- a/src/components/SidePanel/AccountRow.tsx
+++ b/src/components/SidePanel/AccountRow.tsx
@@ -1,0 +1,86 @@
+import { ChevronsUpDown, User as UserIcon } from 'lucide-react'
+import { useAuth } from '@/hooks/useAuth'
+import { useAccountTier } from '@/hooks/useAccountTier'
+import {
+  ANONYMOUS_IDENTITY,
+  TIER_LABELS,
+  avatarInitial,
+  emailLocalPart,
+} from '@/constants/tierLabels'
+import { AccountMenu } from './AccountMenu'
+
+interface AccountRowProps {
+  onOpenAccountDetails: () => void
+  onSignIn: () => void
+  onSignOut: () => void
+  onDeleteAccount: () => void
+}
+
+/**
+ * The bottom of the side panel: who you are, what you're on, and the way in to
+ * everything account-shaped.
+ *
+ * Replaces a footer that rendered the email beside an unlabelled logout glyph
+ * and then Privacy / Terms / Delete account as three equal-weight 12px links —
+ * an arrangement that gave an irreversible action the same visual weight as a
+ * link to the privacy policy.
+ */
+export function AccountRow({
+  onOpenAccountDetails,
+  onSignIn,
+  onSignOut,
+  onDeleteAccount,
+}: AccountRowProps) {
+  const { user } = useAuth()
+  const tier = useAccountTier()
+
+  // `user` is null both before the session lookup answers and when genuinely
+  // signed out, so anything rendered during this window is a guess. Guessing
+  // wrong here tells a signed-in user they have no account, which reads as a
+  // logout bug rather than a loading state.
+  if (tier === 'loading') {
+    return (
+      <div className="border-t border-[#404040] px-3 py-3 shrink-0">
+        <div className="flex items-center gap-2 px-2 py-1.5" aria-hidden="true">
+          <div className="w-6 h-6 rounded-full bg-[#262626] animate-pulse shrink-0" />
+          <div className="h-4 flex-1 max-w-[140px] rounded bg-[#262626] animate-pulse" />
+        </div>
+      </div>
+    )
+  }
+
+  const identity = user ? emailLocalPart(user.email ?? '') : ANONYMOUS_IDENTITY
+  const tierLabel = TIER_LABELS[tier]
+
+  return (
+    <div className="border-t border-[#404040] px-3 py-3 shrink-0">
+      <AccountMenu
+        onOpenAccountDetails={onOpenAccountDetails}
+        onSignIn={onSignIn}
+        onSignOut={onSignOut}
+        onDeleteAccount={onDeleteAccount}
+        trigger={
+          <button
+            type="button"
+            className="w-full flex items-center gap-2 px-2 py-1.5 rounded-[10px] text-left transition-colors hover:bg-[#262626] data-[state=open]:bg-[#262626] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[#6b6e73]"
+            aria-label={`Account menu for ${identity}, ${tierLabel}`}
+          >
+            <span className="shrink-0 w-6 h-6 rounded-full bg-[#262626] text-[#c9ced4] flex items-center justify-center text-[11px] font-medium">
+              {user ? avatarInitial(user.email ?? '') : <UserIcon size={13} />}
+            </span>
+            <span className="flex-1 min-w-0 flex items-baseline gap-1.5">
+              <span className="min-w-0 truncate text-[14px] leading-[20px] text-[#dadee5]">
+                {identity}
+              </span>
+              <span className="shrink-0 text-[12px] leading-[18px] text-[#6b6e73]">
+                · {tierLabel}
+              </span>
+            </span>
+            {/* Decoration, not a second target — the whole row is the button. */}
+            <ChevronsUpDown size={14} className="shrink-0 text-[#6b6e73]" />
+          </button>
+        }
+      />
+    </div>
+  )
+}

--- a/src/components/SidePanel/AccountRow.tsx
+++ b/src/components/SidePanel/AccountRow.tsx
@@ -10,7 +10,7 @@ import {
 import { AccountMenu } from './AccountMenu'
 
 interface AccountRowProps {
-  onOpenAccountDetails: () => void
+  onOpenSettings: () => void
   onSignIn: () => void
   onSignOut: () => void
   onDeleteAccount: () => void
@@ -26,7 +26,7 @@ interface AccountRowProps {
  * link to the privacy policy.
  */
 export function AccountRow({
-  onOpenAccountDetails,
+  onOpenSettings,
   onSignIn,
   onSignOut,
   onDeleteAccount,
@@ -55,7 +55,7 @@ export function AccountRow({
   return (
     <div className="border-t border-[#404040] px-3 py-3 shrink-0">
       <AccountMenu
-        onOpenAccountDetails={onOpenAccountDetails}
+        onOpenSettings={onOpenSettings}
         onSignIn={onSignIn}
         onSignOut={onSignOut}
         onDeleteAccount={onDeleteAccount}

--- a/src/components/SidePanel/SidePanelBody.tsx
+++ b/src/components/SidePanel/SidePanelBody.tsx
@@ -675,7 +675,7 @@ export function SidePanelBody() {
 
       {/* Footer */}
       <AccountRow
-        onOpenAccountDetails={() => setIsAccountDetailsOpen(true)}
+        onOpenSettings={() => setIsAccountDetailsOpen(true)}
         onSignIn={() => setIsAuthModalOpen(true)}
         onSignOut={() => setShowSignOutConfirm(true)}
         onDeleteAccount={() => setShowDeleteAccountConfirm(true)}

--- a/src/components/SidePanel/SidePanelBody.tsx
+++ b/src/components/SidePanel/SidePanelBody.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import {
   CirclePlus,
   Copy,
   Download,
   FileDown,
   FileSpreadsheet,
-  LogOut,
   MoreVertical,
   PanelLeft,
   Share2,
@@ -33,8 +32,10 @@ import {
 import { exportEventsToExcel } from '@/utils/excelExport'
 import { downloadTemplate } from '@/utils/excelSheet'
 import type { TimelineEvent } from '@/types/event'
+import { AccountDetailsModal } from '@/components/Modal/AccountDetailsModal'
 import { UsageLimits } from './UsageLimits'
 import { SidePanelActionButton } from './SidePanelActionButton'
+import { AccountRow } from './AccountRow'
 
 interface TileRow {
   id: string
@@ -152,7 +153,7 @@ function TileMenuButton({
 
 export function SidePanelBody() {
   const navigate = useNavigate()
-  const { user } = useAuth()
+  const { user, signOut } = useAuth()
   const tier = useAccountTier()
   const { isOpen, close, onTimelineSelect, onDraftSelect, setRefreshTimelines, activeTimelineId, activeDraftId, activeTimelineTitle, activeEventCount, activeDominantCategoryColor } = useSidePanel()
   const { timelines, isLoading, error, loadTimelines } = useTimelines()
@@ -164,6 +165,7 @@ export function SidePanelBody() {
   const [isDeletingAccount, setIsDeletingAccount] = useState(false)
   const [isImportOpen, setIsImportOpen] = useState(false)
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false)
+  const [isAccountDetailsOpen, setIsAccountDetailsOpen] = useState(false)
 
   // `activeDraftId` is in the deps because it is the only signal this component
   // gets that the guest's draft list changed. This panel lives outside the
@@ -373,7 +375,12 @@ export function SidePanelBody() {
 
   const handleSignOut = async () => {
     try {
-      await supabase.auth.signOut()
+      // Through AuthContext rather than `supabase.auth.signOut()` directly:
+      // the context wraps the same call in a `finally` that runs
+      // `clearAllCachedEvents()`. Calling the client straight left events from
+      // viewed shared timelines cached in the browser after sign-out — but only
+      // for a sign-out taken from this panel, which is why nobody noticed.
+      await signOut()
       close()
     } catch (err) {
       console.error('Error signing out:', err)
@@ -667,39 +674,12 @@ export function SidePanelBody() {
       </div>
 
       {/* Footer */}
-      <div className="border-t border-[#404040] px-5 pt-3 pb-4 shrink-0">
-        {user && (
-          <div className="flex items-center justify-between gap-2 py-1.5">
-            <p className="flex-1 min-w-0 font-['Avenir',sans-serif] text-[16px] leading-[24px] text-[#9b9ea3] truncate">
-              {user.email}
-            </p>
-            <button
-              onClick={() => setShowSignOutConfirm(true)}
-              className="shrink-0 p-1 text-[#9b9ea3] hover:text-[#dadee5] rounded transition-colors"
-              aria-label="Sign out"
-              title="Sign out"
-            >
-              <LogOut size={16} />
-            </button>
-          </div>
-        )}
-        <div className="flex items-center gap-3 pt-1 text-[12px] text-[#6b6e73]">
-          <Link to="/privacy" className="hover:text-[#9b9ea3] transition-colors">
-            Privacy
-          </Link>
-          <Link to="/terms" className="hover:text-[#9b9ea3] transition-colors">
-            Terms
-          </Link>
-          {user && (
-            <button
-              onClick={() => setShowDeleteAccountConfirm(true)}
-              className="ml-auto hover:text-destructive transition-colors"
-            >
-              Delete account
-            </button>
-          )}
-        </div>
-      </div>
+      <AccountRow
+        onOpenAccountDetails={() => setIsAccountDetailsOpen(true)}
+        onSignIn={() => setIsAuthModalOpen(true)}
+        onSignOut={() => setShowSignOutConfirm(true)}
+        onDeleteAccount={() => setShowDeleteAccountConfirm(true)}
+      />
 
       <ConfirmationModal
         isOpen={pendingDeleteId !== null}
@@ -741,6 +721,12 @@ export function SidePanelBody() {
       />
 
       <AuthModal isOpen={isAuthModalOpen} onClose={() => setIsAuthModalOpen(false)} />
+
+      <AccountDetailsModal
+        isOpen={isAccountDetailsOpen}
+        onClose={() => setIsAccountDetailsOpen(false)}
+        onDeleteAccount={() => setShowDeleteAccountConfirm(true)}
+      />
     </>
   )
 }

--- a/src/components/SidePanel/UsageLimits.tsx
+++ b/src/components/SidePanel/UsageLimits.tsx
@@ -10,11 +10,11 @@ import type { AccountTier } from '@/hooks/useAccountTier'
 const STAT_TILE_LABEL_CLASS =
   "font-['Avenir',sans-serif] text-[12px] leading-[140%] font-medium text-[#9B9EA3]"
 const STAT_TILE_VALUE_CLASS =
-  "font-['JetBrains_Mono',monospace] text-[14px] leading-[140%] font-normal text-right text-[#9B9EA3] flex-1"
+  "font-['Avenir',sans-serif] text-[14px] leading-[140%] font-normal text-right text-[#9B9EA3] flex-1"
 const TIER_ROW_LABEL_CLASS =
   "font-['Avenir',sans-serif] text-[12px] leading-[18px] font-normal text-[#C9CED4]"
 const TIER_ROW_NUM_CLASS =
-  "font-['JetBrains_Mono',monospace] text-[12px] leading-[140%] font-normal text-[#C9CED4] text-center"
+  "font-['Avenir',sans-serif] text-[12px] leading-[140%] font-normal text-[#C9CED4] text-center"
 const COL_HEADER_CLASS =
   "font-['Avenir',sans-serif] text-[12px] leading-[140%] font-medium text-[#9B9EA3]"
 

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,148 @@
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { ChevronRight } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * Deliberately *not* themed off the shadcn `--popover` token.
+ *
+ * `index.css:21` defines it as `217 33% 17%` — a blue-tinted slate inherited
+ * from the default palette. Every floating surface in this product is the
+ * panel's neutral `#171717` on a `#404040` border, so a menu on `bg-popover`
+ * arrives subtly and inexplicably blue against the panel it hangs off. The
+ * colours below match `TileMenuButton` in `SidePanel/SidePanelBody.tsx`, which
+ * is the menu this one sits four pixels away from.
+ *
+ * Every surface portals to `document.body` (Radix's default), which is load
+ * bearing rather than incidental: `GlobalSidePanel` is `overflow-hidden` and
+ * the panel carries a `transform`, so an in-flow menu is clipped and a
+ * `position: fixed` one is trapped. Same hazard `Modal.tsx` documents.
+ */
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+
+const SURFACE_CLASS =
+  "z-50 min-w-[8rem] overflow-hidden rounded-md border border-[#404040] bg-[#171717] p-1 " +
+  "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 " +
+  "data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 " +
+  "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 " +
+  "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
+
+const SURFACE_SHADOW = { filter: "drop-shadow(0 4px 6px rgba(0, 0, 0, 0.3))" }
+
+// Radix moves DOM focus onto an item on hover as well as on arrow-key
+// traversal, so `focus:` covers both and a separate `hover:` rule would only
+// diverge from the keyboard highlight.
+const ITEM_CLASS =
+  "relative flex cursor-pointer select-none items-center gap-2 rounded px-3 py-2 text-sm " +
+  "text-[#c9ced4] outline-none transition-colors focus:bg-white/5 focus:text-[#dadee5] " +
+  "data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(ITEM_CLASS, "data-[state=open]:bg-white/5", className)}
+    {...props}
+  >
+    {children}
+    <ChevronRight size={14} className="ml-auto shrink-0" />
+  </DropdownMenuPrimitive.SubTrigger>
+))
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    style={SURFACE_SHADOW}
+    className={cn(SURFACE_CLASS, className)}
+    {...props}
+  />
+))
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      style={SURFACE_SHADOW}
+      className={cn(SURFACE_CLASS, className)}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    destructive?: boolean
+  }
+>(({ className, destructive, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      ITEM_CLASS,
+      destructive && "text-destructive focus:text-destructive",
+      className,
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn("px-3 py-2 text-sm text-[#6b6e73]", className)}
+    {...props}
+  />
+))
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-[#404040]", className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+}

--- a/src/components/ui/glassButton.ts
+++ b/src/components/ui/glassButton.ts
@@ -35,15 +35,22 @@ export const destructiveGlassButtonClass = `
 `
 
 /**
- * A sidebar tab in a modal's left rail. Active tabs take the brand fill; the
- * rest stay flat until hovered.
+ * A tab in a modal's section rail. Active tabs take the brand fill; the rest
+ * stay flat until hovered.
+ *
+ * Serves both orientations from one string. Below `sm` the rail is a horizontal
+ * strip, where a tab must keep its intrinsic width and refuse to wrap or shrink
+ * — `w-full` there would give every tab the strip's width, and a flex child's
+ * default `min-width: auto` would let long labels squeeze instead of overflow,
+ * which is what makes the strip scroll in the first place.
  */
 export function modalSidebarTabClass(isActive: boolean): string {
   // An explicit focus ring, because the modal autofocuses its first tab on open
   // and the browser default paints a heavy halo there before the user has done
   // anything. Keyboard users still get a clear indicator, just a quieter one.
   return `
-    w-full py-[9px] px-[11px] rounded-[10px] text-left
+    w-auto shrink-0 whitespace-nowrap sm:w-full
+    py-[9px] px-[11px] rounded-[10px] text-left
     font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-colors
     border border-transparent
     outline-none focus-visible:ring-1 focus-visible:ring-white/40
@@ -53,3 +60,41 @@ export function modalSidebarTabClass(isActive: boolean): string {
     }
   `
 }
+
+/**
+ * The rail container: a full-height column down the left at `sm` and above, a
+ * band across the top below it.
+ *
+ * It only stacks its groups — scrolling belongs to the groups themselves, so a
+ * rail with two of them (the Events modal: pages, then category filters) gets
+ * two independently scrolling strips on mobile rather than one flattened row.
+ * Collapsing those into a single strip would imply they are the same kind of
+ * choice.
+ */
+export const modalRailClass = `
+  flex flex-col min-w-0
+  border-b border-[rgba(210,210,210,0.2)]
+  sm:w-[200px] sm:shrink-0 sm:h-full sm:p-3 sm:gap-1 sm:overflow-y-auto
+  sm:border-b-0 sm:border-r sm:bg-[#141415]
+`
+
+/**
+ * A group of tabs inside the rail: a horizontally scrolling strip below `sm`, a
+ * plain column above it.
+ *
+ * `scrollbar-hide` (index.css) suppresses the bar on the strip. The signal that
+ * more tabs exist is the reference's own — the strip is not padded to fit, so an
+ * overflowing tab stays visibly clipped at the edge. `TIMELINE_ARCHITECTURE.md`
+ * §Discoverability records what happens when a hidden scrollbar is the *only*
+ * thing standing in for that signal.
+ */
+export const modalRailGroupClass = `
+  flex flex-row gap-[2px] px-3 py-2
+  overflow-x-auto overflow-y-hidden scrollbar-hide
+  sm:flex-col sm:overflow-visible sm:p-0
+`
+
+/** Separates two groups. A rule on the column, a row edge on the strip. */
+export const modalRailDividerClass = `
+  hidden sm:block h-px w-full bg-[rgba(210,210,210,0.2)] my-1
+`

--- a/src/components/ui/glassButton.ts
+++ b/src/components/ui/glassButton.ts
@@ -1,0 +1,55 @@
+/**
+ * The glass button styles used by the full-size modals.
+ *
+ * Lifted out of `EventTableEditor` when the Account Details modal adopted the
+ * same shell, because two copies of a shadow-and-blur recipe drift the moment
+ * either one is nudged — and these are the buttons a user sees side by side
+ * across the two surfaces.
+ */
+
+/** Secondary action — Cancel, Close, Add. */
+export const glassButtonClass = `
+  relative min-w-[80px] px-[11px] py-[6px] rounded-[10px]
+  backdrop-blur-[12px] bg-white/10 border border-white/[0.15]
+  shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
+  font-['Avenir',sans-serif] font-medium text-[14px] text-[#c9ced4]
+  hover:bg-white/20 hover:text-[#dadee5] transition-all
+`
+
+/** Primary action — Save. Same geometry, brand fill. */
+export const primaryGlassButtonClass = `
+  relative min-w-[80px] px-[11px] py-[6px] rounded-[10px]
+  backdrop-blur-[12px] bg-[rgba(37,99,235,0.8)] border border-white/[0.15]
+  shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
+  font-['Avenir',sans-serif] font-medium text-[14px] text-[#dadee5]
+  hover:bg-[rgba(37,99,235,0.9)] transition-all
+`
+
+/** Destructive action. Same geometry so it sits in a footer row unchanged. */
+export const destructiveGlassButtonClass = `
+  relative min-w-[80px] px-[11px] py-[6px] rounded-[10px]
+  backdrop-blur-[12px] bg-destructive/20 border border-destructive/40
+  shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]
+  font-['Avenir',sans-serif] font-medium text-[14px] text-destructive
+  hover:bg-destructive/30 transition-all
+`
+
+/**
+ * A sidebar tab in a modal's left rail. Active tabs take the brand fill; the
+ * rest stay flat until hovered.
+ */
+export function modalSidebarTabClass(isActive: boolean): string {
+  // An explicit focus ring, because the modal autofocuses its first tab on open
+  // and the browser default paints a heavy halo there before the user has done
+  // anything. Keyboard users still get a clear indicator, just a quieter one.
+  return `
+    w-full py-[9px] px-[11px] rounded-[10px] text-left
+    font-['Avenir',sans-serif] font-medium text-[14px] leading-[20px] transition-colors
+    border border-transparent
+    outline-none focus-visible:ring-1 focus-visible:ring-white/40
+    ${isActive
+      ? 'bg-[rgba(37,99,235,0.4)] text-[#dadee5]'
+      : 'bg-transparent text-[#c9ced4] hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[#dadee5]'
+    }
+  `
+}

--- a/src/constants/tierLabels.ts
+++ b/src/constants/tierLabels.ts
@@ -1,0 +1,65 @@
+import type { AccountTier } from '@/hooks/useAccountTier'
+
+/**
+ * The user-facing name for each state `useAccountTier()` can return.
+ *
+ * One module because three surfaces name these states — the account row at the
+ * bottom of the side panel, the Account Details modal, and `UsageLimits` — and
+ * three files inventing their own wording is how the same tier ends up called
+ * "Your API key" in one place and "API Key Connected" in another. Same reason
+ * `constants/byokProviders.ts` exists for provider names.
+ *
+ * `byok-anon` and `byok` share a label deliberately. They differ in where the
+ * work is stored, not in what the key does, and limits do not vary by provider
+ * — so the row has nothing tier-shaped to say that distinguishes them. The
+ * account/no-account difference is already carried by the identity beside it.
+ */
+export const TIER_LABELS: Record<Exclude<AccountTier, 'loading'>, string> = {
+  trial: 'Not saved',
+  'byok-anon': 'Your API key',
+  free: 'Free',
+  byok: 'Your API key',
+}
+
+/**
+ * What each tier actually grants, for surfaces with room to explain rather than
+ * just label. Kept beside the labels so the two cannot drift apart.
+ */
+export const TIER_DESCRIPTIONS: Record<Exclude<AccountTier, 'loading'>, string> = {
+  trial:
+    'Timelines you build stay in this tab and are lost when it closes. Sign in or add an API key to keep them.',
+  'byok-anon':
+    'Drafts are saved in this browser only, and AI runs on your own API key. Sign in to save them to your account.',
+  free:
+    'Timelines are saved to your account. AI generation runs on our budget, within a daily limit.',
+  byok:
+    'Timelines are saved to your account, and AI runs on your own API key rather than our budget.',
+}
+
+/**
+ * The name shown where an account would be. Not a tier label — this is the
+ * identity slot, and the two anonymous states have no identity to put in it.
+ */
+export const ANONYMOUS_IDENTITY = 'Guest'
+
+/**
+ * The part of an email shown on the account row.
+ *
+ * Returned as-is, never capitalised or otherwise prettified: there is no
+ * display-name field to fall back on (identity here is email-only by design),
+ * and every transformation that flatters `alex` mangles `o'brien`.
+ */
+export function emailLocalPart(email: string): string {
+  const at = email.indexOf('@')
+  return at === -1 ? email : email.slice(0, at)
+}
+
+/**
+ * The letter for the avatar circle. Skips leading non-alphanumerics so an
+ * address like `_alex@…` gets `A` rather than an underscore, and falls back to
+ * a dot when there is no alphanumeric at all.
+ */
+export function avatarInitial(email: string): string {
+  const match = emailLocalPart(email).match(/[a-z0-9]/i)
+  return match ? match[0].toUpperCase() : '·'
+}

--- a/src/contexts/SidePanelContext.tsx
+++ b/src/contexts/SidePanelContext.tsx
@@ -34,6 +34,13 @@ interface SidePanelContextValue {
   /** Open the Settings panel. Registered by the editor route; no-op elsewhere. */
   onOpenSettings: OpenSettingsHandler
   setOnOpenSettings: (handler: OpenSettingsHandler | null) => void
+  /**
+   * Whether `onOpenSettings` currently has somewhere to go. State rather than a
+   * read of the ref, because a ref write does not re-render the account menu
+   * that needs to know — and a Settings item that is visibly present and does
+   * nothing is worse than one that isn't there.
+   */
+  hasSettingsHandler: boolean
   activeTimelineId: string | null
   setActiveTimelineId: (id: string | null) => void
   activeDraftId: string | null
@@ -73,6 +80,7 @@ export function SidePanelProvider({ children }: { children: ReactNode }) {
   const [activeTimelineTitle, setActiveTimelineTitle] = useState<string | null>(null)
   const [activeEventCount, setActiveEventCount] = useState<number | null>(null)
   const [activeDominantCategoryColor, setActiveDominantCategoryColor] = useState<string | null>(null)
+  const [hasSettingsHandler, setHasSettingsHandler] = useState(false)
   const navigate = useNavigate()
   const customHandlerRef = useRef<TimelineSelectHandler | null>(null)
   const customDraftHandlerRef = useRef<DraftSelectHandler | null>(null)
@@ -129,6 +137,7 @@ export function SidePanelProvider({ children }: { children: ReactNode }) {
 
   const setOnOpenSettings = useCallback((handler: OpenSettingsHandler | null) => {
     customOpenSettingsRef.current = handler
+    setHasSettingsHandler(Boolean(handler))
   }, [])
 
   const value = useMemo<SidePanelContextValue>(() => ({
@@ -149,6 +158,7 @@ export function SidePanelProvider({ children }: { children: ReactNode }) {
     setRefreshTimelines,
     onOpenSettings,
     setOnOpenSettings,
+    hasSettingsHandler,
     activeTimelineId,
     setActiveTimelineId,
     activeDraftId,
@@ -159,7 +169,7 @@ export function SidePanelProvider({ children }: { children: ReactNode }) {
     setActiveEventCount,
     activeDominantCategoryColor,
     setActiveDominantCategoryColor,
-  }), [isOpen, open, close, toggle, width, setWidth, resetWidth, isResizing, onTimelineSelect, setOnTimelineSelect, onDraftSelect, setOnDraftSelect, refreshTimelines, setRefreshTimelines, onOpenSettings, setOnOpenSettings, activeTimelineId, activeDraftId, activeTimelineTitle, activeEventCount, activeDominantCategoryColor])
+  }), [isOpen, open, close, toggle, width, setWidth, resetWidth, isResizing, onTimelineSelect, setOnTimelineSelect, onDraftSelect, setOnDraftSelect, refreshTimelines, setRefreshTimelines, onOpenSettings, setOnOpenSettings, hasSettingsHandler, activeTimelineId, activeDraftId, activeTimelineTitle, activeEventCount, activeDominantCategoryColor])
 
   return (
     <SidePanelContext.Provider value={value}>

--- a/src/hooks/useIsNarrow.ts
+++ b/src/hooks/useIsNarrow.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Tailwind's `sm` breakpoint, in px. The modals' rails collapse to horizontal
+ * tab strips below it — a 200px rail plus ~320px of content plus padding needs
+ * roughly 570px, so this is where the vertical layout stops fitting.
+ *
+ * Deliberately not `PANEL_RESIZE_BREAKPOINT` (768): that governs the side
+ * panel's resize handles, which is a different question about a different
+ * element.
+ */
+export const NARROW_BREAKPOINT = 640
+
+function isNarrowViewport(): boolean {
+  // Matches the SSR-safe read in `usePanelWidth.ts`. Answering "not narrow"
+  // without a window is the right default: it is the layout the markup
+  // describes before any media query resolves.
+  return typeof window === 'undefined' ? false : window.innerWidth < NARROW_BREAKPOINT
+}
+
+/**
+ * Whether the viewport is below `sm`.
+ *
+ * Layout should use Tailwind's `sm:` prefix instead of this — CSS handles a
+ * breakpoint without a render pass. This exists for the cases a media query
+ * cannot reach, which in practice means props: `EventTableEditor` picks a
+ * dnd-kit sorting strategy and a set of drag modifiers per orientation, and
+ * those are JavaScript values, not classes.
+ */
+export function useIsNarrow(): boolean {
+  const [narrow, setNarrow] = useState(isNarrowViewport)
+
+  useEffect(() => {
+    const query = window.matchMedia(`(max-width: ${NARROW_BREAKPOINT - 0.02}px)`)
+    const sync = () => setNarrow(query.matches)
+    // Re-read on mount as well as on change: the initial `useState` ran during
+    // the first render, and a resize between then and this effect would
+    // otherwise be missed until the next one.
+    sync()
+    query.addEventListener('change', sync)
+    return () => query.removeEventListener('change', sync)
+  }, [])
+
+  return narrow
+}


### PR DESCRIPTION
Redesigns the bottom of the left panel around a single account row and a menu, modelled on the pattern Claude uses in the same position. Two commits: the PRD, then the implementation.

## The problem

The footer (`SidePanelBody.tsx:664-702`) held the user's email beside an unlabelled `LogOut` glyph, and beneath it **Privacy**, **Terms** and **Delete account** as three equal-weight 12px text links. Account deletion was one click from a confirmation dialog, styled identically to a link to the privacy policy. The tier was invisible next to the identity even though `useAccountTier()` already knew it.

## What it becomes

One row — avatar, email local-part, tier, chevron — opening a menu upward with **Settings**, **Account Details**, a **Learn more** submenu holding the two legal pages, **Log Out** and **Delete Account**. Signed-out visitors get the same row with **Sign in** in place of Log Out; `byok-anon` keeps it because the panel is its only sign-in entry point.

Account Details is a modal on the existing `Modal` shell: identity, plan, usage against caps, key status, and a destructive footer.

## Notable implementation details

- **The menu portals**, which is load bearing rather than incidental — `GlobalSidePanel` is `overflow-hidden` and the panel carries a `transform`, so an in-flow menu is clipped and a `position: fixed` one is trapped.
- **Its width is measured off the trigger** (`calc(var(--radix-dropdown-menu-trigger-width) + 48px)`), not fixed. No literal can stay wider than the card across the 300–400px resize range: 260px was narrower than the 314px default. This is the one thing that failed first time round.
- **`ui/dropdown-menu.tsx` is themed to the panel's neutral palette**, not the shadcn `--popover` token (`index.css:21`), which is a blue-tinted slate.
- **Account Details reads caps from `PLAN_LIMITS[tier]`**, not `useEventUsage`'s limits — those come from a module-level cache refreshed by an async `auth.getUser()` and showed a `byok` account 3/150 while the card beside it showed 25. Counts still come from the hook. Same split `UsageLimits.tsx:45-49` already makes.

## Two fixes carried along

- **Legal links open new tabs.** `/privacy` and `/terms` mount outside `LayoutRoute` (`Router.tsx:33-40`), so the old in-tab `<Link>`s unmounted the editor.
- **Sign-out goes through `AuthContext.signOut()`.** The direct `supabase.auth.signOut()` call skipped `clearAllCachedEvents()`, leaving events from viewed shared timelines cached after sign-out — but only for a sign-out taken from this panel, which is why it went unnoticed.

## Untouched, by decision

`TimelineSettingsPanel`, `ApiKeySection`, `UsageLimits`. Settings points at the existing panel unchanged, hidden where no handler is registered (`hasSettingsHandler`, new on `SidePanelContext`). Slimming the usage card is specced as a phase 2 in the PRD.

## Verification

Driven with Playwright against `npm run dev` — **55 assertions across two suites, all passing**:

- Menu clears the panel at both ends of the resize range: 312px menu vs 294px card at `PANEL_MIN_WIDTH`, 411 vs 394 at `PANEL_MAX_WIDTH`. Submenu clears it too (right edge x=569).
- Submenu opens on hover and holds across the pointer gap; Enter opens the menu, ArrowDown moves onto the first item, Escape closes and returns focus to the row.
- All four tier states render the right row and menu. Local-parts are left unprettified — `a.o-brien@example.com` renders as `a.o-brien`.
- Legal links carry `target="_blank" rel="noopener noreferrer"` and load in a second tab with the original tab intact.
- Delete Account is `rgb(174, 41, 41)` against Log Out's `rgb(201, 206, 212)`.
- No layer leak: closing the modal leaves `body` at `pointer-events: auto` and the menu reopens.

`npx tsc --noEmit -p tsconfig.app.json` holds at the 16-error pre-existing baseline, none in touched files. `npm run lint` clean.

**Not verified** — recorded in PRD §8 rather than glossed: the `loading` window never rendering "Guest" (needs a real session; the stub resolves auth too fast to observe it), sign-out actually clearing the viewer cache, Delete Account end to end from the new entry point, and unsaved editor state surviving a legal-link click. All four need a reachable Supabase.

The PRD also corrects a stale note in `CLAUDE.md`, which lists account deletion as never exercised — the 7 August runbook has it verified end to end.