### PR TITLE
Render timelines before 1900 instead of piling them at one point

### DIFF
--- a/src/TIMELINE_ARCHITECTURE.md
+++ b/src/TIMELINE_ARCHITECTURE.md
@@ -347,9 +347,9 @@ Drag transforms take priority over FLIP transforms — the dragged event is excl
 
 ### Algorithm
 
-1. **Sort** events by `startDate` ascending (stable; same-start events keep their original order).
+1. **Sort** events by `startDate` ascending, comparing the `YYYY-MM-DD` strings directly — that ordering is chronological and cannot be shifted by the viewer's timezone (stable; same-start events keep their original order).
 2. For each event:
-   - Compute `startColumn` and `endColumn` from the start/end month indices.
+   - Compute `startColumn` and `endColumn` from the start/end month indices, via the same `findMonthIndex` the renderer uses (§21), with `end` floored at `start`.
    - Compute the title's required pixel width via canvas-based `measureTextWidth`, rounded up to whole columns:
      ```ts
      displayPx  = max(EVENT_MIN_WIDTH, textPx + TITLE_CHROME_WIDTH)
@@ -570,7 +570,7 @@ Switching scale recalculates all event positions: the grid math (§21) is unchan
 ## Date-to-Grid Math
 
 ```
-monthIndex   = months.findIndex(m => m.year === date.year && m.month === date.month - 1)
+monthIndex   = findMonthIndex(months, dateStr)       // src/utils/dateUtils.ts
 quarterIndex = Math.floor((day - 1) / 8)
                  // Day  1– 8 → 0
                  // Day  9–16 → 1
@@ -578,9 +578,30 @@ quarterIndex = Math.floor((day - 1) / 8)
                  // Day 25–31 → 3
 
 startColumn  = monthIndex * 4 + quarterIndex + 1     // CSS Grid is 1-indexed
-endColumn    = endMonthIndex * 4 + endQuarter + 2    // exclusive end for `gridColumn: start / end`
+endColumn    = max(endMonthIndex * 4 + endQuarter + 2, startColumn + 1)
 pixelX       = (column - 1) * scale.quarterWidth
 ```
+
+**Both the month index and the dates behind it come from shared helpers, and
+must.** `findMonthIndex` and `parseDateParts` (`src/utils/dateUtils.ts`) are used
+by `TimelineEvent.tsx` and by `eventStacking.ts` alike, so the renderer and the
+stacker cannot place the same event in two different months. Two rules they
+enforce that a bare `findIndex` did not:
+
+- **A month index is never negative.** A date outside the rendered range clamps
+  to the nearest edge (0 or `months.length - 1`); only an unparseable date
+  returns `-1`, and its event renders nothing. Feeding a raw `findIndex` miss
+  into the arithmetic above yields a *negative* `gridColumn`, and negative CSS
+  grid lines count from the **end** of the grid — so every off-range event
+  silently stacked against the timeline's right edge.
+- **Dates are read from the string, never via `new Date(str)`.** That parses as
+  UTC midnight and reads back in local time, so west of UTC every
+  January-1st date lands in the previous December — and the generator is
+  instructed to emit January 1 for year-only events.
+
+`endColumn` is floored one column past `startColumn` because nothing rejects an
+event whose `endDate` precedes its `startDate`, and a reversed `gridColumn`
+range renders the bar backwards.
 
 **Reverse (drag delta → date shift):**
 
@@ -598,26 +619,54 @@ Each quarter represents ~7 days. The mapping is approximate but visually consist
 `getTimelineRange(events)` in `src/utils/dateUtils.ts` decides which months to render.
 
 ```
-1. If events is empty:
-     [DEFAULT_START_YEAR, DEFAULT_END_YEAR] = [2014, 2024]
+1. Collect every event's start/end year via parseDateParts, skipping any date
+   that does not parse.
 
-2. Otherwise:
+2. If no year survives (empty timeline, or every date malformed):
+     [DEFAULT_START_YEAR, DEFAULT_END_YEAR] = [2014, 2024]   — returned as-is,
+     without the padding in step 4.
+
+3. Otherwise:
      startYear = max(MIN_YEAR, min over all event start/end years)
      endYear   = min(MAX_YEAR, max over all event start/end years)
 
-3. Ensure at least 10 years of span:
+4. Ensure at least 10 years of span:
      if (endYear - startYear < 9) {
        midYear   = floor((startYear + endYear) / 2)
        startYear = max(MIN_YEAR, midYear - 5)
        endYear   = min(MAX_YEAR, midYear + 5)
      }
 
-4. Add 3-year scroll padding on both sides (clamped to [MIN_YEAR, MAX_YEAR]).
+5. Add 3-year scroll padding on both sides (clamped to [MIN_YEAR, MAX_YEAR]).
 
-5. Generate one Month per (year, 0..11) in the range.
+6. Generate one Month per (year, 0..11) in the range.
 ```
 
-Constants: `MIN_YEAR = 1900`, `MAX_YEAR = 2100`, `DEFAULT_START_YEAR = 2014`, `DEFAULT_END_YEAR = 2024`.
+Constants: `MIN_YEAR = 1`, `MAX_YEAR = 2100`, `DEFAULT_START_YEAR = 2014`, `DEFAULT_END_YEAR = 2024`.
+
+`getTimelineRange` returns `{ months }` only. It used to also return
+`startDate` / `endDate` built with `new Date(startYear, 0, 1)`; nothing consumed
+them, and they would have started lying the moment `MIN_YEAR` dropped below 100,
+because `new Date(1, 0, 1)` means **1901**.
+
+### Why `MIN_YEAR` is 1 and not 1900
+
+`MIN_YEAR` was `1900`, which silently clamped every earlier event off the grid.
+For a timeline spanning 1596–1900 the steps above produced `startYear = 1900`,
+`endYear = 1907` — an axis on which **no event's month exists** — and each event
+then took a negative `gridColumn` and stacked against the right edge (see §21).
+A timeline entirely before 1900 was worse: the range inverted
+(`startYear 1900 > endYear`), `generateMonthsRange` returned `[]`, and the canvas
+rendered nothing at all.
+
+Year 1 is the floor because `YYYY-MM-DD` strings and the `split('-')` parsing
+throughout cannot express a negative year — **BC/BCE dates are unsupported**, and
+the generator prompt says so. The trade is span: a correct 17th-century timeline
+renders ~3,700 months rather than 96, and month granularity over a
+millennium-scale range is genuinely heavy. That is why the three arrays feeding
+it (`visibleCategories`, `visibleEvents`, `months`) are memoized in
+`Timeline.tsx` — without it the `layout` memo never hit, and the whole stacking
+pass, canvas text measurement included, re-ran on every render.
 
 ### Visibility caveat
 
@@ -989,7 +1038,7 @@ list deliberately omits, implying a saved timeline that does not exist.
 | `TITLE_CHROME_WIDTH` | `src/utils/eventStacking.ts` | `20` (px) |
 | `TRAILING_BUFFER_PX` | `src/utils/eventStacking.ts` | `24` (px) |
 | `TITLE_FONT` | `src/utils/eventStacking.ts` | `'400 16px Avenir, sans-serif'` |
-| `MIN_YEAR` / `MAX_YEAR` | `src/utils/dateUtils.ts` | `1900` / `2100` |
+| `MIN_YEAR` / `MAX_YEAR` | `src/utils/dateUtils.ts` | `1` / `2100` |
 | `DEFAULT_START_YEAR` / `DEFAULT_END_YEAR` | `src/utils/dateUtils.ts` | `2014` / `2024` |
 | `STACK_TRANSITION_MS` | `src/components/Timeline/TimelineEvent.tsx` | `220` |
 | Wheel lerp factor | `src/components/Timeline/Timeline.tsx` | `0.18` |

--- a/src/components/AIMode/ImportCSVModal.tsx
+++ b/src/components/AIMode/ImportCSVModal.tsx
@@ -14,17 +14,10 @@ import {
   downloadTemplate,
   isInstructionRow,
   parseSheetRows,
-  type SheetCellValue,
+  toDateString,
 } from '@/utils/excelSheet'
 
 const MAX_TITLE_LENGTH = 55
-
-function toDateString(value: SheetCellValue | undefined): string {
-  if (value == null || String(value).trim() === '') return ''
-  const date = value instanceof Date ? value : new Date(String(value))
-  if (isNaN(date.getTime())) return ''
-  return date.toISOString().split('T')[0]
-}
 
 interface ImportCSVModalProps {
   isOpen: boolean

--- a/src/components/Settings/TimelineSettingsPanel.tsx
+++ b/src/components/Settings/TimelineSettingsPanel.tsx
@@ -16,15 +16,8 @@ import { DEFAULT_TIMELINE_DESCRIPTION } from '../../constants/defaults';
 import {
   isInstructionRow,
   parseSheetRows,
-  type SheetCellValue,
+  toDateString,
 } from '../../utils/excelSheet';
-
-function toDateString(value: SheetCellValue | undefined): string {
-  if (value == null || String(value).trim() === '') return '';
-  const date = value instanceof Date ? value : new Date(String(value));
-  if (isNaN(date.getTime())) return '';
-  return date.toISOString().split('T')[0];
-}
 
 interface TimelineSettingsPanelProps {
   isOpen: boolean;

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useCallback, useEffect } from 'react';
+import React, { useRef, useState, useCallback, useEffect, useMemo } from 'react';
 import { TimelineHeader } from './TimelineHeader';
 import { TimelineGrid } from './TimelineGrid';
 import { TimelineVerticalLines } from './TimelineVerticalLines';
@@ -8,7 +8,7 @@ import { TimelineScrollIndicator } from './TimelineScrollIndicator';
 import { EventActionsMenu } from '../EventActionsMenu/EventActionsMenu';
 import { TimelineEvent as ITimelineEvent, CategoryConfig } from '../../types/event';
 import { TimelineScale, TimelineVerticalScale } from '../../types/timeline';
-import { getTimelineRange, shiftEventDates } from '../../utils/dateUtils';
+import { formatYMD, getTimelineRange, shiftEventDates } from '../../utils/dateUtils';
 import { calculateEventStacks, StackedEvent } from '../../utils/eventStacking';
 import { useTimelineScroll } from '../../hooks/useTimelineScroll';
 import { useEventDrag } from '../../hooks/useEventDrag';
@@ -71,13 +71,24 @@ export function Timeline({
   mode = 'edit',
 }: TimelineProps) {
   const isEditing = mode === 'edit';
-  // Filter visible categories and their events
-  const visibleCategories = categories.filter(cat => cat.visible);
-  const visibleEvents = events.filter(event =>
-    visibleCategories.some(cat => cat.id === event.category)
+  // Filter visible categories and their events. Memoized because `months` and
+  // `layout` below key off these arrays: rebuilding them every render meant the
+  // `layout` memo never hit, so the whole stacking pass — including canvas text
+  // measurement per event — re-ran on every render. That is affordable for a
+  // 96-month range and is not for the ~3,700 months a 17th-century timeline
+  // legitimately spans.
+  const visibleCategories = useMemo(
+    () => categories.filter(cat => cat.visible),
+    [categories]
+  );
+  const visibleEvents = useMemo(
+    () => events.filter(event =>
+      visibleCategories.some(cat => cat.id === event.category)
+    ),
+    [events, visibleCategories]
   );
 
-  const { months } = getTimelineRange(visibleEvents);
+  const { months } = useMemo(() => getTimelineRange(visibleEvents), [visibleEvents]);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [hoveredMonth, setHoveredMonth] = useState<number | null>(null);
   const [showEventModal, setShowEventModal] = useState(false);
@@ -222,8 +233,10 @@ export function Timeline({
 
     const clickedMonth = months[monthIndex];
     if (clickedMonth) {
-      const date = new Date(clickedMonth.year, clickedMonth.month, 1);
-      setSelectedDate(date.toISOString().split('T')[0]);
+      // Built from the parts directly: `new Date(y, m, 1).toISOString()` shifts
+      // to the previous day west of UTC, and coerces a year below 100 into
+      // 19xx.
+      setSelectedDate(formatYMD(clickedMonth.year, clickedMonth.month, 1));
       setEditingEvent(null);
       setShowEventModal(true);
     }

--- a/src/components/Timeline/TimelineEvent.tsx
+++ b/src/components/Timeline/TimelineEvent.tsx
@@ -2,6 +2,7 @@ import React, { memo, useRef, useEffect, useState, useLayoutEffect } from 'react
 import { TimelineEvent as ITimelineEvent } from '../../types/event';
 import { Month, TimelineScale } from '../../types/timeline';
 import { EVENT_ROW_HEIGHT, EVENT_MIN_WIDTH } from '../../constants/timeline';
+import { findMonthIndex, parseDateParts } from '../../utils/dateUtils';
 
 interface TimelineEventProps {
   event: ITimelineEvent & { stackIndex: number };
@@ -81,26 +82,32 @@ export const TimelineEvent = memo(function TimelineEvent({
   if (!months.length) return null;
 
   // Parse dates
-  const [startYear, startMonth, startDay] = event.startDate.split('-').map(Number);
-  const [endYear, endMonth, endDay] = event.endDate.split('-').map(Number);
+  const startParts = parseDateParts(event.startDate);
+  const endParts = parseDateParts(event.endDate);
+  if (!startParts || !endParts) return null;
+
+  // `findMonthIndex` clamps to the nearest edge, so these are always valid grid
+  // lines. Deriving them arithmetically from a raw `findIndex` was the bug: a
+  // miss returns -1, and a negative CSS grid line counts from the *end* of the
+  // grid, which piled every off-range event onto the timeline's right edge.
+  const startMonthIndex = findMonthIndex(months, event.startDate);
+  const endMonthIndex = findMonthIndex(months, event.endDate);
+  if (startMonthIndex === -1 || endMonthIndex === -1) return null;
 
   // Calculate which quarter of the month the day falls into (1-8, 9-16, 17-24, 25-32)
   const getQuarter = (day: number) => Math.floor((day - 1) / 8);
 
-  const startQuarter = getQuarter(startDay);
-  const endQuarter = getQuarter(endDay);
+  const startQuarter = getQuarter(startParts.day);
+  const endQuarter = getQuarter(endParts.day);
 
-  // Find the month indices in the timeline
-  const startMonthIndex = months.findIndex(
-    m => m.year === startYear && m.month === startMonth - 1
-  );
-  const endMonthIndex = months.findIndex(
-    m => m.year === endYear && m.month === endMonth - 1
-  );
-
-  // Calculate grid columns based on month index
+  // Calculate grid columns based on month index. The end is floored one column
+  // past the start: nothing rejects an event whose endDate precedes its
+  // startDate, and a reversed `gridColumn` range renders the bar backwards.
   const startColumn = (startMonthIndex * 4) + startQuarter + 1;
-  const endColumn = (endMonthIndex * 4) + endQuarter + 2;
+  const endColumn = Math.max(
+    (endMonthIndex * 4) + endQuarter + 2,
+    startColumn + 1
+  );
 
   const isSingleDay = event.startDate === event.endDate;
   const isDraggable = !!onPointerDown;

--- a/src/components/Timeline/TimelineMonthLabels.tsx
+++ b/src/components/Timeline/TimelineMonthLabels.tsx
@@ -3,6 +3,10 @@ import { format } from 'date-fns';
 import { Month, TimelineScale } from '../../types/timeline';
 import { getMonthBorderClass } from '../../utils/timelineUtils';
 
+// Only the month name is rendered, but `new Date(y, m)` coerces a year below
+// 100 into 19xx, so the year is pinned rather than taken from the month.
+const MONTH_LABEL_REFERENCE_YEAR = 2000;
+
 interface TimelineMonthLabelsProps {
   months: Month[];
   scale: TimelineScale;
@@ -26,7 +30,7 @@ export function TimelineMonthLabels({ months, scale }: TimelineMonthLabelsProps)
         >
           {scale.value === 'large' && (
             <span className="text-[10px] text-[#9b9ea3] font-mono transition-transform duration-200 ease-in-out">
-              {format(new Date(month.year, month.month), 'MMM')}
+              {format(new Date(MONTH_LABEL_REFERENCE_YEAR, month.month), 'MMM')}
             </span>
           )}
         </div>

--- a/src/services/llmPrompts.ts
+++ b/src/services/llmPrompts.ts
@@ -28,8 +28,9 @@ HARD RULES:
 3. EVENT QUALITY — Max 55 characters per title. Prefer specific facts over vague summaries.
    BAD:  "Had a successful career"
    GOOD: "Scored 81 points vs. Raptors"
-4. DATE FORMAT — YYYY-MM-DD. Year-only → January 1. Ranges → use startDate/endDate span. Chronological order.
-5. JSON ONLY — No markdown, no code fences, no explanation.
+4. DATE FORMAT — YYYY-MM-DD, AD years only (never a BC/BCE date). Year-only → January 1. Ranges → use startDate/endDate span. Chronological order.
+5. EVENT SPAN — Keep every event inside the subject's own span: for a person, birth to death. Express legacy and influence as events dated within that span, never as one long event reaching into later centuries.
+6. JSON ONLY — No markdown, no code fences, no explanation.
 
 RESPONSE SCHEMA:
 {

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -2,33 +2,104 @@ import { TimelineEvent } from '../types/event';
 import { Month } from '../types/timeline';
 import { format } from 'date-fns';
 
-const MIN_YEAR = 1900;
+// Year 1 rather than 1900: the app charts history, and a 1900 floor silently
+// pulled every earlier event off the rendered grid. AD only — `YYYY-MM-DD`
+// strings and the `split('-')` parsing below cannot express a negative year.
+const MIN_YEAR = 1;
 const MAX_YEAR = 2100;
 const DEFAULT_START_YEAR = 2014;
 const DEFAULT_END_YEAR = 2024;
 
+export interface DateParts {
+  year: number;
+  /** 0-indexed, matching `Month.month`. */
+  month: number;
+  day: number;
+}
+
+/**
+ * Calendar parts of a `YYYY-MM-DD` string, read without going through `Date`.
+ *
+ * `new Date('1900-01-01')` parses as UTC midnight but `getFullYear()` reads back
+ * in local time, so anywhere west of UTC a January-1st date reports the
+ * *previous* year. The generator is told "year-only -> January 1", so that hit
+ * a large share of AI events and is what made the header read `1596-1899` for a
+ * timeline whose last date is 1900-01-01.
+ *
+ * Returns null for anything unparseable, so callers can skip the event rather
+ * than propagate a NaN through `Math.min`/`Math.max`.
+ */
+export function parseDateParts(dateStr: string): DateParts | null {
+  if (!dateStr) return null;
+
+  const match = /^(\d{1,4})-(\d{1,2})-(\d{1,2})$/.exec(dateStr.trim());
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+
+  if (year < 1 || month < 1 || month > 12 || day < 1 || day > 31) return null;
+
+  return { year, month: month - 1, day };
+}
+
+/**
+ * Build a `YYYY-MM-DD` string from calendar parts (`month` 0-indexed).
+ *
+ * The year is padded to four digits: `isValidDateFormat` requires `\d{4}`, and
+ * `new Date('596-01-01T00:00:00')` is Invalid Date while `'0596-01-01T00:00:00'`
+ * parses correctly.
+ */
+export function formatYMD(year: number, month: number, day: number): string {
+  return `${String(year).padStart(4, '0')}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
+/**
+ * Index of the month containing `dateStr` within `months`, clamped to the
+ * nearest edge when the date falls outside the rendered range.
+ *
+ * Returns -1 only when there are no months or the date is unparseable. Callers
+ * must never turn that into a CSS grid line: a negative grid line counts from
+ * the *end* of the grid, which is what stacked every off-grid event onto the
+ * timeline's right edge.
+ */
+export function findMonthIndex(months: Month[], dateStr: string): number {
+  if (!months.length) return -1;
+
+  const parts = parseDateParts(dateStr);
+  if (!parts) return -1;
+
+  const index = months.findIndex(
+    m => m.year === parts.year && m.month === parts.month
+  );
+  if (index !== -1) return index;
+
+  const first = months[0];
+  const beforeStart =
+    parts.year < first.year ||
+    (parts.year === first.year && parts.month < first.month);
+
+  return beforeStart ? 0 : months.length - 1;
+}
+
 function calculateTimelineRange(events: TimelineEvent[]) {
-  if (events.length === 0) {
+  const years = events
+    .flatMap(event => [event.startDate, event.endDate])
+    .map(parseDateParts)
+    .filter((parts): parts is DateParts => parts !== null)
+    .map(parts => parts.year);
+
+  // Also covers an empty timeline and one whose dates are all malformed.
+  if (years.length === 0) {
     return {
       startYear: DEFAULT_START_YEAR,
       endYear: DEFAULT_END_YEAR
     };
   }
 
-  const dates = events.flatMap(event => [
-    new Date(event.startDate),
-    new Date(event.endDate)
-  ]);
-
-  let startYear = Math.max(
-    MIN_YEAR,
-    Math.min(...dates.map(d => d.getFullYear()))
-  );
-
-  let endYear = Math.min(
-    MAX_YEAR,
-    Math.max(...dates.map(d => d.getFullYear()))
-  );
+  let startYear = Math.max(MIN_YEAR, Math.min(...years));
+  let endYear = Math.min(MAX_YEAR, Math.max(...years));
 
   // Ensure we always show at least 10 years
   if (endYear - startYear < 9) {
@@ -59,12 +130,8 @@ function generateMonthsRange(startYear: number, endYear: number): Month[] {
 // Timeline range utilities
 export function getTimelineRange(events: TimelineEvent[]) {
   const { startYear, endYear } = calculateTimelineRange(events);
-  const months = generateMonthsRange(startYear, endYear);
 
-  const startDate = new Date(startYear, 0, 1);
-  const endDate = new Date(endYear, 11, 31);
-
-  return { startDate, endDate, months };
+  return { months: generateMonthsRange(startYear, endYear) };
 }
 
 // Date parsing and formatting utilities
@@ -82,12 +149,12 @@ export function normalizeDate(dateStr: string): string | null {
     const y = parseInt(year);
     
     // Basic date validation
-    if (m < 1 || m > 12 || d < 1 || d > 31 || y < 1900) {
+    if (m < 1 || m > 12 || d < 1 || d > 31 || y < MIN_YEAR) {
       return null;
     }
     
     // Format as YYYY-MM-DD
-    return `${y}-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+    return formatYMD(y, m - 1, d);
   }
 
   return null;
@@ -159,12 +226,7 @@ export function shiftEventDates(
   start.setDate(start.getDate() + daysDelta);
   end.setDate(end.getDate() + daysDelta);
 
-  const fmt = (d: Date) => {
-    const y = d.getFullYear();
-    const m = String(d.getMonth() + 1).padStart(2, '0');
-    const day = String(d.getDate()).padStart(2, '0');
-    return `${y}-${m}-${day}`;
-  };
+  const fmt = (d: Date) => formatYMD(d.getFullYear(), d.getMonth(), d.getDate());
 
   return { startDate: fmt(start), endDate: fmt(end) };
 }

--- a/src/utils/eventStacking.ts
+++ b/src/utils/eventStacking.ts
@@ -1,6 +1,7 @@
 import { TimelineEvent } from '../types/event';
 import { Month } from '../types/timeline';
 import { EVENT_MIN_WIDTH } from '../constants/timeline';
+import { findMonthIndex } from './dateUtils';
 
 export interface StackedEvent extends TimelineEvent {
   stackIndex: number;
@@ -44,21 +45,17 @@ function measureTextWidth(text: string): number {
 function getEventColumns(event: TimelineEvent, months: Month[]): { start: number; end: number } {
   if (!months?.length) return { start: 0, end: 0 };
 
-  const startDate = new Date(event.startDate);
-  const endDate = new Date(event.endDate);
+  // Shares `findMonthIndex` with TimelineEvent so the stacker and the renderer
+  // can never place the same event in two different months. They used to
+  // disagree twice over: this read years via `new Date(str).getFullYear()`
+  // (UTC parse, local read — a month early west of UTC), and it turned a miss
+  // into `start: 0, end: -1` while the renderer turned it into a negative grid
+  // column. That is why off-range events fanned into one row each on the left
+  // while rendering as a stack on the right.
+  const start = Math.max(0, findMonthIndex(months, event.startDate));
+  const end = Math.max(start, findMonthIndex(months, event.endDate));
 
-  const startIndex = months.findIndex(
-    m => m.year === startDate.getFullYear() && m.month === startDate.getMonth()
-  );
-
-  const endIndex = months.findIndex(
-    m => m.year === endDate.getFullYear() && m.month === endDate.getMonth()
-  );
-
-  return {
-    start: Math.max(0, startIndex),
-    end: Math.min(months.length - 1, endIndex)
-  };
+  return { start, end };
 }
 
 function calculateRequiredColumns(title: string, monthWidth: number): number {
@@ -81,11 +78,11 @@ export function calculateEventStacks(events: TimelineEvent[], months: Month[] = 
 
   // Sort events by start date only — earlier events get the top rows.
   // Stable sort preserves array order for equal start dates.
-  const sortedEvents = [...events].sort((a, b) => {
-    const aStart = new Date(a.startDate).getTime();
-    const bStart = new Date(b.startDate).getTime();
-    return aStart - bStart;
-  });
+  // `YYYY-MM-DD` sorts chronologically as a plain string, so this needs no Date
+  // and cannot be shifted by the viewer's timezone.
+  const sortedEvents = [...events].sort((a, b) =>
+    a.startDate.localeCompare(b.startDate)
+  );
 
   const placements: EventPlacement[] = [];
 

--- a/src/utils/excelSheet.ts
+++ b/src/utils/excelSheet.ts
@@ -5,6 +5,7 @@
 // spreadsheets in the same origin that holds the user's session.
 
 import type { CellValue } from 'exceljs'
+import { formatYMD, isValidDateFormat, normalizeDate } from './dateUtils'
 
 // exceljs is heavy; load it only when a spreadsheet is actually read or
 // written so it stays out of the main bundle.
@@ -30,6 +31,30 @@ export function templateInstructions(maxTitleLength: number): string[] {
 export type SheetCellValue = string | number | Date
 
 export type SheetRow = Record<string, SheetCellValue>
+
+/**
+ * Normalize one spreadsheet cell into the app's `YYYY-MM-DD` form, or `''`.
+ *
+ * exceljs hands back date cells as UTC midnight, so the parts are read in UTC.
+ * The previous `new Date(value).toISOString().split('T')[0]` round-tripped
+ * through local time and landed a day early east of UTC, and could not express
+ * a pre-1900 date at all. Text cells go through the same `normalizeDate` the
+ * CSV importer uses, so the two paths finally agree on what a date looks like.
+ */
+export function toDateString(value: SheetCellValue | undefined): string {
+  if (value == null) return ''
+
+  if (value instanceof Date) {
+    if (isNaN(value.getTime())) return ''
+    return formatYMD(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate())
+  }
+
+  const text = String(value).trim()
+  if (text === '') return ''
+  if (isValidDateFormat(text)) return text
+
+  return normalizeDate(text) ?? ''
+}
 
 function coerceCellValue(value: CellValue): SheetCellValue {
   if (value == null) return ''

--- a/src/utils/timelineUtils.ts
+++ b/src/utils/timelineUtils.ts
@@ -1,5 +1,6 @@
 import { Month } from '../types/timeline';
 import { TimelineEvent } from '../types/event';
+import { parseDateParts } from './dateUtils';
 
 export function getUniqueYears(months: Month[]): number[] {
   return Array.from(new Set(months.map(month => month.year))).sort();
@@ -63,11 +64,20 @@ export function getTimelineYearRange(events: TimelineEvent[]): string {
     return `${currentYear}`;
   }
 
-  // Get all years from events
-  const years = events.flatMap(event => [
-    new Date(event.startDate).getFullYear(),
-    new Date(event.endDate).getFullYear()
-  ]);
+  // Years come from the string, not from `new Date(str).getFullYear()`, which
+  // parses as UTC and reads back local — reporting the previous year for a
+  // January-1st date anywhere west of UTC. That mismatch is what made this
+  // label read `1596-1899` for a timeline whose last date is 1900-01-01, while
+  // the axis beside it was computed from the same dates a different way.
+  const years = events
+    .flatMap(event => [event.startDate, event.endDate])
+    .map(parseDateParts)
+    .filter((parts): parts is NonNullable<typeof parts> => parts !== null)
+    .map(parts => parts.year);
+
+  if (years.length === 0) {
+    return `${new Date().getFullYear()}`;
+  }
 
   const startYear = Math.min(...years);
   const endYear = Math.max(...years);

--- a/supabase/functions/_shared/prompts.ts
+++ b/supabase/functions/_shared/prompts.ts
@@ -20,8 +20,9 @@ HARD RULES:
 3. EVENT QUALITY — Max 55 characters per title. Prefer specific facts over vague summaries.
    BAD:  "Had a successful career"
    GOOD: "Scored 81 points vs. Raptors"
-4. DATE FORMAT — YYYY-MM-DD. Year-only → January 1. Ranges → use startDate/endDate span. Chronological order.
-5. JSON ONLY — No markdown, no code fences, no explanation.
+4. DATE FORMAT — YYYY-MM-DD, AD years only (never a BC/BCE date). Year-only → January 1. Ranges → use startDate/endDate span. Chronological order.
+5. EVENT SPAN — Keep every event inside the subject's own span: for a person, birth to death. Express legacy and influence as events dated within that span, never as one long event reaching into later centuries.
+6. JSON ONLY — No markdown, no code fences, no explanation.
 
 RESPONSE SCHEMA:
 {


### PR DESCRIPTION
## The bug

An AI-generated timeline for René Descartes (events spanning 1596–1900) drew a **1900–1907** year axis and stacked nearly every event as a vertical ladder pinned to the right edge, so they read as if they all happened on the same day. The nav header said `1596–1899`, disagreeing with the axis beside it. The Events modal showed every date correctly.

Generation and storage were fine — the dates are correct in the `date` columns and in every path that reads them as strings. The bug was entirely in range calculation and grid positioning.

## Root cause

`dateUtils.ts` hard-coded `MIN_YEAR = 1900` and clamped the rendered range to it. For events spanning 1596–1899:

| Step | startYear | endYear |
|---|---|---|
| clamp to `[1900, 2100]` | 1900 | 1899 |
| "at least 10 years" widening | 1900 | 1904 |
| 3-year padding | **1900** | **1907** |

So `months` was 1900-01 … 1907-12 — exactly the axis on screen — and **no event's month existed in it**. Two layers then handled the `findIndex` miss differently:

- `TimelineEvent.tsx` fed `-1` straight into the arithmetic, giving `gridColumn: -3 / -2`. **Negative CSS grid lines count from the end of the grid**, so every off-range event landed against the right edge.
- `eventStacking.ts` clamped the same miss to `start: 0`, so the stacker thought all events collided and gave each its own row.

Stacker spread them vertically, renderer piled them horizontally — the ladder. A timeline *entirely* before 1900 was worse: the range inverted, `generateMonthsRange` returned `[]`, and the canvas rendered nothing at all.

**Why the header said 1899:** `getTimelineYearRange` wasn't clamped, but it read years via `new Date('YYYY-MM-DD').getFullYear()` — UTC parse, local read. West of UTC that reports the previous year for a January-1st date, and the generator prompt says "year-only → January 1". A legacy event ending `1900-01-01` therefore reported as 1899. Both observed numbers fall out of one data set.

## Changes

- **`MIN_YEAR: 1900 → 1`.** AD only — `YYYY-MM-DD` and `split('-')` cannot express a negative year.
- **Shared helpers in `dateUtils`** — `parseDateParts`, `formatYMD`, `findMonthIndex`. `findMonthIndex` clamps an off-range date to the nearest edge and returns `-1` only for an unparseable one, whose event now renders nothing. `TimelineEvent` and `eventStacking` both use them, so the two layers can no longer disagree.
- **`endColumn` floored one past `startColumn`** — nothing rejects `endDate < startDate`, and a reversed range renders the bar backwards.
- **Dates read from the string everywhere**, never `new Date(str).getFullYear()`: the header range, the stacker's sort, the range calc, click-to-add (which also hit the `new Date(1, 0, 1) → 1901` trap), and the month labels.
- **One shared `toDateString`** in `excelSheet.ts` replacing two duplicated copies — reads exceljs cells in UTC (they arrive as UTC midnight) and sends text through `normalizeDate`, so the CSV and Excel import paths finally agree.
- **`normalizeDate`'s own `y < 1900` floor removed**, so pre-1900 dates can be typed into the Add Event form and imported. Years pad to four digits so `isValidDateFormat` still matches and `new Date('0596-…')` stays valid.
- **Memoized `visibleCategories` / `visibleEvents` / `months`** in `Timeline.tsx`. They were rebuilt every render, so the `layout` memo never hit and the full stacking pass — canvas text measurement included — re-ran each time. Affordable at 96 months, not at the ~3,700 a 17th-century timeline spans.
- **Generated events bounded to the subject's own span** in both copies of the LLM prompt, kept byte-identical. An influence event dated 1900 is what stretched a 54-year life across three centuries.
- **`TIMELINE_ARCHITECTURE.md` updated** per its maintenance contract (§12, §21, §22, Key Constants).

## Verification

**Before / after on the reported data**, run against both trees in `TZ=America/Los_Angeles`:

|  | before | after |
|---|---|---|
| header label | `1596–1899` | `1596–1900` |
| axis | `1900..1907` (96 months) | `1593..1903` (3,732 months) |
| events with a negative/zero `gridColumn` | **7 of 7** | **0 of 7** |

The "before" column reproduces the reported screenshot exactly.

- Assertion harness over the range math, column math, clamping, reversed dates, unparseable dates, `normalizeDate`, `shiftEventDates` and `toDateString` — all pass under `TZ=America/Los_Angeles`, `UTC`, `Europe/Berlin` and `Pacific/Kiritimati` (UTC+14). The timezone sweep is the real regression test: the original bug is invisible in UTC.
- Rendered the `Timeline` component in Chromium against the Descartes data. Events sit at distinct, increasing, positive columns (156, 210, 673, 1145, 1201, 1681, 2043, 2742…); the far right edge now holds only the legacy event that genuinely ends there; auto-scroll lands on the first event, which had been silently dead since `scrollToDate` returns early on `monthIndex === -1`.
- `npm run lint` clean; `npm run build` passes. `tsc --noEmit` reports the same 16 pre-existing errors before and after — this change adds none. (Note `npm run build` is `vite build`, which does not typecheck.)

No test framework is configured, so the harness above is scratch-only and not committed.

## Deploy note

The prompt change touches `supabase/functions/_shared/prompts.ts`, so the edge-function half ships via `deploy-functions.yml` on merge while the client half ships with Netlify. They land at different times; nothing parses the prompt text, so either order is safe.

## Not included

- **BC/BCE dates** — `YYYY-MM-DD`, `split('-')`, date-fns formatting and the Excel export all assume non-negative years. Separate feature.
- **A span cap / coarser zoom levels** — the full span renders. A millennium-scale AD timeline (~17k month columns) will be sluggish; the memoization is a mitigation, not a fix for that ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5WcNzgmdU8DhB3BFPvC84

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5WcNzgmdU8DhB3BFPvC84)_