### PR TITLE
Centre the global nav on mobile and raise the title to Header/Small

### DIFF
--- a/src/components/Navigation/GlobalNav.tsx
+++ b/src/components/Navigation/GlobalNav.tsx
@@ -68,11 +68,13 @@ export function GlobalNav({
 
   return (
     <div>
-      <div className="flex h-[80px] items-start gap-5 px-4 py-[20px] md:px-6 md:py-[22px] relative">
-        {/* Left cluster: panel toggle + optional timeline identity */}
-        <div className="flex items-start gap-5 min-w-0">
+      <div className="flex h-[80px] items-start gap-5 px-4 pt-4 pb-3 md:px-6 md:py-[22px] relative">
+        {/* Left cluster: panel toggle + optional timeline identity.
+            Below `md` it owns the whole bar so the title can centre in it — the
+            right cluster is gone there and the toggle floats out of flow. */}
+        <div className="flex w-full items-start gap-5 min-w-0 md:w-auto">
           <div
-            className={`shrink-0 overflow-visible transition-[max-width,opacity,margin] duration-300 ease-out ${
+            className={`absolute left-4 top-4 z-10 md:static md:z-auto shrink-0 overflow-visible transition-[max-width,opacity,margin] duration-300 ease-out ${
               isPanelOpen ? 'max-w-0 opacity-0 pointer-events-none -ml-5' : 'max-w-[48px] opacity-100'
             }`}
             aria-hidden={isPanelOpen}
@@ -88,7 +90,7 @@ export function GlobalNav({
           </div>
 
           {showTitleCluster && (
-            <div className="flex flex-col gap-1 min-w-0">
+            <div className="flex flex-col gap-0 min-w-0 w-full items-center text-center px-10 md:gap-[2px] md:w-auto md:items-start md:text-left md:px-0">
               {onTimelineTitleChange && mode === 'edit' ? (
                 <input
                   type="text"
@@ -102,11 +104,14 @@ export function GlobalNav({
                   placeholder="Untitled Timeline"
                   aria-label="Timeline name"
                   size={Math.max((timelineTitle ?? '').length, 'Untitled Timeline'.length)}
-                  className="font-['Aleo',serif] font-normal text-[18px] leading-[1.4] text-text-secondary hover:text-text-primary focus:text-text-primary bg-transparent border-none outline-none caret-white min-w-0 p-0"
+                  // `fieldSizing: content` sizes the box to the text, so
+                  // without a cap a long title runs off the bar — and on mobile
+                  // straight under the floating panel toggle.
+                  className="header-small text-text-primary text-center md:text-left bg-transparent border-none outline-none caret-white min-w-0 max-w-full p-0"
                   style={{ fieldSizing: 'content' } as CSSProperties}
                 />
               ) : (
-                <p className="font-['Aleo',serif] font-normal text-[18px] leading-[1.4] text-text-secondary truncate">
+                <p className="header-small text-text-primary max-w-full truncate">
                   {timelineTitle || 'Untitled Timeline'}
                 </p>
               )}
@@ -127,8 +132,12 @@ export function GlobalNav({
           )}
         </div>
 
-        {/* Right cluster: save status + action buttons */}
-        <div className="ml-auto flex items-center gap-2">
+        {/* Right cluster: save status + action buttons. Hidden below `md` —
+            the mobile header is title-only. `mode` is unpersisted state that
+            defaults to 'edit' (App.tsx), so hiding the toggle can't strand a
+            phone in view mode, and FloatingToolbar already carries the editing
+            affordances there. */}
+        <div className="ml-auto hidden md:flex items-center gap-2">
           {/* SaveStatusIndicator hidden for now — keeping wiring in place for future reuse */}
           {SHOW_SAVE_STATUS && variant === 'timeline' && saveStatus && (
             <div className="hidden md:block mr-2">

--- a/src/components/NewTimeline/NewTimelineScreen.tsx
+++ b/src/components/NewTimeline/NewTimelineScreen.tsx
@@ -48,7 +48,7 @@ const PLACEHOLDER_NAMES = [
  * a contract worth resting alignment on.
  */
 const SEARCH_FIELD_FONT =
-  "font-['Aleo',serif] font-normal text-[24px] leading-[1.4] md:text-[32px] md:leading-[1.25]"
+  "font-['Aleo',serif] font-normal tracking-[-0.01em] text-[24px] leading-[1.4] md:text-[32px] md:leading-[1.25]"
 
 /** Box padding. Shared with the ghost overlay, for the same reason. */
 const SEARCH_FIELD_PADDING = 'px-[11px] py-[9px] md:p-[11px]'

--- a/src/index.css
+++ b/src/index.css
@@ -123,6 +123,7 @@
     font-weight: 500;
     font-size: 48px;
     line-height: 115%;
+    letter-spacing: -0.01em;
   }
 
   .header-medium {
@@ -130,6 +131,7 @@
     font-weight: 400;
     font-size: 32px;
     line-height: 125%;
+    letter-spacing: -0.01em;
   }
 
   .header-small {
@@ -137,6 +139,7 @@
     font-weight: 400;
     font-size: 24px;
     line-height: 140%;
+    letter-spacing: -0.01em;
   }
 
   .header-xsmall {


### PR DESCRIPTION
## Summary

The global nav shown after a search (`variant="timeline"`) was built desktop-first and never adapted below `md`. On a phone the 80px bar tried to hold a left-aligned title cluster, a 174px Edit/Present toggle and a Share button inside 361px.

Below `md` it now matches the [Figma mobile frame](https://www.figma.com/design/UOK8iRF59saXCjSEbHVooR/Timeline.academy?node-id=5896-40511): the panel toggle floats at the left over a centred title and its date/events line, and the right cluster is gone entirely. Desktop keeps the left-aligned treatment from the [three-variant frame](https://www.figma.com/design/UOK8iRF59saXCjSEbHVooR/Timeline.academy?node-id=5638-17966) and changes only in type.

Alongside that, the type scale moved: the timeline title is Header/Small at every width in `text-color/Primary`, and Header large / medium / small all carry -1% letter spacing.

## Changes

**`src/index.css`** — `letter-spacing: -0.01em` on `.header-large`, `.header-medium` and `.header-small`. CSS `letter-spacing` takes no percentage, and `em` resolves against the element's own `font-size`, so `-0.01em` *is* -1%: 24px → -0.24px, matching what Figma emits. `.header-xsmall` is unchanged.

**`src/components/Navigation/GlobalNav.tsx`**
- Bar padding `px-4 pt-4 pb-3 md:px-6 md:py-[22px]`; height stays `h-[80px]` at both widths, so `App.tsx`'s `pt-[140px]` on `<main>` stays valid.
- Panel toggle is `absolute left-4 top-4 z-10 md:static`, floating over the centred title exactly as the frame has it. Its existing `isPanelOpen` collapse classes are untouched.
- Title cluster is full-width and centred below `md`, left-aligned above it. Its horizontal padding is symmetric, so it holds a long title clear of the toggle without moving the centre.
- Both title branches drop their inline `font-['Aleo',serif] … text-[18px]` for the `header-small` token and a flat `text-text-primary`. A single header class is safe here — the source-order hazard documented in `NewTimelineScreen` applies only to *stacking* two across a breakpoint.
- The editable title is capped at the container width. `fieldSizing: content` sizes the box to its text, so a long name previously ran off the bar unchecked (measured at −29→404px in a 375px viewport).
- Right cluster is `hidden md:flex`, which hides the Edit/Present toggle and Share together. No trap: `mode` is unpersisted state defaulting to `'edit'`, and `FloatingToolbar` already ships a `flex md:hidden` bottom bar for the editing affordances.

**`src/components/NewTimeline/NewTimelineScreen.tsx`** — `SEARCH_FIELD_FONT` is a deliberate inline copy of the header-small/medium metrics (its docblock says why), so it gains `tracking-[-0.01em]` in step. Without this the AI-mode field would silently diverge from the classes it mirrors.

## Verification

`npm run lint` and `npm run build` both pass. Checked in Chromium against the dev server at 375px and 1440px, with the side panel open and closed:

- Title computes to `Aleo 400 24px/33.6px ls=-0.24px` in `rgb(218, 222, 229)` — Header/Small in text-color/Primary — at every width.
- Mobile: title centres to the bar exactly (0px offset), toggle lands at left 16 / top 16, no Edit/Present and no Share.
- A 42-character title stays inside the bar with clearance from the toggle, rather than overflowing the viewport.
- Desktop: title left-aligned beside the toggle when the panel is closed, flush to the content edge when it is open; Edit/Present and Share both present.
- AI-mode search field and its typewriter ghost stay aligned and both report the new tracking (-0.24px at 24px, -0.32px at 32px).

Not covered by the automated pass: `.header-large` has no consumers in TSX today, so Tailwind purges it from the bundle — the rule is correct in source and will emit as soon as something uses it.

## Out of scope

- The toggle's icon is `PanelLeft size={16}`; Figma draws it at 20px in every variant. Pre-existing mismatch, left alone.
- `Avenir` still doesn't load, so the Edit/Present labels keep falling back.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FT7MeLAEDCX4uU5T5g3eZY)_