### PR TITLE
Search field restyle, quick-search chips, and the first mobile pass

### DIFF
--- a/src/components/AIMode/SubjectSuggestions.tsx
+++ b/src/components/AIMode/SubjectSuggestions.tsx
@@ -42,7 +42,7 @@ export function SubjectSuggestions({
 
   return (
     <div
-      className="flex flex-col items-start gap-[2px] min-w-[350px] w-fit h-[270px] max-w-full py-[12px] px-[8px] rounded-[8px] border border-[#262626] bg-[rgba(184,184,184,0.04)] backdrop-blur-[4px] shadow-[0px_8px_32px_0px_rgba(155,158,163,0.04)]"
+      className="flex flex-col items-start gap-[2px] w-full max-h-[270px] overflow-y-auto py-[12px] px-[8px] rounded-[8px] border border-[#262626] bg-[rgba(184,184,184,0.04)] backdrop-blur-[4px] shadow-[0px_8px_32px_0px_rgba(155,158,163,0.04)]"
       role="listbox"
       aria-busy={isLoading ? 'true' : 'false'}
     >
@@ -51,7 +51,7 @@ export function SubjectSuggestions({
             <div
               key={i}
               aria-hidden="true"
-              className="self-stretch h-[36px] px-[12px] py-[4px] rounded-[8px] flex items-center"
+              className="shrink-0 self-stretch h-[36px] px-[12px] py-[4px] rounded-[8px] flex items-center"
             >
               <div
                 className="h-[14px] rounded-[4px] bg-white/[0.08] animate-pulse"
@@ -74,13 +74,14 @@ export function SubjectSuggestions({
                   e.preventDefault()
                   onSelect(s.title)
                 }}
+                onClick={() => onSelect(s.title)}
                 onMouseEnter={() => setHighlight(i)}
                 className={[
-                  'header-xsmall text-left self-stretch h-[36px] px-[12px] py-[4px] rounded-[8px] flex items-center transition-colors',
+                  'header-xsmall text-left shrink-0 self-stretch h-[36px] px-[12px] py-[4px] rounded-[8px] flex items-center transition-colors',
                   i === highlight ? 'bg-[#262626]' : 'hover:bg-[#262626]',
                 ].join(' ')}
               >
-                <span className="whitespace-nowrap">
+                <span className="min-w-0 flex-1 truncate">
                   {matchIdx >= 0 ? (
                     <>
                       {before && <span className="text-text-tertiary">{before}</span>}

--- a/src/components/Layout/GlobalLayout.tsx
+++ b/src/components/Layout/GlobalLayout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import { GlobalSidePanel } from '@/components/SidePanel/GlobalSidePanel'
 import { PanelResizeHandle } from '@/components/ui/PanelResizeHandle'
 import { useSidePanel } from '@/hooks/useSidePanel'
@@ -8,16 +8,29 @@ interface GlobalLayoutProps {
 }
 
 /**
- * Push-layout with a viewport-pinned floating side panel:
- * - Panel is position: fixed with a 6px gap on left/top/bottom so it floats.
- * - Its footprint (`width`, gap included) is user-resizable and persisted; the
- *   main content's padding-left tracks the same value so the two never drift.
- *   `FloatingToolbar` is the third reader — see `SidePanelContext`.
+ * Two layouts for one panel, split at `md`.
  *
- * `-translate-x-full` is a percentage of the panel's own width, so the
- * collapse animation follows a variable width for free. The width itself needs
- * an explicit transition leg, dropped mid-drag so the edge tracks the cursor
- * instead of easing 300ms behind it.
+ * **At `md` and above — push layout.** The panel is position: fixed with a 6px
+ * gap on left/top/bottom so it floats. Its footprint (`width`, gap included) is
+ * user-resizable and persisted; the main content's padding-left tracks the same
+ * value so the two never drift. `FloatingToolbar` is the third reader — see
+ * `SidePanelContext`.
+ *
+ * **Below `md` — full-bleed drawer.** The panel covers the viewport off
+ * `inset-0` and the content is not pushed at all: there is no room beside a
+ * panel on a phone, and the push left the page in a 64px gutter.
+ * `EventDetailPanel` does the same thing mirrored to the right edge.
+ *
+ * Both values travel as **CSS custom properties rather than inline styles**,
+ * which is the only thing that makes the split expressible: an inline `width`
+ * or `padding-left` wins over every class, so no `md:` prefix could undo it
+ * below the breakpoint. `md:right-auto` is load-bearing for the same reason in
+ * reverse — `inset-0` sets `right: 0`, and the docked rail has to give it back.
+ *
+ * `-translate-x-full` is a percentage of the panel's own width, so the collapse
+ * animation follows both a variable width and a full-viewport one for free. The
+ * width itself needs an explicit transition leg, dropped mid-drag so the edge
+ * tracks the cursor instead of easing 300ms behind it.
  */
 export function GlobalLayout({ children }: GlobalLayoutProps) {
   const { isOpen, width, setWidth, resetWidth, isResizing, setIsResizing } = useSidePanel()
@@ -25,10 +38,10 @@ export function GlobalLayout({ children }: GlobalLayoutProps) {
   return (
     <div className="min-h-screen">
       <aside
-        className={`fixed inset-y-0 left-0 z-40 pl-[6px] py-[6px] ${
+        className={`fixed inset-0 z-40 md:inset-y-0 md:left-0 md:right-auto md:w-[var(--side-panel-width)] md:pl-[6px] md:py-[6px] ${
           isResizing ? '' : 'transition-[transform,width] duration-300 ease-out'
         } ${isOpen ? 'translate-x-0' : '-translate-x-full'}`}
-        style={{ width: `${width}px` }}
+        style={{ '--side-panel-width': `${width}px` } as CSSProperties}
         aria-hidden={!isOpen}
       >
         <GlobalSidePanel />
@@ -44,10 +57,10 @@ export function GlobalLayout({ children }: GlobalLayoutProps) {
         )}
       </aside>
       <div
-        className={`min-h-screen ${
+        className={`min-h-screen md:pl-[var(--side-panel-push)] ${
           isResizing ? '' : 'transition-[padding-left] duration-300 ease-out'
         }`}
-        style={{ paddingLeft: isOpen ? `${width}px` : '0px' }}
+        style={{ '--side-panel-push': isOpen ? `${width}px` : '0px' } as CSSProperties}
       >
         {children}
       </div>

--- a/src/components/Navigation/GlobalNav.tsx
+++ b/src/components/Navigation/GlobalNav.tsx
@@ -68,7 +68,7 @@ export function GlobalNav({
 
   return (
     <div>
-      <div className="flex h-[80px] items-start gap-5 px-6 py-[22px] relative">
+      <div className="flex h-[80px] items-start gap-5 px-4 py-[20px] md:px-6 md:py-[22px] relative">
         {/* Left cluster: panel toggle + optional timeline identity */}
         <div className="flex items-start gap-5 min-w-0">
           <div

--- a/src/components/NewTimeline/NewTimelineScreen.tsx
+++ b/src/components/NewTimeline/NewTimelineScreen.tsx
@@ -3,6 +3,11 @@ import type { SubjectType } from '@/constants/pillDefinitions'
 import { SubjectSuggestions } from '@/components/AIMode/SubjectSuggestions'
 import { GeneratingIndicator } from '@/components/NewTimeline/GeneratingIndicator'
 import { useSubjectSuggestions } from '@/hooks/useSubjectSuggestions'
+import {
+  MIN_SUGGESTION_QUERY_LENGTH,
+  pickQuickSearches,
+} from '@/constants/aiSubjectSuggestions'
+import { glassButtonClass } from '@/components/ui/glassButton'
 import { PROVIDER_META } from '@/constants/byokProviders'
 import type { ByokProvider } from '@/types/ai'
 
@@ -30,6 +35,24 @@ const PLACEHOLDER_NAMES = [
   'Civil Rights Movement',
 ]
 
+/**
+ * The field's type at each size, as one string.
+ *
+ * The real input and the typewriter ghost drawn on top of it have to resolve to
+ * identical metrics or the animated placeholder slides off the caret — so both
+ * read this rather than each carrying a copy.
+ *
+ * `.header-small` / `.header-medium` in `index.css` say the same thing, but
+ * stacking them (`header-small md:header-medium`) leaves the winner to source
+ * order between two equal-specificity utilities in the same layer, which is not
+ * a contract worth resting alignment on.
+ */
+const SEARCH_FIELD_FONT =
+  "font-['Aleo',serif] font-normal text-[24px] leading-[1.4] md:text-[32px] md:leading-[1.25]"
+
+/** Box padding. Shared with the ghost overlay, for the same reason. */
+const SEARCH_FIELD_PADDING = 'px-[11px] py-[9px] md:p-[11px]'
+
 function BackgroundGrid() {
   return (
     <div
@@ -39,7 +62,9 @@ function BackgroundGrid() {
       <div
         className="absolute top-0 bottom-0"
         style={{
-          left: '120px',
+          // Tracks the page gutter declared on this screen's root, so the
+          // first column line always lands on the content's left edge.
+          left: 'var(--page-gutter)',
           right: '0',
           backgroundImage:
             'repeating-linear-gradient(to right, rgba(210,210,210,0.1) 0 1px, transparent 1px 200px)',
@@ -131,6 +156,9 @@ export function NewTimelineScreen({
   const [showSuggestions, setShowSuggestions] = useState(false)
   const [hasEngaged, setHasEngaged] = useState(false)
   const [renderDropdown, setRenderDropdown] = useState(false)
+  // Drawn once per mount, so the chips rotate between visits but never move
+  // under a cursor that is already reaching for one.
+  const [quickSearches] = useState(pickQuickSearches)
   const inputRef = useRef<HTMLInputElement>(null)
   const formRef = useRef<HTMLFormElement>(null)
 
@@ -198,8 +226,26 @@ export function NewTimelineScreen({
     inputRef.current?.focus()
   }
 
+  const handleQuickSearch = (subject: string) => {
+    if (isWorking) return
+    // Seed the field before generating: `GeneratingIndicator` reads `name`, and
+    // for a signed-out visitor `onAIGenerate` opens the key/sign-in gate, which
+    // should show what they asked for rather than an empty box.
+    setName(subject)
+    setHasEngaged(true)
+    setShowSuggestions(false)
+    onAIGenerate(subject)
+  }
+
+  // The length test is not redundant with the hook's: that effect runs *after*
+  // render, so on the render where the query drops back to one character
+  // `suggestions` still holds the previous six. Without it, backspacing flashes
+  // stale rows on the way down.
   const dropdownVisible =
-    showSuggestions && !isWorking && (suggestions.length > 0 || suggestionsLoading)
+    showSuggestions &&
+    !isWorking &&
+    name.trim().length >= MIN_SUGGESTION_QUERY_LENGTH &&
+    (suggestions.length > 0 || suggestionsLoading)
 
   useEffect(() => {
     if (dropdownVisible) {
@@ -212,60 +258,91 @@ export function NewTimelineScreen({
   }, [dropdownVisible, renderDropdown])
 
   return (
-    <div className="relative min-h-screen bg-surface-primary overflow-auto">
+    <div className="relative min-h-screen bg-surface-primary overflow-auto [--page-gutter:16px] sm:[--page-gutter:40px] md:[--page-gutter:64px] lg:[--page-gutter:120px]">
       <BackgroundGrid />
       <BackgroundPattern />
       <div className="relative z-10">
-        <div
-          className="flex flex-col items-start gap-[40px]"
-          style={{ padding: '200px 120px 120px 120px' }}
-        >
+        <div className="flex flex-col items-center gap-[40px] px-[var(--page-gutter)] pt-[160px] pb-[64px] md:pt-[200px] md:pb-[120px]">
           <form
             ref={formRef}
             onSubmit={handleSubmit}
             aria-busy={isWorking}
-            className="w-[996px] max-w-full flex flex-col"
+            className="w-full flex flex-col items-center gap-[8px]"
           >
-            <h2 className="header-xsmall text-text-tertiary m-0">
+            <h2 className="header-xsmall text-text-tertiary m-0 text-center">
               Search for a person, era, or event
             </h2>
 
-            <div className="relative flex flex-row items-end gap-[10px] pt-[8px] pb-[2px] min-h-[80px]">
-              <input
-                ref={inputRef}
-                type="text"
-                value={name}
-                onChange={(e) => {
-                  setName(e.target.value)
-                  if (!isWorking) setShowSuggestions(true)
-                }}
-                onFocus={() => {
-                  setHasEngaged(true)
-                  if (!isWorking) setShowSuggestions(true)
-                }}
-                onBlur={() => {
-                  if (name.trim().length === 0) setHasEngaged(false)
-                }}
-                placeholder=""
-                disabled={isWorking}
-                className="flex-1 min-w-0 bg-transparent border-0 outline-none p-0 font-['Aleo'] text-[60px] leading-[100%] font-normal text-text-secondary disabled:opacity-70"
-                aria-label="Subject for timeline generation"
-              />
+            {/* Everything below the heading shares one column so the chips, the
+                suggestions and any error all hang off the field's left edge. */}
+            <div className="w-full max-w-[440px] flex flex-col items-start gap-[4px]">
+              <div className="relative w-full">
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={name}
+                  onChange={(e) => {
+                    setName(e.target.value)
+                    if (!isWorking) setShowSuggestions(true)
+                  }}
+                  onFocus={() => setHasEngaged(true)}
+                  onBlur={() => {
+                    if (name.trim().length === 0) setHasEngaged(false)
+                  }}
+                  placeholder=""
+                  disabled={isWorking}
+                  autoComplete="off"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  enterKeyHint="search"
+                  className={`w-full rounded-[8px] border outline-none transition-colors text-text-secondary focus-visible:ring-1 focus-visible:ring-white/40 disabled:opacity-70 ${SEARCH_FIELD_PADDING} ${SEARCH_FIELD_FONT} ${
+                    hasEngaged
+                      ? 'bg-surface-secondary border-[#404040] shadow-[0px_8px_16px_0px_rgba(155,158,163,0.04)]'
+                      : 'bg-surface-primary border-[#171717] shadow-[0px_8px_16px_0px_rgba(0,0,0,0.4)]'
+                  }`}
+                  aria-label="Subject for timeline generation"
+                />
 
-              {!hasEngaged && name === '' && (
-                <div
-                  aria-hidden="true"
-                  className="pointer-events-none absolute left-0 bottom-[2px] font-['Aleo'] text-[60px] leading-[100%] font-normal text-text-tertiary select-none"
-                >
-                  {placeholderText}
-                  <span className="animate-blink-caret">|</span>
-                </div>
-              )}
+                {/* `border border-transparent` is load-bearing: the input has a
+                    1px border and an inset-0 overlay does not, so without it the
+                    ghost sits a pixel up and left of the real caret. */}
+                {!hasEngaged && name === '' && (
+                  <div
+                    aria-hidden="true"
+                    className={`pointer-events-none absolute inset-0 flex items-center border border-transparent overflow-hidden whitespace-nowrap select-none text-text-tertiary ${SEARCH_FIELD_PADDING} ${SEARCH_FIELD_FONT}`}
+                  >
+                    {placeholderText}
+                    <span className="animate-blink-caret">|</span>
+                  </div>
+                )}
+              </div>
+
+              {/* `type="button"` is required, not tidiness: the form has no
+                  submit control, so Enter works only through HTML's implicit
+                  submission, and a chip left as the default `submit` would
+                  become the form's default button and silently take it over. */}
+              <div
+                role="group"
+                aria-label="Quick searches"
+                className="w-full flex flex-row flex-wrap items-start gap-[8px]"
+              >
+                {quickSearches.map((subject) => (
+                  <button
+                    key={subject}
+                    type="button"
+                    disabled={isWorking}
+                    onClick={() => handleQuickSearch(subject)}
+                    className={`${glassButtonClass} shrink-0 whitespace-nowrap disabled:opacity-50 disabled:pointer-events-none`}
+                  >
+                    {subject}
+                  </button>
+                ))}
+              </div>
 
               {renderDropdown && (
                 <div
                   data-state={dropdownVisible ? 'open' : 'closed'}
-                  className="absolute left-0 top-[calc(100%+4px)] z-20 duration-150 ease-in fill-mode-forwards data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-1 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-1 data-[state=closed]:pointer-events-none"
+                  className="w-full duration-150 ease-in fill-mode-forwards data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-1 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-1 data-[state=closed]:pointer-events-none"
                 >
                   <SubjectSuggestions
                     query={name}
@@ -275,30 +352,30 @@ export function NewTimelineScreen({
                   />
                 </div>
               )}
+
+              {isWorking && (
+                <GeneratingIndicator
+                  subject={name}
+                  phase={isClassifying ? 'classifying' : 'generating'}
+                  categoryLabels={categoryLabels}
+                />
+              )}
+
+              {!isWorking && error && (
+                <div className="mt-[16px] flex flex-wrap items-baseline gap-2">
+                  <p className="text-sm text-red-400 m-0">{error}</p>
+                  {retryProvider && onRetryWithProvider && (
+                    <button
+                      type="button"
+                      onClick={() => onRetryWithProvider(retryProvider)}
+                      className="text-sm text-[#9B9EA3] underline hover:text-[#DADEE5] transition-colors"
+                    >
+                      Retry with {PROVIDER_META[retryProvider].label}
+                    </button>
+                  )}
+                </div>
+              )}
             </div>
-
-            {isWorking && (
-              <GeneratingIndicator
-                subject={name}
-                phase={isClassifying ? 'classifying' : 'generating'}
-                categoryLabels={categoryLabels}
-              />
-            )}
-
-            {!isWorking && error && (
-              <div className="mt-[16px] flex flex-wrap items-baseline gap-2">
-                <p className="text-sm text-red-400 m-0">{error}</p>
-                {retryProvider && onRetryWithProvider && (
-                  <button
-                    type="button"
-                    onClick={() => onRetryWithProvider(retryProvider)}
-                    className="text-sm text-[#9B9EA3] underline hover:text-[#DADEE5] transition-colors"
-                  >
-                    Retry with {PROVIDER_META[retryProvider].label}
-                  </button>
-                )}
-              </div>
-            )}
           </form>
         </div>
       </div>

--- a/src/components/NewTimeline/NewTimelineScreen.tsx
+++ b/src/components/NewTimeline/NewTimelineScreen.tsx
@@ -278,6 +278,10 @@ export function NewTimelineScreen({
                 field itself and covers the chips. */}
             <div className="w-full max-w-[440px] flex flex-col items-start gap-[8px]">
               <div className="relative w-full">
+                {/* Fill and border are constant by design — the component carries
+                    them on its base and varies only the shadow between resting and
+                    typed. Not duplication waiting to be folded away: those two
+                    shadows are the whole of the state difference. */}
                 <input
                   ref={inputRef}
                   type="text"
@@ -296,10 +300,10 @@ export function NewTimelineScreen({
                   autoCorrect="off"
                   spellCheck={false}
                   enterKeyHint="search"
-                  className={`w-full rounded-[8px] border outline-none transition-colors text-text-secondary focus-visible:ring-1 focus-visible:ring-white/40 disabled:opacity-70 ${SEARCH_FIELD_PADDING} ${SEARCH_FIELD_FONT} ${
+                  className={`w-full rounded-[8px] border border-[#404040] bg-surface-secondary outline-none transition-shadow text-text-secondary focus-visible:ring-1 focus-visible:ring-white/40 disabled:opacity-70 ${SEARCH_FIELD_PADDING} ${SEARCH_FIELD_FONT} ${
                     hasEngaged
-                      ? 'bg-surface-secondary border-[#404040] shadow-[0px_8px_16px_0px_rgba(155,158,163,0.04)]'
-                      : 'bg-surface-primary border-[#171717] shadow-[0px_8px_16px_0px_rgba(0,0,0,0.4)]'
+                      ? 'shadow-[0px_8px_16px_0px_rgba(155,158,163,0.04)]'
+                      : 'shadow-[0px_8px_16px_0px_rgba(0,0,0,0.4)]'
                   }`}
                   aria-label="Subject for timeline generation"
                 />

--- a/src/components/NewTimeline/NewTimelineScreen.tsx
+++ b/src/components/NewTimeline/NewTimelineScreen.tsx
@@ -273,9 +273,10 @@ export function NewTimelineScreen({
               Search for a person, era, or event
             </h2>
 
-            {/* Everything below the heading shares one column so the chips, the
-                suggestions and any error all hang off the field's left edge. */}
-            <div className="w-full max-w-[440px] flex flex-col items-start gap-[4px]">
+            {/* One column, so the chips and any error hang off the field's left
+                edge. The suggestions panel is not part of it — it anchors to the
+                field itself and covers the chips. */}
+            <div className="w-full max-w-[440px] flex flex-col items-start gap-[8px]">
               <div className="relative w-full">
                 <input
                   ref={inputRef}
@@ -315,16 +316,39 @@ export function NewTimelineScreen({
                     <span className="animate-blink-caret">|</span>
                   </div>
                 )}
+
+                {renderDropdown && (
+                  <div
+                    data-state={dropdownVisible ? 'open' : 'closed'}
+                    className="absolute left-0 right-0 top-[calc(100%+4px)] z-20 duration-150 ease-in fill-mode-forwards data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-1 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-1 data-[state=closed]:pointer-events-none"
+                  >
+                    <SubjectSuggestions
+                      query={name}
+                      suggestions={suggestions}
+                      isLoading={suggestionsLoading}
+                      onSelect={handleSelectSuggestion}
+                    />
+                  </div>
+                )}
               </div>
 
               {/* `type="button"` is required, not tidiness: the form has no
                   submit control, so Enter works only through HTML's implicit
                   submission, and a chip left as the default `submit` would
-                  become the form's default button and silently take it over. */}
+                  become the form's default button and silently take it over.
+
+                  `invisible` rather than a fade, because it also takes the chips
+                  out of the tab order — right for controls sitting under an open
+                  panel. Keyed to `renderDropdown`, not `dropdownVisible`, so they
+                  stay hidden through the exit animation rather than reappearing
+                  under a panel that is still fading. The row keeps its space
+                  either way, so opening the panel reflows nothing. */}
               <div
                 role="group"
                 aria-label="Quick searches"
-                className="w-full flex flex-row flex-wrap items-start gap-[8px]"
+                className={`w-full flex flex-row flex-wrap items-start gap-[8px] ${
+                  renderDropdown ? 'invisible' : ''
+                }`}
               >
                 {quickSearches.map((subject) => (
                   <button
@@ -338,20 +362,6 @@ export function NewTimelineScreen({
                   </button>
                 ))}
               </div>
-
-              {renderDropdown && (
-                <div
-                  data-state={dropdownVisible ? 'open' : 'closed'}
-                  className="w-full duration-150 ease-in fill-mode-forwards data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-1 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-1 data-[state=closed]:pointer-events-none"
-                >
-                  <SubjectSuggestions
-                    query={name}
-                    suggestions={suggestions}
-                    isLoading={suggestionsLoading}
-                    onSelect={handleSelectSuggestion}
-                  />
-                </div>
-              )}
 
               {isWorking && (
                 <GeneratingIndicator

--- a/src/components/SidePanel/GlobalSidePanel.tsx
+++ b/src/components/SidePanel/GlobalSidePanel.tsx
@@ -8,7 +8,7 @@ import { SidePanelBody } from './SidePanelBody'
 export function GlobalSidePanel() {
   return (
     <div
-      className="h-full w-full bg-[#171717] rounded-[6px] border border-[#262626] flex flex-col overflow-hidden"
+      className="h-full w-full bg-[#171717] rounded-none border-0 md:rounded-[6px] md:border md:border-[#262626] flex flex-col overflow-hidden"
       aria-label="Timelines side panel"
     >
       <SidePanelBody />

--- a/src/components/SidePanel/SidePanelBody.tsx
+++ b/src/components/SidePanel/SidePanelBody.tsx
@@ -11,6 +11,7 @@ import {
   Share2,
   Telescope,
   Trash2,
+  X,
 } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
 import { useAccountTier } from '@/hooks/useAccountTier'
@@ -32,6 +33,7 @@ import {
 import { notifyUsageChanged } from '@/utils/usageChanged'
 import { exportEventsToExcel } from '@/utils/excelExport'
 import { downloadTemplate } from '@/utils/excelSheet'
+import { isPanelOverlay } from '@/constants/panels'
 import type { TimelineEvent } from '@/types/event'
 import { AccountDetailsModal } from '@/components/Modal/AccountDetailsModal'
 import { UsageLimits } from './UsageLimits'
@@ -295,13 +297,23 @@ export function SidePanelBody() {
     })
   }, [activeTimelineId, activeEventCount, activeDominantCategoryColor, applyLocalMetadata])
 
+  /**
+   * Below `md` the panel is a full-bleed drawer over the page, so anything that
+   * navigates has to get out of the way — otherwise the tap lands you on a
+   * screen you cannot see. At desktop widths the panel pushes rather than
+   * covers, so it stays open and only the toggle closes it.
+   */
+  const dismissIfOverlay = () => {
+    if (isPanelOverlay()) close()
+  }
+
   const handleTileClick = (row: TileRow) => {
     if (row.kind === 'timeline') {
       onTimelineSelect(row.id)
     } else {
       onDraftSelect(row.id)
     }
-    // Panel stays open — it's only toggled via the panel-left button
+    dismissIfOverlay()
   }
 
   const confirmDelete = (row: TileRow) => {
@@ -417,10 +429,12 @@ export function SidePanelBody() {
   }
 
   const handleBuildWithAI = () => {
+    dismissIfOverlay()
     navigate('/')
   }
 
   const handleBuildFromScratch = () => {
+    dismissIfOverlay()
     if (user) {
       navigate('/editor', { state: { timelineId: 'new', skipCreationScreen: true } })
     } else {
@@ -429,6 +443,7 @@ export function SidePanelBody() {
   }
 
   const handleImportData = () => {
+    dismissIfOverlay()
     setIsImportOpen(true)
   }
 
@@ -437,6 +452,7 @@ export function SidePanelBody() {
   }
 
   const handleImportEvents = (events: TimelineEvent[]) => {
+    dismissIfOverlay()
     setIsImportOpen(false)
     navigate('/editor', { state: { importedEvents: events } })
   }
@@ -550,7 +566,10 @@ export function SidePanelBody() {
       {/* Header */}
       <div className="flex items-center justify-between gap-2 px-5 pt-4 pb-2 border-b border-[#404040] shrink-0">
         <button
-          onClick={() => navigate('/')}
+          onClick={() => {
+            dismissIfOverlay()
+            navigate('/')
+          }}
           className="font-['Aleo',serif] font-normal text-[18px] leading-[1.4] text-[#c9ced4] hover:text-[#dadee5] transition-colors bg-transparent border-none p-0 cursor-pointer"
         >
           Timelines
@@ -560,7 +579,10 @@ export function SidePanelBody() {
           className="relative flex items-center justify-center p-1.5 rounded-lg border border-white/15 bg-white/10 backdrop-blur-[12px] text-[#c9ced4] shadow-[0px_8px_32px_0px_rgba(0,0,0,0.4),inset_0px_1px_0px_0px_rgba(255,255,255,0.1)] hover:bg-white/20 hover:text-[#dadee5] transition-colors"
           aria-label="Close timelines panel"
         >
-          <PanelLeft size={16} strokeWidth={1.25} />
+          {/* A full-bleed drawer is dismissed, not collapsed, so the rail icon
+              reads wrong below `md`. Same swap as `EventDetailPanel`. */}
+          <PanelLeft size={16} strokeWidth={1.25} className="hidden md:block" />
+          <X size={16} strokeWidth={1.25} className="md:hidden" />
         </button>
       </div>
 

--- a/src/constants/aiSubjectSuggestions.ts
+++ b/src/constants/aiSubjectSuggestions.ts
@@ -3,11 +3,15 @@ export interface SubjectSuggestion {
   description?: string
 }
 
-export const DEFAULT_SUBJECT_SUGGESTIONS: SubjectSuggestion[] = [
-  { title: 'Kobe Bryant', description: 'American basketball player' },
-  { title: 'Frida Kahlo', description: 'Mexican painter' },
-  { title: 'Muhammad Ali', description: 'American boxer' },
-]
+/**
+ * Shortest query that earns a suggestion request — and the same threshold the
+ * dropdown opens at, so the panel can never appear holding nothing useful. One
+ * character matches thousands of Wikipedia titles and none of them usefully.
+ *
+ * Read by `useSubjectSuggestions` and by the dropdown's visibility gate. They
+ * have to agree, which is why the number lives here rather than in either.
+ */
+export const MIN_SUGGESTION_QUERY_LENGTH = 2
 
 export const SUBJECT_SUGGESTIONS: string[] = [
   // People — Athletes
@@ -88,3 +92,61 @@ export const SUBJECT_SUGGESTIONS: string[] = [
   'The United Nations',
   'SpaceX',
 ]
+
+/**
+ * What one quick-search chip costs the row, in px.
+ *
+ * `glassButtonClass` gives every chip `min-w-[80px]` and `px-[11px]`, and at
+ * its 14px medium type a label measures about 8px per character — checked
+ * against the rendered chips rather than assumed. The floor is why a character
+ * budget cannot stand in for this one: `NASA` spends four characters and 80px.
+ *
+ * Deliberately an over-estimate for longer labels (a 17-character name comes
+ * out at 158px against a measured 148px), and the measurement came from a wide
+ * system sans. Both errors point the same way — a row that fits here fits on
+ * the narrower faces phones actually ship.
+ */
+function estimateChipWidth(subject: string): number {
+  return Math.max(80, 22 + subject.length * 8)
+}
+
+/**
+ * How much width the chip row plans for.
+ *
+ * The narrowest common phone is 375px, which leaves `375 - 32` of page gutter
+ * for the field, less the row's two 8px gaps: 327px across three chips.
+ *
+ * A preference, not a guarantee — the row is `flex-wrap`, so a draw that
+ * overruns on an unusually wide face wraps rather than clipping.
+ */
+const QUICK_SEARCH_ROW_BUDGET = 327
+
+/**
+ * Draw `count` distinct subjects for the quick-search chips under the field.
+ *
+ * Meant for a `useState` initializer, so the set is fixed for the life of the
+ * screen and rotates per visit — chips that reshuffled mid-session would be a
+ * target that moves while you reach for it.
+ */
+export function pickQuickSearches(count = 3): string[] {
+  const pool = [...SUBJECT_SUGGESTIONS]
+  const picked: string[] = []
+  let remaining = QUICK_SEARCH_ROW_BUDGET
+
+  while (picked.length < count && pool.length > 0) {
+    // Every chip still to be drawn gets an equal share of what is left, so an
+    // early long draw cannot spend the row on itself. The share never falls
+    // below a chip's 80px floor, so `eligible` holds for every real draw and
+    // the total stays inside the budget by construction.
+    const share = remaining / (count - picked.length)
+    const eligible = pool.filter((subject) => estimateChipWidth(subject) <= share)
+    const source = eligible.length > 0 ? eligible : pool
+    const subject = source[Math.floor(Math.random() * source.length)]
+
+    pool.splice(pool.indexOf(subject), 1)
+    picked.push(subject)
+    remaining -= estimateChipWidth(subject)
+  }
+
+  return picked
+}

--- a/src/constants/panels.ts
+++ b/src/constants/panels.ts
@@ -33,8 +33,27 @@ export const PANEL_RESIZE_BREAKPOINT = 768
 /**
  * Content that must stay visible beside a panel below the breakpoint, so a
  * stored desktop width can't leave a phone with nothing but panel.
+ *
+ * Applies to Settings and Feedback, which stay narrow rails at every width. The
+ * left panel and the event details panel go full-bleed below the breakpoint and
+ * ignore their width there, so for those two the clamp now only costs the
+ * stored preference — see `usePanelWidth`, which persists the clamped value.
  */
 export const MIN_CONTENT_GUTTER = 64
+
+/**
+ * True when the left panel covers the page rather than pushing it aside.
+ *
+ * Below `PANEL_RESIZE_BREAKPOINT` `GlobalLayout` renders it as a full-bleed
+ * drawer, so anything that navigates has to dismiss it first.
+ *
+ * A one-shot read rather than a hook: the answer is only wanted at the moment
+ * of a click, and a hook would re-render the panel on every viewport change to
+ * compute something nothing renders.
+ */
+export function isPanelOverlay(): boolean {
+  return typeof window !== 'undefined' && window.innerWidth < PANEL_RESIZE_BREAKPOINT
+}
 
 /** Default footprint for the left timelines panel and the event details panel. */
 export const PANEL_DEFAULT_WIDTH = 320

--- a/src/contexts/SidePanelContext.tsx
+++ b/src/contexts/SidePanelContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { usePanelWidth } from '@/hooks/usePanelWidth'
-import { PANEL_DEFAULT_WIDTH } from '@/constants/panels'
+import { PANEL_DEFAULT_WIDTH, PANEL_RESIZE_BREAKPOINT } from '@/constants/panels'
 
 type TimelineSelectHandler = (timelineId: string) => void
 type DraftSelectHandler = (draftId: string) => void
@@ -61,13 +61,25 @@ export const SidePanelContext = createContext<SidePanelContextValue | null>(null
 const STORAGE_KEY = 'side_panel_open'
 const WIDTH_STORAGE_KEY = 'side_panel_width'
 
+/**
+ * Open by default — except on a viewport too narrow to hold the panel and
+ * anything else beside it. Below `PANEL_RESIZE_BREAKPOINT` the resize handles
+ * are hidden and `clampPanelWidth` shrinks the panel to
+ * `viewportWidth - MIN_CONTENT_GUTTER`, so a first visit on a phone used to
+ * land on a 64px strip of page next to a panel nobody asked for.
+ *
+ * Only the nothing-stored case moves. A returning user's own choice still wins
+ * on every device, and at desktop widths this is the `true` it has always been.
+ */
 function readStoredIsOpen(): boolean {
+  const defaultIsOpen =
+    typeof window === 'undefined' || window.innerWidth >= PANEL_RESIZE_BREAKPOINT
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
-    if (raw === null) return true
+    if (raw === null) return defaultIsOpen
     return raw === 'true'
   } catch {
-    return true
+    return defaultIsOpen
   }
 }
 

--- a/src/hooks/useSubjectSuggestions.ts
+++ b/src/hooks/useSubjectSuggestions.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import {
-  DEFAULT_SUBJECT_SUGGESTIONS,
+  MIN_SUGGESTION_QUERY_LENGTH,
   type SubjectSuggestion,
 } from '@/constants/aiSubjectSuggestions'
 import { searchWikipedia } from '@/services/wikipediaSearch'
@@ -11,19 +11,15 @@ export interface UseSubjectSuggestionsResult {
 }
 
 export function useSubjectSuggestions(query: string): UseSubjectSuggestionsResult {
-  const [suggestions, setSuggestions] = useState<SubjectSuggestion[]>(DEFAULT_SUBJECT_SUGGESTIONS)
+  // Empty, not a set of defaults: the dropdown no longer opens on focus, so a
+  // query too short to search is a query with nothing to show.
+  const [suggestions, setSuggestions] = useState<SubjectSuggestion[]>([])
   const [isLoading, setIsLoading] = useState(false)
 
   useEffect(() => {
     const trimmed = query.trim()
 
-    if (trimmed.length === 0) {
-      setSuggestions(DEFAULT_SUBJECT_SUGGESTIONS)
-      setIsLoading(false)
-      return
-    }
-
-    if (trimmed.length === 1) {
+    if (trimmed.length < MIN_SUGGESTION_QUERY_LENGTH) {
       setSuggestions([])
       setIsLoading(false)
       return


### PR DESCRIPTION
Brings the `/` search field to the Figma design ([desktop](https://www.figma.com/design/UOK8iRF59saXCjSEbHVooR/Timeline.academy?node-id=5893-40049), [mobile](https://www.figma.com/design/UOK8iRF59saXCjSEbHVooR/Timeline.academy?node-id=5894-40284)) and makes the page usable on a phone. Nothing on this screen carried a responsive class before, and its page padding was an inline style that breakpoints could not reach.

## What changes

**The field is a real input.** A bordered, filled box centred in the content area — 32px Aleo on desktop, 24px on mobile — replacing the borderless 60px field pinned against a hardcoded 120px left padding. It has a resting treatment (darker fill, dim border) that lifts to the active one once focused or holding text. That state is the existing `hasEngaged`, which already meant exactly "focused or non-empty", so no new state was needed.

**Quick-search chips** sit under the field, so a visitor can reach a timeline in one tap. Labels are drawn per visit from the curated `SUBJECT_SUGGESTIONS` list — 68 entries that were exported and imported nowhere until now. They reuse `glassButtonClass`, which turned out to be a pixel match for the Figma chip.

**The dropdown no longer opens on focus.** It waits for `MIN_SUGGESTION_QUERY_LENGTH`, which gives a name to the unnamed `trimmed.length === 1` branch that previously lived in the hook alone. `DEFAULT_SUBJECT_SUGGESTIONS` had no consumer left once focus stopped surfacing it, so it is deleted; the chips are what replaces it. The panel anchors 4px below the field, spans its width, and covers the chip row rather than following it. Spacing down the column is an even 8px.

**The timelines panel becomes a full-bleed drawer below 768px.** It covers the viewport and slides over the page instead of pushing it — there is no room beside a panel on a phone, and the push layout left the page in a 64px gutter. The toggle floats 16px/20px from the viewport edge, and anything that navigates dismisses the drawer first. The panel also now defaults closed at phone widths on a first visit. Desktop keeps the resizable push layout unchanged.

## Four things worth a reviewer's attention

**The panel width had to stop being an inline style.** An inline `width` or `padding-left` beats every class, so no `md:` prefix could undo it below the breakpoint. Both move to CSS custom properties. `EventDetailPanel` already solved exactly this, mirrored to the right edge, and this follows it rather than inventing a second approach — including `md:right-auto`, which is load-bearing because `inset-0` sets `right: 0` and the docked rail has to give it back.

**The nav's padding, not a fixed button, positions the toggle.** `/` renders the nav absolutely; `/editor` renders it in flow inside a container whose push padding is now zero at phone widths. Dropping the nav's padding to 16/20 below `md` lands both on the same offset from the viewport edge. A `fixed` button would have escaped the editor's flow layout and needed its own spacer.

**The chip row budgets pixels, not characters.** `glassButtonClass` carries `min-w-[80px]`, so a short label spends few characters but 80px of width regardless. A character budget therefore lets a draw like `["NASA", 14-char, 15-char]` satisfy the limit and still overflow — I measured this happening before switching units. The estimate (`max(80, 22 + chars × 8)`) was checked against rendered chips; 2,400 sampled draws stay on one row at 375/393/430px. `flex-wrap` remains the correctness guarantee.

**The screen re-checks the query length rather than trusting the hook.** The hook's effect runs *after* render, so on the render where the query drops back to one character the previous six suggestions are still in state. Without the check, backspacing flashes them.

## Supporting changes

- The page gutter is one inherited custom property (16 / 40 / 64 / 120px) instead of an inline style plus a second hardcoded 120px in `BackgroundGrid` kept in sync by hand. It reaches 120px only at `lg:`: the content box is viewport minus the side panel, so at `md:` with the panel open, 120px gutters would leave 208px for a 440px column.
- The field's type and padding are shared constants. The real input and the typewriter ghost drawn over it must resolve identically or the placeholder slides off the caret; the ghost also needs a transparent border, since the input has one and an `inset-0` overlay does not.
- The chips go `invisible`, not transparent, while the panel is up — the panel is translucent over a backdrop blur, so anything underneath reads through it, and `visibility: hidden` also drops them out of the tab order. Keyed to `renderDropdown` so they stay hidden through the exit animation rather than reappearing under a panel still fading.
- The suggestions panel drops `min-w-[350px]`, which was the real overflow bug — `min-width` beats `max-width`, so `max-w-full` never applied inside a narrower column. It now tracks the field, hugs its content up to a cap, and truncates rows.
- Suggestion rows gain `onClick` alongside `onMouseDown`, so selection does not depend on a synthesized mouse event, and `shrink-0` so a scrollable panel cannot squash them below 36px.
- The drawer's close control shows an X below `md` — a full-bleed drawer is dismissed, not collapsed, so the rail icon reads wrong there. Same swap `EventDetailPanel` makes.

## Verification

No test framework is configured, so this was driven in a real browser and measured with `getBoundingClientRect()` rather than eyeballed. `npm run lint` and `npm run build` are clean; the typecheck error count is unchanged at 23 (all pre-existing, none in touched files). Both new Tailwind arbitrary-value classes were confirmed to emit inside `@media (min-width: 768px)` — a class that fails to generate fails silently.

**Search field**, at 393 and 1440: label → field 8px, field → chips 8px, field → panel 4px, exact at both. Panel width equals field width (361/440) and its box fully spans the chip row. Chip row is `hidden` while open, still `hidden` 120ms into the fade, `visible` after; Tab from the field skips it. Heading, field and chip positions identical open vs. closed — no reflow. Ghost placeholder pixel-exact against the input at both type sizes.

**Drawer**, at 393: toggle at exactly (16, 20) on `/` **and** `/editor`; opening gives an aside rect equal to the full viewport, a card with `border-width: 0` and `border-radius: 0`, and content `padding-left: 0px`; the page centre hit-tests inside the drawer. Tapping "AI Timeline" and "New Timeline" closes it; "Download Template" leaves it open. A returning user with `side_panel_open: 'true'` gets the drawer full-bleed on load and can dismiss it.

**Desktop unchanged**, at 768 and 1440: aside width equals the stored width, card has its 6px radius and `#262626` border, content padding equals the width, toggle back at (24, 22), and clicking an action leaves the panel open.

**Behaviour**, at 375 / 393 / 430 / 768 / 1440: cold load → panel closed, 16px gutters, no horizontal overflow. Focus does not open the dropdown; one character does not; two do; backspacing to one closes with no stale rows. Chip tap fills the field and starts generation; signed out it opens the key/sign-in gate showing that subject. Touch tap selects a suggestion; mouse click selects and refocuses. Enter submits, Escape closes, outside click closes, clicking inside the form does not.

At 768 with the panel open the search column clamps to 320px and the chips still fit one row — the acknowledged worst case, handled.

## Follow-ups, not in this PR

- **`usePanelWidth` persists the clamped width.** Below 768 `clampPanelWidth` returns `viewportWidth - 64`, so a phone visit rewrites `side_panel_width` and the chosen desktop width is gone. This predates the PR, but now that the left panel ignores its width on mobile the clamp costs a stored preference and buys nothing there. The fix is to persist intent and clamp only for render — a change to a hook all four panels share, so it wants its own diff.
- **`Avenir` never loads, and the fix is a deletion.** `index.css:79-84` points a `@font-face src` at a URL that returns a *stylesheet*, not a font binary. Worse, a `@font-face` outranks a system-installed font of the same name, so the failed face masks the real Avenir that ships with macOS and iOS. Deleting the block would render it on every Apple device with no new dependency. Held back deliberately: it shifts type across the whole interface.
- **Enter ignores the dropdown highlight.** ArrowUp/ArrowDown move a visible highlight local to `SubjectSuggestions`, but `handleSubmit` cannot see it, so ↓↓Enter generates the raw typed text. The fix moves state ownership.
- **Landscape phones.** The suggestions panel is absolutely positioned, so it does not extend the page's scroll height; portrait is fine at 393×852 even with the keyboard up, but an 852×393 viewport is ≥768 and takes `md:pt-[200px]`, putting the field halfway down the window. Worth its own pass.
- The search input has no `role="combobox"` / `aria-expanded` pointing at the `role="listbox"`, and the mobile drawer has no focus trap.
- `BackgroundPattern`'s ellipses are positioned for a 1440 frame, so four of five fall outside a phone's clip.