### PR TITLE
Replace usage counts with bar meters, and refresh them from the write layer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { TrialGateModal } from './components/Modal/TrialGateModal';
 import { ApiKeyModal } from './components/Modal/ApiKeyModal';
 import { AuthModal } from './components/Auth/AuthModal';
 import { exportEventsToExcel } from './utils/excelExport';
+import { notifyUsageChanged } from './utils/usageChanged';
 import { EventDetailPanel } from './components/EventDetailPanel/EventDetailPanel';
 import { useLocalDraft } from './hooks/useLocalDraft';
 import { useAccountTier, type AccountTier } from './hooks/useAccountTier';
@@ -898,6 +899,9 @@ export function App() {
     // realtime DELETE event isn't fast enough to rely on here.
     setActiveTimelineId(null);
     refreshTimelines();
+    // Refreshes rows and tile metadata but never the usage counts, and realtime
+    // cannot report a delete — see `utils/usageChanged.ts`.
+    notifyUsageChanged();
 
     setTitle(DEFAULT_TIMELINE_TITLE);
     setDescription('');

--- a/src/components/Modal/AccountDetailsModal.tsx
+++ b/src/components/Modal/AccountDetailsModal.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '@/hooks/useAuth'
 import { useAccountTier } from '@/hooks/useAccountTier'
 import { useEventUsage } from '@/hooks/useEventUsage'
 import { useSidePanel } from '@/hooks/useSidePanel'
+import { UsageMeter } from '@/components/ui/UsageMeter'
 import { maskKey, useByokCredential } from '@/services/userApiKey'
 import { PLAN_LIMITS } from '@/constants/plans'
 import { PROVIDER_META } from '@/constants/byokProviders'
@@ -201,7 +202,7 @@ function UsagePane() {
   // reads a module-level cache refreshed by an async `auth.getUser()`; it lags
   // an auth or key transition by a frame and holds its 'byok-anon' initial
   // value if that call never lands.
-  const { eventCount, timelineCount } = useEventUsage()
+  const { eventCount, timelineCount, isLoading } = useEventUsage()
   const credential = useByokCredential()
   const { onOpenSettings, hasSettingsHandler } = useSidePanel()
 
@@ -218,8 +219,28 @@ function UsagePane() {
         <div>
           <FieldLabel>Usage</FieldLabel>
           <div className="flex flex-col gap-1.5 mt-1.5">
-            <UsageRow label="Timelines" count={timelineCount} limit={caps.timelineLimit} />
-            <UsageRow label="Events" count={eventCount} limit={caps.eventLimit} />
+            {/* Same meter the side panel's Usage Limits card uses. The track
+                tone differs because the surfaces nest in opposite directions:
+                these rows are recessed to #0A0A0A inside a #171717 modal, so
+                the panel's near-black track would vanish here. */}
+            <UsageMeter
+              label="Timelines"
+              count={timelineCount}
+              limit={caps.timelineLimit}
+              size="md"
+              pending={isLoading}
+              trackClass="bg-[#262626]"
+              className="bg-[#0A0A0A] rounded-md px-3 py-1.5"
+            />
+            <UsageMeter
+              label="Events"
+              count={eventCount}
+              limit={caps.eventLimit}
+              size="md"
+              pending={isLoading}
+              trackClass="bg-[#262626]"
+              className="bg-[#0A0A0A] rounded-md px-3 py-1.5"
+            />
           </div>
         </div>
       )}
@@ -317,28 +338,6 @@ function Field({
       <FieldLabel>{label}</FieldLabel>
       <p className="mt-1 text-[14px] leading-[20px] text-[#dadee5] break-all">{value}</p>
       {hint && <p className="text-[12px] leading-[18px] text-[#6b6e73] mt-1">{hint}</p>}
-    </div>
-  )
-}
-
-function UsageRow({
-  label,
-  count,
-  limit,
-}: {
-  label: string
-  count: number
-  limit: number | null
-}) {
-  return (
-    <div className="flex items-center justify-between gap-2 bg-[#0A0A0A] rounded-md px-3 py-1.5">
-      <span className="font-['Avenir',sans-serif] text-[13px] leading-[18px] text-[#c9ced4]">
-        {label}
-      </span>
-      <span className="font-['Avenir',sans-serif] text-[13px] leading-[18px] text-[#9b9ea3]">
-        {count}
-        {limit == null ? '' : ` / ${limit}`}
-      </span>
     </div>
   )
 }

--- a/src/components/SidePanel/SidePanelBody.tsx
+++ b/src/components/SidePanel/SidePanelBody.tsx
@@ -29,6 +29,7 @@ import {
   MAX_DRAFTS,
   type LocalDraft,
 } from '@/utils/draftStorage'
+import { notifyUsageChanged } from '@/utils/usageChanged'
 import { exportEventsToExcel } from '@/utils/excelExport'
 import { downloadTemplate } from '@/utils/excelSheet'
 import type { TimelineEvent } from '@/types/event'
@@ -354,6 +355,9 @@ export function SidePanelBody() {
           .eq('id', pendingDeleteId)
         if (deleteError) throw deleteError
         loadTimelines()
+        // The row set changed, so the usage counts did too. Realtime cannot
+        // report a delete on either table — see `utils/usageChanged.ts`.
+        notifyUsageChanged()
       } else {
         byokAnonDraftStore.deleteDraft(pendingDeleteId)
         setLocalDrafts(byokAnonDraftStore.getAllDrafts())
@@ -534,6 +538,7 @@ export function SidePanelBody() {
       }
 
       loadTimelines()
+      notifyUsageChanged()
     } catch (err) {
       console.error('Error duplicating timeline:', err)
       alert('Failed to duplicate timeline. Please try again.')

--- a/src/components/SidePanel/UsageLimits.tsx
+++ b/src/components/SidePanel/UsageLimits.tsx
@@ -4,24 +4,23 @@ import { useEventUsage } from '@/hooks/useEventUsage'
 import { useSidePanel } from '@/hooks/useSidePanel'
 import { AuthModal } from '@/components/Auth/AuthModal'
 import { ApiKeyModal } from '@/components/Modal/ApiKeyModal'
+import { UsageMeter } from '@/components/ui/UsageMeter'
 import { PLAN_LIMITS } from '@/constants/plans'
 import type { AccountTier } from '@/hooks/useAccountTier'
 
-const STAT_TILE_LABEL_CLASS =
+const TRIAL_LABEL_CLASS =
   "font-['Avenir',sans-serif] text-[12px] leading-[140%] font-medium text-[#9B9EA3]"
-const STAT_TILE_VALUE_CLASS =
-  "font-['Avenir',sans-serif] text-[14px] leading-[140%] font-normal text-right text-[#9B9EA3] flex-1"
-const TIER_ROW_LABEL_CLASS =
-  "font-['Avenir',sans-serif] text-[12px] leading-[18px] font-normal text-[#C9CED4]"
-const TIER_ROW_NUM_CLASS =
-  "font-['Avenir',sans-serif] text-[12px] leading-[140%] font-normal text-[#C9CED4] text-center"
-const COL_HEADER_CLASS =
-  "font-['Avenir',sans-serif] text-[12px] leading-[140%] font-medium text-[#9B9EA3]"
+const CTA_TEXT_CLASS =
+  "m-0 px-2 font-['Avenir',sans-serif] text-[12px] leading-[16px] text-[#6b6e73]"
+// One class for every inline call to action in this card — the trial copy and
+// the upgrade line both used their own copy of this string before.
+const LINK_CLASS =
+  "font-['Avenir',sans-serif] text-[12px] leading-[18px] font-normal underline text-text-secondary hover:text-text-primary transition-colors"
 
 export function UsageLimits() {
   const tier = useAccountTier()
-  const { eventCount, timelineCount } = useEventUsage()
-  const { onOpenSettings } = useSidePanel()
+  const { eventCount, timelineCount, isLoading } = useEventUsage()
+  const { onOpenSettings, hasSettingsHandler } = useSidePanel()
 
   const [showAuthModal, setShowAuthModal] = useState(false)
   const [showApiKeyModal, setShowApiKeyModal] = useState(false)
@@ -42,7 +41,7 @@ export function UsageLimits() {
     onOpenSettings()
   }
 
-  // Caps for the table — pulled from PLAN_LIMITS so this stays in sync with
+  // Caps for the meters — pulled from PLAN_LIMITS so this stays in sync with
   // the data layer without depending on the resolver's current value.
   const byokAnonCaps = PLAN_LIMITS['byok-anon']
   const freeCaps = PLAN_LIMITS.free
@@ -50,7 +49,7 @@ export function UsageLimits() {
 
   // The trial has no plan and no numbers to show. Until it holds something
   // there is nothing worth saying at all, so the card renders as a single line
-  // rather than a tier table someone hasn't opted into yet.
+  // rather than meters against caps someone hasn't opted into yet.
   if (tier === 'loading') return null
 
   if (tier === 'trial') {
@@ -80,8 +79,9 @@ export function UsageLimits() {
   const timelineCap = currentCaps.timelineLimit
   const eventCap = currentCaps.eventLimit
 
-  const headerCta = renderHeaderCta({
+  const cta = renderUpgradeCta({
     tier,
+    hasSettingsHandler,
     onLogIn: handleLogIn,
     onAddKey: handleAddApiKey,
     onManageKey: handleManageApiKey,
@@ -90,86 +90,32 @@ export function UsageLimits() {
   return (
     <>
       <div className="px-3 pb-2.5">
-        <div className="bg-[#0A0A0A] rounded-[8px] pt-4 pb-3 px-2 flex flex-col gap-4">
+        <div className="bg-[#0A0A0A] rounded-[8px] pt-4 pb-3 px-2 flex flex-col gap-3">
           {/* Header row */}
-          <div className="flex flex-row items-center justify-between px-2">
+          <div className="flex flex-row items-center px-2">
             <h3 className="m-0 font-['Aleo',serif] text-[14px] leading-[140%] font-normal text-[#9B9EA3]">
               Usage Limits
             </h3>
-            {headerCta}
           </div>
 
-          {/* Stat tiles */}
-          <div className="flex flex-row items-start gap-2">
-            <StatTile
+          {/* Meters. The sub-card steps *up* to #171717 — #0A0A0A is already the
+              darkest surface in the system, so a nested tile can only lighten. */}
+          <div className="bg-[#171717] rounded-md px-2.5 py-2 flex flex-col gap-2">
+            <UsageMeter
               label="Timelines"
-              value={`${timelineCount}/${timelineCap ?? ''}`}
+              count={timelineCount}
+              limit={timelineCap}
+              pending={isLoading}
             />
-            <StatTile
+            <UsageMeter
               label="Events"
-              value={
-                tier === 'byok'
-                  ? '♾️'
-                  : `${eventCount}/${eventCap ?? ''}`
-              }
-              ariaLabel={tier === 'byok' ? 'unlimited' : undefined}
+              count={eventCount}
+              limit={eventCap}
+              pending={isLoading}
             />
           </div>
 
-          {/* Tier table — hidden in BYOK state */}
-          {tier !== 'byok' && (
-            <div className="flex flex-col items-start w-full">
-              {/* Column header */}
-              <div className="flex flex-row justify-between items-center px-2 py-1 gap-1 w-full">
-                <span className={COL_HEADER_CLASS}>Tier</span>
-                <div className="flex flex-row items-center gap-2.5 w-[140px]">
-                  <span className={`${COL_HEADER_CLASS} w-[65px] text-center`}>
-                    Timelines
-                  </span>
-                  <span className={`${COL_HEADER_CLASS} w-[65px] text-center`}>
-                    Events
-                  </span>
-                </div>
-              </div>
-
-              {tier === 'byok-anon' ? (
-                <>
-                  <TierRow
-                    label="Your API key"
-                    timelineCap={byokAnonCaps.timelineLimit}
-                    eventCap={byokAnonCaps.eventLimit}
-                    variant="highlighted"
-                  />
-                  {/* Signing in from here lands on byok, not free — the key is
-                      already in hand, so projecting the free caps would
-                      understate what logging in actually gets you. */}
-                  <TierRow
-                    label="Log In"
-                    timelineCap={byokCaps.timelineLimit}
-                    eventCap="Unlimited"
-                    variant="subtle"
-                    onClick={handleLogIn}
-                  />
-                </>
-              ) : (
-                <>
-                  <TierRow
-                    label="Your Account"
-                    timelineCap={freeCaps.timelineLimit}
-                    eventCap={freeCaps.eventLimit}
-                    variant="highlighted"
-                  />
-                  <TierRow
-                    label="Add API Key"
-                    timelineCap={byokCaps.timelineLimit}
-                    eventCap="Unlimited"
-                    variant="link"
-                    onClick={handleAddApiKey}
-                  />
-                </>
-              )}
-            </div>
-          )}
+          {cta}
         </div>
       </div>
 
@@ -187,46 +133,84 @@ export function UsageLimits() {
   )
 }
 
-function renderHeaderCta({
+/** "25 timelines", "1,200 events" — or "unlimited events" if a cap ever goes null. */
+function capPhrase(limit: number | null, noun: string): string {
+  return limit == null ? `unlimited ${noun}` : `${limit.toLocaleString()} ${noun}`
+}
+
+/**
+ * The card's entire upgrade path, in one sentence.
+ *
+ * This replaced a three-column tier comparison table. The numbers are
+ * interpolated from PLAN_LIMITS rather than written out, because the copy this
+ * replaced said "Unlimited" events while PLAN_LIMITS.byok.eventLimit was 1200
+ * and isOverEventLimit enforced it — a BYOK user was told there was no cap and
+ * then stopped at one.
+ */
+function renderUpgradeCta({
   tier,
+  hasSettingsHandler,
   onLogIn,
   onAddKey,
   onManageKey,
 }: {
   tier: AccountTier
+  hasSettingsHandler: boolean
   onLogIn: () => void
   onAddKey: () => void
   onManageKey: () => void
 }) {
-  const baseClass =
-    "font-['Avenir',sans-serif] text-[12px] leading-[18px] font-normal underline text-text-secondary hover:text-text-primary transition-colors"
+  const byokCaps = PLAN_LIMITS.byok
+  const byokPhrase = `${capPhrase(byokCaps.timelineLimit, 'timelines')} and ${capPhrase(
+    byokCaps.eventLimit,
+    'events'
+  )}`
+
+  // Signing in from here lands on byok, not free — the key is already in hand,
+  // so projecting the free caps would understate what logging in actually gets.
   if (tier === 'byok-anon') {
     return (
-      <button type="button" onClick={onLogIn} className={baseClass}>
-        Log In
-      </button>
+      <p className={CTA_TEXT_CLASS}>
+        <button type="button" onClick={onLogIn} className={LINK_CLASS}>
+          Log in
+        </button>{' '}
+        to save your timelines to your account and raise your limits to {byokPhrase}.
+      </p>
     )
   }
+
   if (tier === 'free') {
     return (
-      <button type="button" onClick={onAddKey} className={baseClass}>
-        Add API Key
-      </button>
+      <p className={CTA_TEXT_CLASS}>
+        <button type="button" onClick={onAddKey} className={LINK_CLASS}>
+          Add API Key
+        </button>{' '}
+        to unlock {byokPhrase}.
+      </p>
     )
   }
+
+  // byok is the top tier: nothing left to sell, and the meters above already
+  // state the caps. The only thing left is a way to manage the key — and
+  // onOpenSettings is a no-op off the editor route, where nothing registers a
+  // handler. With nowhere to send anyone, say nothing rather than render a
+  // link that silently does nothing.
+  if (!hasSettingsHandler) return null
   return (
-    <button type="button" onClick={onManageKey} className={baseClass}>
-      API Key Connected
-    </button>
+    <p className={CTA_TEXT_CLASS}>
+      Your API key is connected.{' '}
+      <button type="button" onClick={onManageKey} className={LINK_CLASS}>
+        Manage it in Settings.
+      </button>
+    </p>
   )
 }
 
 /**
  * The trial's entire presence in this panel.
  *
- * Not a TierRow and not a stat tile: this visitor has no plan, no caps and no
- * saved timeline list, and dressing the state up as a row in the tier table
- * would imply all three.
+ * Not a meter and not a stat tile: this visitor has no plan, no caps and no
+ * saved timeline list, and drawing a bar against a limit would imply all three.
  *
  * It does still always render, though — this is the only way in to sign-in or
  * BYOK from the side panel, and the whole tier table it replaced carried those
@@ -242,14 +226,12 @@ function TrialStatus({
   onLogIn: () => void
   onAddKey: () => void
 }) {
-  const linkClass =
-    "font-['Avenir',sans-serif] text-[12px] leading-[18px] font-normal underline text-text-secondary hover:text-text-primary transition-colors"
   const hasWork = eventCount > 0
 
   return (
     <div className="px-3 pb-2.5">
       <div className="bg-[#0A0A0A] rounded-[8px] py-3 px-4 flex flex-col gap-1.5">
-        <span className={STAT_TILE_LABEL_CLASS}>
+        <span className={TRIAL_LABEL_CLASS}>
           {hasWork
             ? `${eventCount} event${eventCount === 1 ? '' : 's'} · not saved`
             : 'Nothing saved yet'}
@@ -258,96 +240,16 @@ function TrialStatus({
           {hasWork
             ? 'This timeline lives in this tab only. '
             : 'Timelines you build stay in this tab. '}
-          <button type="button" onClick={onLogIn} className={linkClass}>
+          <button type="button" onClick={onLogIn} className={LINK_CLASS}>
             Log in
           </button>{' '}
           or{' '}
-          <button type="button" onClick={onAddKey} className={linkClass}>
+          <button type="button" onClick={onAddKey} className={LINK_CLASS}>
             add an API key
           </button>{' '}
           {hasWork ? 'to keep it.' : 'to keep them.'}
         </span>
       </div>
-    </div>
-  )
-}
-
-function StatTile({
-  label,
-  value,
-  ariaLabel,
-}: {
-  label: string
-  value: string
-  ariaLabel?: string
-}) {
-  return (
-    <div className="flex-1 flex flex-col justify-center items-start bg-[#171717] rounded-md px-2 py-1 h-9">
-      <div className="flex flex-row items-center px-0 py-1 gap-2 w-full">
-        <span className={STAT_TILE_LABEL_CLASS}>{label}</span>
-        <span className={STAT_TILE_VALUE_CLASS} aria-label={ariaLabel}>
-          {value}
-        </span>
-      </div>
-    </div>
-  )
-}
-
-function TierRow({
-  label,
-  timelineCap,
-  eventCap,
-  variant,
-  onClick,
-}: {
-  label: string
-  timelineCap: number | string | null
-  eventCap: number | string | null
-  variant: 'highlighted' | 'subtle' | 'link'
-  onClick?: () => void
-}) {
-  const bg =
-    variant === 'highlighted'
-      ? 'bg-[rgba(37,99,235,0.25)]'
-      : variant === 'subtle'
-        ? 'bg-[rgba(23,23,23,0.25)]'
-        : ''
-  const labelClass =
-    variant === 'highlighted'
-      ? TIER_ROW_LABEL_CLASS
-      : `${TIER_ROW_LABEL_CLASS} underline`
-  const interactive = variant !== 'highlighted' && !!onClick
-
-  const content = (
-    <div className="flex flex-row justify-between items-center w-full">
-      <span className={labelClass}>{label}</span>
-      <div className="flex flex-row items-center gap-2.5 w-[140px]">
-        <span className={`${TIER_ROW_NUM_CLASS} w-[65px]`}>
-          {timelineCap ?? 'Unlimited'}
-        </span>
-        <span className={`${TIER_ROW_NUM_CLASS} w-[65px]`}>
-          {eventCap ?? 'Unlimited'}
-        </span>
-      </div>
-    </div>
-  )
-
-  if (interactive) {
-    return (
-      <button
-        type="button"
-        onClick={onClick}
-        className={`flex flex-row justify-between items-center px-2 py-1 gap-1 w-full h-7 rounded-md ${bg} hover:bg-white/5`}
-      >
-        {content}
-      </button>
-    )
-  }
-  return (
-    <div
-      className={`flex flex-row justify-between items-center px-2 py-1 gap-1 w-full h-7 rounded-md ${bg}`}
-    >
-      {content}
     </div>
   )
 }

--- a/src/components/ui/UsageMeter.tsx
+++ b/src/components/ui/UsageMeter.tsx
@@ -1,0 +1,137 @@
+import { cn } from '@/lib/utils'
+
+/**
+ * A labelled usage bar: `label · used/cap · ▬▬▬`.
+ *
+ * The app's first `role="progressbar"` — usage was reported as bare text
+ * everywhere before this, which is accurate but says nothing about how close a
+ * cap actually is.
+ *
+ * Two surfaces render it and they nest in opposite directions, which is why the
+ * track tone is a prop rather than a constant: the side panel's card is #0A0A0A
+ * with the meter sub-card stepping *up* to #171717, while the account modal is
+ * #171717 with its rows recessed *down* to #0A0A0A. One tone cannot read on
+ * both.
+ *
+ * The label and value share a single fixed-width head group rather than sizing
+ * to their content, so every bar starts at the same x — including across the
+ * modal's separate per-row cards, which no shared grid parent could span.
+ */
+
+type UsageMeterSize = 'sm' | 'md'
+
+const SIZES = {
+  sm: {
+    gap: 'gap-2',
+    head: 'w-[112px] gap-1.5',
+    label: "font-['Avenir',sans-serif] text-[12px] leading-[140%] font-medium text-[#C9CED4]",
+    value:
+      "font-['Avenir',sans-serif] text-[12px] leading-[140%] font-normal text-[#9B9EA3] tabular-nums",
+  },
+  md: {
+    gap: 'gap-2.5',
+    head: 'w-[148px] gap-2',
+    label: "font-['Avenir',sans-serif] text-[13px] leading-[18px] text-[#C9CED4]",
+    value: "font-['Avenir',sans-serif] text-[13px] leading-[18px] text-[#9B9EA3] tabular-nums",
+  },
+} as const
+
+interface UsageMeterProps {
+  label: string
+  count: number
+  /**
+   * `null` is this codebase's spelling of "no limit" (see `isOverEventLimit`).
+   * It renders the word "Unlimited" in the bar slot rather than a bar: a full
+   * one would say "you are maxed out" and an empty one "you have nothing", and
+   * both are false.
+   */
+  limit: number | null
+  /** 'sm' for the side panel, 'md' for the account modal. */
+  size?: UsageMeterSize
+  /**
+   * First load not yet resolved. `useEventUsage` starts both counts at 0, so
+   * without this every mount paints an empty bar and then animates it up —
+   * which looks far more like real data than the text tiles ever did.
+   */
+  pending?: boolean
+  /** Container chrome. Each consumer supplies its own surface. */
+  className?: string
+  /** Track tone, which depends on the parent surface. See the note above. */
+  trackClass?: string
+}
+
+/**
+ * Fill percentage, clamped at both ends. A count can exceed its cap after a
+ * downgrade — removing an API key drops byok's 1200 to free's 300 with the
+ * events still in place — so the top clamp is a real case, not defensiveness.
+ */
+function meterPercent(count: number, limit: number): number {
+  if (!Number.isFinite(count)) return 0
+  // A zero cap is not "0% used". Any usage at all against it is over.
+  if (limit <= 0) return count > 0 ? 100 : 0
+  return Math.min(100, Math.max(0, (count / limit) * 100))
+}
+
+export function UsageMeter({
+  label,
+  count,
+  limit,
+  size = 'sm',
+  pending = false,
+  className,
+  trackClass = 'bg-[#0A0A0A]',
+}: UsageMeterProps) {
+  const s = SIZES[size]
+
+  const head = (
+    <div className={cn('flex flex-row items-baseline shrink-0', s.head)}>
+      <span className={cn('flex-1 min-w-0 truncate', s.label)}>{label}</span>
+      <span className={cn('shrink-0', s.value)}>
+        {pending ? '—' : count}
+        {limit == null ? '' : `/${limit}`}
+      </span>
+    </div>
+  )
+
+  // No cap means no range to draw against, so there is no progressbar either.
+  if (limit == null) {
+    return (
+      <div className={cn('flex flex-row items-center', s.gap, className)}>
+        {head}
+        <span className={cn('flex-1 text-[#6B6E73]', s.value)}>Unlimited</span>
+      </div>
+    )
+  }
+
+  const pct = pending ? 0 : meterPercent(count, limit)
+  const isOver = !pending && count > limit
+
+  return (
+    <div className={cn('flex flex-row items-center', s.gap, className)}>
+      {head}
+      {/* Omitting aria-valuenow while pending is what marks the bar
+          indeterminate; aria-valuetext carries the real count once it lands, so
+          an over-cap state reads "14 of 10" rather than the clamped 100%. */}
+      <div
+        role="progressbar"
+        aria-label={`${label} used`}
+        aria-valuemin={0}
+        aria-valuemax={limit}
+        aria-valuenow={pending ? undefined : count}
+        aria-valuetext={pending ? undefined : `${count} of ${limit}`}
+        aria-busy={pending || undefined}
+        className={cn('flex-1 min-w-[40px] h-[6px] rounded-full overflow-hidden', trackClass)}
+      >
+        <div
+          className={cn(
+            'h-full rounded-full transition-[width] duration-300 ease-out motion-reduce:transition-none',
+            isOver ? 'bg-destructive' : 'bg-[#2563EB]'
+          )}
+          // A nonzero count must never render as nothing, so a sliver survives
+          // rounding. `rounded-full` makes it a dot rather than a chip.
+          style={{ width: `${pct}%`, minWidth: !pending && count > 0 ? 3 : 0 }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -9,6 +9,7 @@ import {
   type Fingerprint,
 } from '../utils/timelineFingerprint';
 import { notifyTimelineSaved } from '../utils/timelineSaved';
+import { notifyUsageChanged } from '../utils/usageChanged';
 import type { SaveStatus } from '../components/SaveStatusIndicator/SaveStatusIndicator';
 import type { TimelineEvent, CategoryConfig } from '../types/event';
 
@@ -127,6 +128,10 @@ export function useAutosave(timelineData: TimelineData) {
 
       // Diff-based event save
       await saveTimelineEvents(data.id, data.events);
+
+      // After the event save, not beside the bump above: this one reports how
+      // many events now exist, and above they had not been written yet.
+      notifyUsageChanged();
 
       // This payload's fingerprint, not the editor's current one — a newer
       // edit that landed mid-flight has already armed its own write.

--- a/src/hooks/useEventUsage.ts
+++ b/src/hooks/useEventUsage.ts
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/hooks/useAuth'
 import { useAccountTier } from '@/hooks/useAccountTier'
 import { getCurrentLimits } from '@/lib/limits'
 import { byokAnonDraftStore, trialDraftStore, type DraftStore } from '@/utils/draftStorage'
+import { onUsageChanged } from '@/utils/usageChanged'
 
 interface EventUsage {
   eventCount: number
@@ -60,6 +61,29 @@ export function useEventUsage(): EventUsage {
       setIsLoading(false)
     }
   }, [user, localStore])
+
+  /**
+   * Recount when this tab writes something that changes the counts.
+   *
+   * This is what actually keeps the card current. Realtime below is the
+   * cross-tab bonus, and it cannot carry a delete at all — see
+   * `utils/usageChanged.ts` for why both channels miss it. Before this, the
+   * card refreshed once per page load: it renders outside the router's
+   * `<Outlet/>` in an always-mounted `<aside>`, so nothing remounted the hook.
+   *
+   * Deliberately its own effect with empty deps, NOT folded into the
+   * subscription below. That one re-runs on every `user` object identity
+   * change, and AuthContext mints a fresh one on each TOKEN_REFRESHED — this
+   * listener would be torn down and rebuilt roughly hourly, with a window in
+   * which an emit lands on nothing. `useTimelines` avoids the same trap the
+   * same way. The ref is what lets the deps stay empty while `refetch` (which
+   * closes over `user` and `localStore`) stays current.
+   *
+   * No `user` gate: signed out, `refetch` reads the local draft store.
+   */
+  const refetchRef = useRef(refetch)
+  useEffect(() => { refetchRef.current = refetch }, [refetch])
+  useEffect(() => onUsageChanged(() => { refetchRef.current() }), [])
 
   useEffect(() => {
     refetch()

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -3,6 +3,7 @@ import { supabase } from '../lib/supabase';
 import { TimelineEvent, CategoryConfig } from '../types/event';
 import { useAuth } from './useAuth';
 import { DEFAULT_TIMELINE_TITLE } from '../constants/defaults';
+import { notifyUsageChanged } from '../utils/usageChanged';
 import {
   LimitReachedError,
   getCurrentLimits,
@@ -115,6 +116,9 @@ export function useTimeline() {
 
       if (createError) throw createError;
 
+      // One more row against the timeline cap.
+      notifyUsageChanged();
+
       return {
         id: newTimeline.id,
         title: DEFAULT_TIMELINE_TITLE,
@@ -218,6 +222,9 @@ export function useTimeline() {
 
       if (eventsError) throw eventsError;
     }
+
+    // After both writes, so one recount covers the new timeline and its events.
+    notifyUsageChanged();
 
     return timeline.id;
   }, [user]);

--- a/src/utils/usageChanged.ts
+++ b/src/utils/usageChanged.ts
@@ -1,0 +1,42 @@
+/**
+ * "The usage counts just moved" — a same-tab notification, so the Usage Limits
+ * card can recount the moment a timeline is created, deleted or duplicated, or
+ * a save changes how many events exist.
+ *
+ * The sibling of `TIMELINE_SAVED_EVENT` in `timelineSaved.ts`, and it exists
+ * for the same reason: hanging the signal off the write layer covers every
+ * caller wherever they're called from.
+ *
+ * Why the card must not simply lean on Supabase realtime — `useEventUsage`
+ * subscribes to `postgres_changes` on both tables, and neither subscription can
+ * carry a delete:
+ *
+ *   - The `timelines` channel filters on `user_id`, but under default replica
+ *     identity a DELETE's `old` record carries only the primary key, so that
+ *     filter never matches. `20260808000000_timeline_ordering.sql` says so, and
+ *     handles the same problem in `useTimelines` by refetching explicitly at
+ *     the delete sites.
+ *   - No migration in this repo adds `public.events` to the
+ *     `supabase_realtime` publication at all, so the cascade that removes a
+ *     deleted timeline's events is invisible too.
+ *
+ * The result was a card that refreshed exactly once per page load: it is
+ * rendered outside the router's `<Outlet/>`, in an `<aside>` that stays mounted
+ * and hides by transform, so nothing short of a reload remounted the hook.
+ * Realtime is the cross-tab bonus it should always have been.
+ *
+ * Payload-free, like `DRAFTS_CHANGED_EVENT` and unlike `TIMELINE_SAVED_EVENT`:
+ * the only thing a listener can do here is recount, and the counts come from
+ * the server rather than from anything a caller could hand over.
+ */
+export const USAGE_CHANGED_EVENT = 'timeline-academy:usage-changed'
+
+export function notifyUsageChanged(): void {
+  window.dispatchEvent(new Event(USAGE_CHANGED_EVENT))
+}
+
+/** Returns its own unsubscribe, so it drops straight into a `useEffect` return. */
+export function onUsageChanged(handler: () => void): () => void {
+  window.addEventListener(USAGE_CHANGED_EVENT, handler)
+  return () => window.removeEventListener(USAGE_CHANGED_EVENT, handler)
+}


### PR DESCRIPTION
Redesigns the side panel&#39;s Usage Limits card to match the supplied mockup, reuses the same bars in **Account Details → Account usage**, and fixes a pre-existing bug where the counts went stale.

Two commits, reviewable independently.

---

# 1. The bar meters

## What changed

**New `src/components/ui/UsageMeter.tsx`** — a shared `label · used/cap · bar` row. There was no progress primitive in the codebase before this (no `progress.tsx`, no `@radix-ui/react-progress`, no `role=&#34;progressbar&#34;` anywhere), so this is the app&#39;s first one.

**`UsageLimits.tsx`** — the two `StatTile`s become meters in a nested sub-card; the three-column tier comparison table and its header CTA collapse into one prose sentence.

**`AccountDetailsModal.tsx`** — the local `UsageRow` is deleted in favour of the shared meter. Row chrome, height and pane rhythm are unchanged.

## Design notes

- **The bars align across rows.** The label and value sit in a single fixed-width head group rather than sizing to their content, so every bar starts at the same x. This is what lets the same component work in the modal, where each row is its own card and no shared grid parent could span them.
- **Track tone is a prop** because the two surfaces nest in opposite directions — the side panel card is `#0A0A0A` with its sub-card stepping *up* to `#171717`, while the modal is `#171717` with rows recessed *down* to `#0A0A0A`. One tone cannot read on both.
- `tabular-nums` on the value keeps the bar from shifting as counts tick past a digit boundary.

## Behaviour worth review

- **BYOK no longer claims &#34;unlimited&#34; events.** The old copy hardcoded `Unlimited` and `♾️` while `PLAN_LIMITS.byok.eventLimit` is `1200` and `isOverEventLimit` enforces it — a BYOK user was told there was no cap and then stopped at one. The sentence now interpolates from `PLAN_LIMITS` so the two can&#39;t drift again. **`PLAN_LIMITS` and the SQL are unchanged** — only the copy stops contradicting them.
- **The BYOK sentence is omitted when `hasSettingsHandler` is false.** The button it replaced called `onOpenSettings()`, which is a no-op off the editor route since nothing registers a handler there — so on `/` it did nothing. `AccountDetailsModal` already guarded this; `UsageLimits` never did.
- **A `pending` flag suppresses the fill during first load.** `useEventUsage` starts both counts at 0, and a bar animating up from empty reads far more like real data than the text tiles ever did.
- **Over-cap is a real state**, reachable by removing a key (byok&#39;s 1200 → free&#39;s 300 with the events still there). The fill clamps to 100% and tints with the existing `--destructive` token, while `aria-valuetext` and the visible numerals both report the true count.
- **Trial is untouched.** It has no caps, and drawing a bar against a limit would imply one. `TrialStatus` remains the panel&#39;s only sign-in entry point.

---

# 2. The counts went stale after a delete

Reported while testing: deleting two of five timelines left the card reading five, and clicking between the remaining three never corrected it.

**This predates the redesign** — the old text tiles read `5/10` just as wrongly. The meters only made it obvious.

## Why

**The card refreshed exactly once per page load.** `useEventUsage` had two refresh paths for a signed-in user, and neither could fire:

1. **`refetch()` on mount.** But `UsageLimits` renders inside the always-mounted `<aside>`, which sits *outside* the router&#39;s `<Outlet/>` and hides by transform. Switching timelines, opening/closing the panel, and the `navigate(&#39;/&#39;)` a delete performs all leave the hook mounted.
2. **Supabase Realtime** — which cannot carry a delete, for two independent reasons already documented in the repo:
   - The `timelines` channel filters `user_id=eq.…`, but under default replica identity a DELETE&#39;s `old` record holds **only the primary key**, so that filter never matches. `20260808000000_timeline_ordering.sql` states this, and notes `useTimelines` survives only by refetching explicitly at the delete sites.
   - **No migration adds `public.events` to the `supabase_realtime` publication**, so the cascade that removes a deleted timeline&#39;s events is invisible too.

And nothing else called `refetch` — it was dead API surface.

This is the failure `CLAUDE.md` warns about — *nothing user-visible may depend on Supabase Realtime* — in the one hook never converted off it.

> A corroborating detail: **Account Details → Account usage showed the right numbers**, because that pane remounts on every open. Same hook, same query — right in the modal, stale in the panel. That asymmetry was the diagnosis.

## The fix

**New `src/utils/usageChanged.ts`** — a payload-free same-tab signal, the sibling of `timelineSaved.ts`. Emitted wherever the row set moves: both timeline delete paths, duplicate, both create paths, and **after autosave&#39;s event write**. That last one keeps the Events meter honest while editing; without it the event count has the identical staleness bug, just less noticed.

It is a new event rather than a reuse of `TIMELINE_SAVED_EVENT`, because that one fires *deliberately before* the events write — a refetch driven by it would race the very write it reports.

**The listener lives in its own effect with empty deps, reading `refetch` through a ref.** `AuthContext` mints a fresh `user` object on every `TOKEN_REFRESHED`, so folding it into the hook&#39;s existing `[user, refetch, localStore]` effect would rebuild the listener roughly hourly, with a window where an emit lands on nothing — the trap `useTimelines` documents and dodges the same way.

Realtime stays in place as the cross-tab bonus. Anonymous tiers are unchanged — they already poll the draft store every 2s.

**Scope:** same-tab only, as agreed. A second tab still stays stale until reload — the gap that exists today, and no longer the reported symptom. No focus refetch, no new migration.

---

## Verification

- `npx tsc --noEmit -p tsconfig.app.json` — 16 errors, byte-identical to the pre-change baseline, after both commits (`npm run build` is `vite build` alone and does not type-check).
- `npm run lint` — clean. `npm run build` — succeeds.
- **Rendered in Chromium and measured from the DOM** across both surfaces and every edge case. Fill widths are proportional and the ARIA is correct:

| Case | Fill | Notes |
|---|---|---|
| `2/3`, `90/150` | 66.7%, 60% | proportional |
| `0/3` | 0% | genuinely empty rail |
| `1/150` | 3px floor | 2.3% would otherwise round to nothing |
| `150/150` | 100% | |
| `200/150` | 100%, `rgb(174,41,41)` | clamped + tinted; `aria-valuetext=&#34;200 of 150&#34;` keeps the true count |
| `limit: null` | no bar | renders &#34;Unlimited&#34;; no `progressbar` role, since there&#39;s no range |
| `pending` | 0%, `aria-busy` | `aria-valuenow` omitted → indeterminate |
| 25-char label | — | truncates; bar still starts at the same x as its neighbours |

  Bar left-edges were identical within each container, and track colours resolved to `#0A0A0A` and `#262626` on their respective surfaces. Also checked at `PANEL_MIN_WIDTH` (294px card) and at 250px — the mobile width where `clampPanelWidth`&#39;s desktop floor doesn&#39;t apply — with no wrap or bar collapse.

- **The refresh listener is verified end-to-end** in the `byok-anon` tier, whose counts come from localStorage. Mutating the store and dispatching the signal updated the card in **14ms**; a control that mutated the store *without* dispatching was caught only by the 2s poll, at **861ms**. The gap is what proves the update came from the event.

- **Not exercised against a real backend.** The signed-in tiers (`free`, `byok`) render from the same code path with different caps, but the live count queries (`get_user_event_count`, the `timelines` count) need a reachable Supabase — as do the six emit call sites, which all sit on signed-in write paths. Worth a pass before this leaves draft: delete a timeline and confirm the meter drops without a reload, and that the panel card and Account usage agree afterwards.

One note on the mockup: its bars are illustrative rather than proportional — it draws `0/2` at ~72% full and `90/150` at ~78%. These are proportional, so `0/2` renders as an empty rail.