### PR TITLE
Add a category legend, and move the Edit/Present switch into the dock

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -942,6 +942,8 @@ export function App() {
         timelineTitle={title}
         onTimelineTitleChange={setTitle}
         events={events}
+        categories={categories}
+        onCategoriesChange={updateCategories}
         timelineAccentColor={timelineAccentColor}
         saveStatus={saveStatus}
         lastSavedTime={lastSavedTime}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -948,11 +948,6 @@ export function App() {
         saveStatus={saveStatus}
         lastSavedTime={lastSavedTime}
         mode={mode}
-        onModeChange={(newMode) => {
-          setMode(newMode);
-          // Force any open editing panel closed when switching to view mode.
-          if (newMode === 'view') setActivePanel(null);
-        }}
       />
       <Header
         title={title}
@@ -978,6 +973,15 @@ export function App() {
         onCloseAddEventModal={() => setShowAddEventModal(false)}
         onDeleteTimeline={handleDeleteTimeline}
         mode={mode}
+        onModeChange={(newMode) => {
+          setMode(newMode);
+          if (newMode === 'view') {
+            // Settings has no control in present mode, so it must not stay
+            // open. Events does — it keeps its dock button and opens read-only.
+            setActivePanel(prev => (prev === 'settings' ? null : prev));
+            setShowAddEventModal(false);
+          }
+        }}
       />
       {bootstrapError ? (
         <div className="flex-1 flex items-center justify-center py-20">

--- a/src/TIMELINE_ARCHITECTURE.md
+++ b/src/TIMELINE_ARCHITECTURE.md
@@ -171,7 +171,9 @@ In grouped mode, each `TimelineEvent` receives `categoryOffset = band.offset` so
 
 ## Edit / View Modes
 
-The `mode` prop is `'edit' | 'view'` and defaults to `'edit'`. `Timeline.tsx` derives `const isEditing = mode === 'edit'`.
+The `mode` prop is `'edit' | 'view'` and defaults to `'edit'`. `Timeline.tsx` derives `const isEditing = mode === 'edit'`, as do `FloatingToolbar` and `EventTableEditor`.
+
+The switch itself lives in the **dock** (`FloatingToolbar/ModeTabs.tsx`), not the nav. That is why the dock renders in both modes: unmounting it in view mode would leave no way back. `GlobalNav` still takes `mode` — it decides whether the title is an input — but no longer changes it.
 
 | Affordance | Edit mode | View mode |
 |---|---|---|
@@ -179,6 +181,15 @@ The `mode` prop is `'edit' | 'view'` and defaults to `'edit'`. `Timeline.tsx` de
 | Add-Event Cursor (hover band) | Rendered when `onAddEvent` is provided. | Not rendered. |
 | Click on event | Opens `EventActionsMenu` at the click position. | Calls `onOpenDetails(event)`. |
 | Click on a month cell | Opens the `EventForm` Dialog seeded with that month's first day. | No-op (`handleMonthClick` returns early). |
+| Timeline title (`GlobalNav`) | Editable `<input>`. | Static `<p>`. |
+| Dock buttons | Add Event, Events, Settings. | Add Event and Settings collapse to zero width and fade out; Events stays. |
+| Mode tabs in the dock | Desktop only. | Desktop, plus the mobile footer — so a window narrowed while presenting can still get back. |
+| `EventDetailPanel` footer | Regenerate / Remove shown. | Hidden (`showFooter`). |
+| `EventTableEditor` | Full editor: Categories page, editable cells, row add/delete, category reorder, Cancel/Save. | Reader: Categories page absent, cells static, no delete column, no Add/Save, Cancel becomes **Close**. The rail's category *filter* stays — it is a reading affordance — but loses drag-to-reorder. |
+
+Switching to view mode closes the Settings panel and the Add Event dialog (`App.tsx`'s `onModeChange`); the Events modal is allowed to stay open, because it has a read-only form. Both closes are defensive — each of those surfaces renders a modal backdrop above the dock, so neither can actually be open at the moment the tabs are clicked.
+
+The dock's width is content-derived rather than a literal, so collapsing a button animates the pill and `translateX(-50%)` keeps it centred without a `width` transition of its own. `Collapsible` measures its child's `scrollWidth` for the open `max-width`: a hardcoded value would either clip the label or waste the start of the animation, and the labels are set in whatever sans the OS supplies since Avenir never loads.
 
 ---
 

--- a/src/components/EventTableEditor/EventTableEditor.tsx
+++ b/src/components/EventTableEditor/EventTableEditor.tsx
@@ -56,6 +56,12 @@ interface EventTableEditorProps {
   onEventsChange: (events: TimelineEvent[]) => void
   categories: CategoryConfig[]
   onCategoriesChange: (categories: CategoryConfig[]) => void
+  /**
+   * Edit/View mode. In view mode this is a reader: the Categories page is gone,
+   * every cell is static, and the footer offers only Close. Reachable because
+   * the dock keeps its Events button while presenting.
+   */
+  mode?: 'edit' | 'view'
 }
 
 interface DraftEvent extends Omit<TimelineEvent, 'id'> {
@@ -273,6 +279,7 @@ function DatePickerCell({
   disabledBefore,
   isEmpty,
   isFilled,
+  readOnly = false,
 }: {
   value: string
   onChange: (date: string) => void
@@ -280,6 +287,7 @@ function DatePickerCell({
   disabledBefore?: Date
   isEmpty: boolean
   isFilled: boolean
+  readOnly?: boolean
 }) {
   const [open, setOpen] = useState(false)
 
@@ -292,7 +300,26 @@ function DatePickerCell({
 
   const cellBg = isEmpty && !isFilled
     ? 'bg-[#151617]'
-    : 'bg-transparent hover:bg-[#151617]'
+    : readOnly
+      ? 'bg-transparent'
+      : 'bg-transparent hover:bg-[#151617]'
+
+  // Read-only drops the Popover entirely rather than disabling the trigger —
+  // the calendar has nothing to offer when the value cannot change.
+  if (readOnly) {
+    return (
+      <div
+        className={`
+          w-full text-left px-[6px] py-[5px] rounded-[4px]
+          font-['Avenir',sans-serif] font-normal text-[14px] leading-[20px]
+          ${cellBg}
+          ${value ? 'text-[#c9ced4]' : 'text-[#6b6e73]'}
+        `}
+      >
+        {value ? formatDateDisplay(value) : '—'}
+      </div>
+    )
+  }
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -376,7 +403,9 @@ export function EventTableEditor({
   onEventsChange,
   categories,
   onCategoriesChange,
+  mode = 'edit',
 }: EventTableEditorProps) {
+  const isEditing = mode === 'edit'
   const [activePageTab, setActivePageTab] = useState<'events' | 'categories'>('events')
   const [activeCategory, setActiveCategory] = useState<string | null>(null)
   const [emptyRows, setEmptyRows] = useState<DraftEvent[]>([])
@@ -583,7 +612,7 @@ export function EventTableEditor({
               sit. The tabs themselves are in the rail now. */}
           <div className="sm:col-start-2 sm:row-start-1 flex items-start justify-between gap-4 px-6 pt-5 pb-4">
             <DialogPrimitive.Title className="m-0 font-['Aleo',serif] font-normal text-[20px] leading-[1.4] text-[#dadee5]">
-              {activePageTab === 'events' ? 'Events' : 'Categories'}
+              {isEditing && activePageTab === 'categories' ? 'Categories' : 'Events'}
             </DialogPrimitive.Title>
           </div>
 
@@ -601,13 +630,15 @@ export function EventTableEditor({
               >
                 Events
               </button>
-              <button
-                onClick={() => setActivePageTab('categories')}
-                aria-current={activePageTab === 'categories' ? 'page' : undefined}
-                className={modalSidebarTabClass(activePageTab === 'categories')}
-              >
-                Categories
-              </button>
+              {isEditing && (
+                <button
+                  onClick={() => setActivePageTab('categories')}
+                  aria-current={activePageTab === 'categories' ? 'page' : undefined}
+                  className={modalSidebarTabClass(activePageTab === 'categories')}
+                >
+                  Categories
+                </button>
+              )}
             </div>
 
             {activePageTab === 'events' && (
@@ -632,7 +663,7 @@ export function EventTableEditor({
                     help: it makes the two gestures identical rather than
                     distinguishing them.
                   */}
-                  {isNarrow ? (
+                  {isNarrow || !isEditing ? (
                     draftCategories.map(cat => (
                       <CategoryTab
                         key={cat.id}
@@ -670,7 +701,7 @@ export function EventTableEditor({
 
           {/* Content Area */}
           <div className="sm:col-start-2 sm:row-start-2 min-w-0 min-h-0 px-6 pb-2 overflow-hidden">
-            {activePageTab === 'events' ? (
+            {!isEditing || activePageTab === 'events' ? (
               /* Events Tab Content */
               <div className="flex h-full">
                 {/* Table Area */}
@@ -680,11 +711,13 @@ export function EventTableEditor({
                     className="flex items-center pl-[16px] pr-[10px] pb-2 gap-[22px] border-b border-[rgba(210,210,210,0.2)]"
                     style={{ fontFamily: "'JetBrains Mono', monospace", fontWeight: 300, fontSize: '12px', lineHeight: '1.4', color: '#9b9ea3' }}
                   >
-                    <div className="w-[240px] shrink-0">Title <span className="text-destructive">*</span></div>
-                    <div className="w-[90px] shrink-0">Start Date <span className="text-destructive">*</span></div>
+                    <div className="w-[240px] shrink-0">Title {isEditing && <span className="text-destructive">*</span>}</div>
+                    <div className="w-[90px] shrink-0">Start Date {isEditing && <span className="text-destructive">*</span>}</div>
                     <div className="w-[90px] shrink-0">End Date</div>
-                    <div className="flex-1">Category <span className="text-destructive">*</span></div>
-                    <div className="w-[32px] shrink-0"></div>
+                    <div className="flex-1">Category {isEditing && <span className="text-destructive">*</span>}</div>
+                    {/* Spacer for the delete column — must appear and disappear
+                        with the cell below it or the columns misalign. */}
+                    {isEditing && <div className="w-[32px] shrink-0"></div>}
                   </div>
 
                   {/* Scrollable Event Rows */}
@@ -705,15 +738,22 @@ export function EventTableEditor({
                               onChange={(e) => handleEventChange(event.id, { title: e.target.value })}
                               placeholder="Event title"
                               autoComplete="off"
+                              readOnly={!isEditing}
+                              // Stays an <input> when read-only so the text is
+                              // still selectable and the column widths do not
+                              // shift; only the hover/focus fills go, since
+                              // those are what read as "editable".
                               className={`
                                 w-full px-[6px] py-[5px] rounded-[4px] border-none outline-none
                                 font-['Avenir',sans-serif] font-normal text-[14px] leading-[20px]
                                 placeholder:text-[#6b6e73]
                                 ${empty && !isFieldFilled(event, 'title')
                                   ? 'bg-[#151617] text-[#c9ced4]'
-                                  : 'bg-transparent text-[#c9ced4] hover:bg-[#151617]'
+                                  : isEditing
+                                    ? 'bg-transparent text-[#c9ced4] hover:bg-[#151617]'
+                                    : 'bg-transparent text-[#c9ced4]'
                                 }
-                                focus:bg-[#151617] transition-colors
+                                ${isEditing ? 'focus:bg-[#151617]' : ''} transition-colors
                               `}
                             />
                           </div>
@@ -731,6 +771,7 @@ export function EventTableEditor({
                               placeholder="Pick a date"
                               isEmpty={empty}
                               isFilled={isFieldFilled(event, 'startDate')}
+                              readOnly={!isEditing}
                             />
                           </div>
 
@@ -743,11 +784,17 @@ export function EventTableEditor({
                               disabledBefore={parseDate(event.startDate)}
                               isEmpty={empty}
                               isFilled={isFieldFilled(event, 'endDate')}
+                              readOnly={!isEditing}
                             />
                           </div>
 
                           {/* Category */}
                           <div className="flex-1 min-w-0">
+                            {!isEditing ? (
+                              <div className="px-[6px] py-[5px] rounded-[4px] font-['Avenir',sans-serif] font-normal text-[14px] leading-[20px] text-[#c9ced4] truncate">
+                                {draftCategories.find(c => c.id === event.category)?.label ?? '—'}
+                              </div>
+                            ) : (
                             <Select
                               value={event.category || undefined}
                               onValueChange={(value) => handleEventChange(event.id, { category: value })}
@@ -778,20 +825,23 @@ export function EventTableEditor({
                                 ))}
                               </SelectContent>
                             </Select>
+                            )}
                           </div>
 
                           {/* Delete */}
-                          <div className="w-[32px] shrink-0 flex justify-center">
-                            <button
-                              onClick={() => empty
-                                ? handleDeleteEmptyRow(event.id)
-                                : handleDeleteEvent(event.id)
-                              }
-                              className="p-1 text-[#9b9ea3] hover:text-[#dadee5] transition-colors rounded"
-                            >
-                              <Trash2 size={16} />
-                            </button>
-                          </div>
+                          {isEditing && (
+                            <div className="w-[32px] shrink-0 flex justify-center">
+                              <button
+                                onClick={() => empty
+                                  ? handleDeleteEmptyRow(event.id)
+                                  : handleDeleteEvent(event.id)
+                                }
+                                className="p-1 text-[#9b9ea3] hover:text-[#dadee5] transition-colors rounded"
+                              >
+                                <Trash2 size={16} />
+                              </button>
+                            </div>
+                          )}
                         </div>
                       )
                     })}
@@ -849,10 +899,15 @@ export function EventTableEditor({
             )}
           </div>
 
-          {/* Footer */}
+          {/* Footer. Kept in view mode even though there is nothing to add or
+              save: this dialog is hand-assembled from DialogPrimitive.Content
+              and so has no close X, which makes this button the only visible
+              way out. */}
           <div className="sm:col-start-2 sm:row-start-3 flex justify-between items-center gap-3 px-6 pt-2 pb-5">
             {/* Add button (left) — context-dependent */}
-            {activePageTab === 'events' ? (
+            {!isEditing ? (
+              <span />
+            ) : activePageTab === 'events' ? (
               <button
                 onClick={handleAddRow}
                 disabled={emptyRows.length >= MAX_EMPTY_ROWS}
@@ -873,16 +928,18 @@ export function EventTableEditor({
             {/* Cancel + Save (right) */}
             <div className="flex gap-[10px]">
               <button onClick={onClose} className={glassButtonClass}>
-                Cancel
+                {isEditing ? 'Cancel' : 'Close'}
               </button>
 
-              <button
-                onClick={handleApplyChanges}
-                disabled={!canApplyChanges}
-                className={`${primaryGlassButtonClass} disabled:opacity-50 disabled:pointer-events-none`}
-              >
-                Save
-              </button>
+              {isEditing && (
+                <button
+                  onClick={handleApplyChanges}
+                  disabled={!canApplyChanges}
+                  className={`${primaryGlassButtonClass} disabled:opacity-50 disabled:pointer-events-none`}
+                >
+                  Save
+                </button>
+              )}
             </div>
           </div>
         </DialogPrimitive.Content>

--- a/src/components/FloatingToolbar/FloatingToolbar.tsx
+++ b/src/components/FloatingToolbar/FloatingToolbar.tsx
@@ -1,5 +1,7 @@
+import { useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import { Plus, CalendarFold, Bolt } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { ModeTabs } from '@/components/FloatingToolbar/ModeTabs'
 import { useSidePanel } from '@/hooks/useSidePanel'
 
 interface FloatingToolbarProps {
@@ -7,6 +9,8 @@ interface FloatingToolbarProps {
   onEventsClick: () => void
   onSettingsClick: () => void
   activePanel: 'events' | 'settings' | null
+  mode?: 'edit' | 'view'
+  onModeChange?: (mode: 'edit' | 'view') => void
 }
 
 export function FloatingToolbar({
@@ -14,6 +18,8 @@ export function FloatingToolbar({
   onEventsClick,
   onSettingsClick,
   activePanel,
+  mode = 'edit',
+  onModeChange,
 }: FloatingToolbarProps) {
   // The pill is centered on the viewport, then shifted by half the side
   // panel's width to recenter over the visible timeline area. The width is
@@ -24,17 +30,26 @@ export function FloatingToolbar({
     ? `calc(-50% + ${sidePanelWidth / 2}px)`
     : '-50%'
 
+  const isEditing = mode === 'edit'
+
   return (
     <>
       {/* Desktop: floating pill, centered over the visible timeline area.
           Animates with the side panel's push transition (300ms ease-out), but
-          tracks the drag directly while the panel is being resized. */}
+          tracks the drag directly while the panel is being resized.
+
+          The pill is deliberately content-width. It used to carry a hand-measured
+          `w-[373px]` matched to exactly three labels, which no conditional button
+          could survive. With width auto it re-lays out from its content every
+          frame, and `translateX(-50%)` resolves against its own border box — so
+          collapsing a child animates the pill's width *and* keeps it centred,
+          with no width transition of its own. */}
       <div
         className={`
           hidden md:flex
           fixed bottom-6 left-1/2 z-30
-          flex-row items-start gap-1.5 p-2
-          w-[373px] h-[58px]
+          flex-row items-start gap-2 p-2
+          h-[58px]
           bg-[rgba(23,23,23,0.8)] border border-[#262626] backdrop-blur-[2px]
           rounded-[20px]
           will-change-transform
@@ -42,10 +57,12 @@ export function FloatingToolbar({
         `}
         style={{ transform: `translateX(${desktopTranslateX})` }}
       >
-        <Button variant="glass" size="none" onClick={onAddEventClick}>
-          <Plus size={20} />
-          Add Event
-        </Button>
+        <Collapsible open={isEditing}>
+          <Button variant="glass" size="none" onClick={onAddEventClick} tabIndex={isEditing ? 0 : -1}>
+            <Plus size={20} />
+            Add Event
+          </Button>
+        </Collapsible>
         <Button
           variant="glass" size="none"
           data-active={activePanel === 'events'}
@@ -54,22 +71,32 @@ export function FloatingToolbar({
           <CalendarFold size={20} />
           Events
         </Button>
-        <Button
-          variant="glass" size="none"
-          data-active={activePanel === 'settings'}
-          onClick={onSettingsClick}
-        >
-          <Bolt size={20} />
-          Settings
-        </Button>
+        <Collapsible open={isEditing}>
+          <Button
+            variant="glass" size="none"
+            data-active={activePanel === 'settings'}
+            onClick={onSettingsClick}
+            tabIndex={isEditing ? 0 : -1}
+          >
+            <Bolt size={20} />
+            Settings
+          </Button>
+        </Collapsible>
+        {onModeChange && <ModeTabs mode={mode} onChange={onModeChange} />}
       </div>
 
-      {/* Mobile: full-width sticky footer */}
-      <div className="fixed bottom-0 left-0 right-0 z-30 w-full flex md:hidden justify-center items-center gap-1.5 px-4 pt-2 pb-6 bg-black border-t border-[#3d3e40]">
-        <Button variant="glass" size="none" onClick={onAddEventClick}>
-          <Plus size={20} />
-          Add Event
-        </Button>
+      {/* Mobile: full-width sticky footer. The tabs are deliberately absent in
+          edit mode — Present is a desktop affordance (see GlobalNav's right
+          cluster) and four controls do not fit a phone. They do appear in view
+          mode, so a desktop window narrowed while presenting always has a way
+          back rather than stranding the reader in a mode it cannot leave. */}
+      <div className="fixed bottom-0 left-0 right-0 z-30 w-full flex md:hidden justify-center items-center gap-2 px-4 pt-2 pb-6 bg-black border-t border-[#3d3e40]">
+        <Collapsible open={isEditing}>
+          <Button variant="glass" size="none" onClick={onAddEventClick} tabIndex={isEditing ? 0 : -1}>
+            <Plus size={20} />
+            Add Event
+          </Button>
+        </Collapsible>
         <Button
           variant="glass" size="none"
           data-active={activePanel === 'events'}
@@ -78,15 +105,64 @@ export function FloatingToolbar({
           <CalendarFold size={20} />
           Events
         </Button>
-        <Button
-          variant="glass" size="none"
-          data-active={activePanel === 'settings'}
-          onClick={onSettingsClick}
-        >
-          <Bolt size={20} />
-          Settings
-        </Button>
+        <Collapsible open={isEditing}>
+          <Button
+            variant="glass" size="none"
+            data-active={activePanel === 'settings'}
+            onClick={onSettingsClick}
+            tabIndex={isEditing ? 0 : -1}
+          >
+            <Bolt size={20} />
+            Settings
+          </Button>
+        </Collapsible>
+        {!isEditing && onModeChange && <ModeTabs mode={mode} onChange={onModeChange} />}
       </div>
     </>
+  )
+}
+
+interface CollapsibleProps {
+  open: boolean
+  children: ReactNode
+}
+
+/**
+ * Collapses a dock button to nothing, following the same recipe as the nav's
+ * panel toggle: the element stays mounted so the width change can animate, and
+ * a negative margin eats the parent's flex gap, which `max-width` alone cannot.
+ *
+ * The collapse classes have to live on this wrapper rather than the button —
+ * `min-width` beats `max-width` in CSS, and every dock button carries
+ * `min-w-[80px]` from the `glass` variant. `overflow-hidden` clips it instead.
+ */
+function Collapsible({ open, children }: CollapsibleProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [naturalWidth, setNaturalWidth] = useState<number | null>(null)
+
+  // Animating `max-width` needs a concrete open value, and the honest one is
+  // whatever the button actually measures. A literal would have to be either
+  // too tight (clipping the label — these are set in whatever sans the OS
+  // supplies, since Avenir never loads) or too loose, in which case the start
+  // of the collapse is spent shrinking empty space. `scrollWidth` reports the
+  // full content width even once the wrapper is clipping, and this runs before
+  // paint, so the unmeasured first frame is never shown.
+  useLayoutEffect(() => {
+    if (!open || !ref.current) return
+    const width = ref.current.scrollWidth + 1
+    setNaturalWidth(prev => (prev === width ? prev : width))
+  }, [open])
+
+  return (
+    <div
+      ref={ref}
+      className={`shrink-0 overflow-hidden transition-[max-width,opacity,margin] duration-300 ease-out motion-reduce:transition-none ${
+        open ? 'opacity-100' : 'opacity-0 -ml-2 pointer-events-none'
+      }`}
+      style={{ maxWidth: open ? naturalWidth ?? undefined : 0 }}
+      aria-hidden={!open}
+    >
+      {children}
+    </div>
   )
 }

--- a/src/components/FloatingToolbar/ModeTabs.tsx
+++ b/src/components/FloatingToolbar/ModeTabs.tsx
@@ -1,0 +1,65 @@
+import { SquarePen, SquarePlay } from 'lucide-react'
+
+interface ModeTabsProps {
+  mode: 'edit' | 'view'
+  onChange: (mode: 'edit' | 'view') => void
+}
+
+/**
+ * Edit / Present segmented control, living in the dock.
+ *
+ * Icon-only by design, so each tab carries its own accessible name — the
+ * labelled version this replaces lived in the top nav and could lean on its
+ * text. Segments are a fixed 54px wide and centre their icon, which is why the
+ * spec's asymmetric padding (17/7 selected vs 16/6 unselected) is not
+ * transcribed: it exists only to offset the selected tab's 1px border, and the
+ * icon lands in the same place without it.
+ */
+export function ModeTabs({ mode, onChange }: ModeTabsProps) {
+  const isEdit = mode === 'edit'
+  return (
+    <div className="flex h-[42px] items-start rounded-[10px] bg-[#262626] border border-[#262626]">
+      <ModeTab
+        active={isEdit}
+        onClick={() => onChange('edit')}
+        icon={<SquarePen size={20} strokeWidth={1} />}
+        label="Edit mode"
+      />
+      <ModeTab
+        active={!isEdit}
+        onClick={() => onChange('view')}
+        icon={<SquarePlay size={20} strokeWidth={1} />}
+        label="Present mode"
+      />
+    </div>
+  )
+}
+
+interface ModeTabProps {
+  active: boolean
+  onClick: () => void
+  icon: React.ReactNode
+  label: string
+}
+
+function ModeTab({ active, onClick, icon, label }: ModeTabProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      aria-label={label}
+      title={label}
+      className={`flex h-full w-[54px] items-center justify-center transition-colors ${
+        active
+          ? 'rounded-[8px] border border-white/[0.15] bg-[#0A0A0A] backdrop-blur-[12px] shadow-[inset_0px_1px_0px_0px_rgba(255,255,255,0.1),0px_8px_16px_0px_rgba(0,0,0,0.4)]'
+          : 'rounded-[6px] bg-transparent hover:bg-white/[0.04]'
+      }`}
+      style={{ color: active ? '#D4D4D4' : '#A3A3A3' }}
+    >
+      <span className="shrink-0" aria-hidden>
+        {icon}
+      </span>
+    </button>
+  )
+}

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -35,6 +35,7 @@ interface HeaderProps {
   onCloseAddEventModal: () => void;
   onDeleteTimeline: () => Promise<void> | void;
   mode?: 'edit' | 'view';
+  onModeChange?: (mode: 'edit' | 'view') => void;
 }
 
 export function Header({
@@ -61,6 +62,7 @@ export function Header({
   onCloseAddEventModal,
   onDeleteTimeline,
   mode = 'edit',
+  onModeChange,
 }: HeaderProps) {
   const closePanel = () => onActivePanelChange(null);
   const togglePanel = (panel: 'events' | 'settings') => {
@@ -74,14 +76,17 @@ export function Header({
 
   return (
     <>
-      {mode === 'edit' && (
-        <FloatingToolbar
-          onAddEventClick={onAddEventClick}
-          onEventsClick={() => togglePanel('events')}
-          onSettingsClick={() => togglePanel('settings')}
-          activePanel={activePanel}
-        />
-      )}
+      {/* Renders in both modes: the dock carries the Edit/Present switch, so
+          unmounting it in view mode would leave no way back. It hides its own
+          edit-only buttons instead. */}
+      <FloatingToolbar
+        onAddEventClick={onAddEventClick}
+        onEventsClick={() => togglePanel('events')}
+        onSettingsClick={() => togglePanel('settings')}
+        activePanel={activePanel}
+        mode={mode}
+        onModeChange={onModeChange}
+      />
 
       <Dialog open={showAddEventModal} onOpenChange={(open) => { if (!open) onCloseAddEventModal(); }}>
         <DialogContent className="bg-surface-secondary border-[rgba(210,210,210,0.15)] max-w-[360px] rounded-[20px] px-5 py-6">
@@ -124,6 +129,7 @@ export function Header({
         onEventsChange={onEventsChange}
         categories={categories}
         onCategoriesChange={onCategoriesChange}
+        mode={mode}
       />
     </>
   );

--- a/src/components/Navigation/CategoryLegend.tsx
+++ b/src/components/Navigation/CategoryLegend.tsx
@@ -1,0 +1,207 @@
+import { useCallback, useMemo, useRef } from 'react'
+import { Eye, EyeOff } from 'lucide-react'
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
+import { countEventsByCategory } from '@/utils/categoryCounts'
+import { cn } from '@/lib/utils'
+import type { CategoryConfig, TimelineEvent } from '@/types/event'
+
+interface CategoryLegendProps {
+  categories: CategoryConfig[]
+  events: TimelineEvent[]
+  onCategoriesChange: (categories: CategoryConfig[]) => void
+}
+
+/**
+ * Nav control that says which colour means which category, and lets the reader
+ * hide a category's events.
+ *
+ * Visibility is the existing `CategoryConfig.visible` flag — the same one the
+ * events modal's Categories tab writes, and the one `Timeline.tsx` already
+ * filters on. So this is a second, *live* entry point into `updateCategories`
+ * rather than new state: a toggle here persists exactly like a toggle there,
+ * which means it arms the debounced autosave and re-sorts the side panel.
+ *
+ * Open/closed is left uncontrolled — Radix supplies `aria-haspopup="dialog"`,
+ * `aria-expanded` and `data-state` on the trigger, so the open-state fill is
+ * pure CSS and there is no React state to keep in sync (or to persist).
+ */
+export function CategoryLegend({ categories, events, onCategoriesChange }: CategoryLegendProps) {
+  const counts = useMemo(() => countEventsByCategory(events), [events])
+  const visibleCount = useMemo(() => categories.filter(c => c.visible).length, [categories])
+  const rowRefs = useRef<(HTMLButtonElement | null)[]>([])
+
+  const totalLabel = `${events.length} ${events.length === 1 ? 'event' : 'events'}`
+
+  const toggle = useCallback(
+    (id: CategoryConfig['id']) => {
+      onCategoriesChange(
+        categories.map(c => (c.id === id ? { ...c, visible: !c.visible } : c)),
+      )
+    },
+    [categories, onCategoriesChange],
+  )
+
+  // Radix Popover does no roving focus of its own, so arrow keys are ours.
+  const handleRowKeyDown = useCallback(
+    (index: number) => (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      const last = categories.length - 1
+      let next: number | null = null
+      if (e.key === 'ArrowDown') next = index === last ? 0 : index + 1
+      else if (e.key === 'ArrowUp') next = index === 0 ? last : index - 1
+      else if (e.key === 'Home') next = 0
+      else if (e.key === 'End') next = last
+      if (next === null) return
+      e.preventDefault()
+      rowRefs.current[next]?.focus()
+    },
+    [categories.length],
+  )
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label="Category legend"
+          className={cn(
+            // Below `md` the nav's right cluster is gone, so the trigger floats
+            // out of flow against the bar's right edge — the mirror of the
+            // panel toggle's `absolute left-4 top-4 md:static` treatment.
+            'absolute right-4 top-5 z-10 md:static md:z-auto',
+            'flex shrink-0 items-center justify-center gap-[6px]',
+            'h-[36px] w-[36px] md:h-[32px] md:w-auto md:px-[11px] md:py-[6px]',
+            'rounded-[10px] border border-white/[0.15] bg-white/10 backdrop-blur-[12px]',
+            'shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)]',
+            'text-[#c9ced4] transition-colors',
+            'hover:bg-white/20 hover:text-[#dadee5]',
+            // Hold the hover fill while the panel is open so the button reads as active.
+            'data-[state=open]:bg-white/20 data-[state=open]:text-[#dadee5]',
+            'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/40',
+          )}
+        >
+          <CategoryDots categories={categories} />
+          <span className="label-m-type2 hidden md:inline">Legend</span>
+        </button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        unstyled
+        align="end"
+        sideOffset={8}
+        collisionPadding={16}
+        aria-label="Category legend"
+        // Land focus on the first row rather than the panel itself.
+        onOpenAutoFocus={(e) => {
+          e.preventDefault()
+          rowRefs.current[0]?.focus()
+        }}
+        // Inline, because an arbitrary duration utility is ambiguous to
+        // Tailwind here — the core transition scale and tailwindcss-animate's
+        // animation scale share the `duration-` namespace and both take a
+        // <time>, so no type hint can separate them. The
+        // `motion-reduce:animate-none` class still wins: it zeroes
+        // `animation-name`, which this does not touch.
+        style={{ animationDuration: '120ms' }}
+        className={cn(
+          'z-50 outline-none',
+          // Mobile is a full-bleed sheet inset 16px each side. That falls out of
+          // Radix's own positioning: the trigger sits at `right-4`, `align="end"`
+          // pins the panel's right edge to it, and this width puts the left edge
+          // at 16px. Fighting the popper wrapper's transform would not work —
+          // it lives on the wrapper element, not on this one.
+          'w-[calc(100vw-32px)] md:w-[264px]',
+          'rounded-[16px] border border-[#262626] p-2 backdrop-blur-[12px]',
+          'bg-[rgba(23,23,23,0.96)] md:bg-[rgba(23,23,23,0.92)]',
+          'shadow-[0px_8px_32px_rgba(0,0,0,0.6)] md:shadow-[0px_8px_32px_rgba(0,0,0,0.4)]',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out',
+          'data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0',
+          'data-[side=bottom]:slide-in-from-top-1 data-[side=top]:slide-in-from-bottom-1',
+          'motion-reduce:animate-none',
+        )}
+      >
+        <div className="flex items-center justify-between px-[10px] pb-[8px] pt-[6px]">
+          <span className="label-s-type2 uppercase tracking-[0.04em] text-[#9B9EA3]">
+            Categories
+          </span>
+          <span className="font-['JetBrains_Mono',monospace] text-[11px] leading-none text-[#9B9EA3]">
+            {totalLabel}
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-[2px]">
+          {categories.map((cat, i) => {
+            // Never let the reader hide everything — an empty timeline has no
+            // range to draw, and there would be no way back from an empty panel.
+            const isLastVisible = cat.visible && visibleCount === 1
+            return (
+              <button
+                key={cat.id}
+                ref={(el) => { rowRefs.current[i] = el }}
+                type="button"
+                aria-pressed={cat.visible}
+                aria-disabled={isLastVisible || undefined}
+                // `aria-disabled` rather than `disabled`: a disabled button
+                // cannot take focus, which would punch a hole in arrow-key nav.
+                aria-label={cat.visible ? `Hide ${cat.label}` : `Show ${cat.label}`}
+                onClick={() => { if (!isLastVisible) toggle(cat.id) }}
+                onKeyDown={handleRowKeyDown(i)}
+                className={cn(
+                  'group flex w-full items-center gap-[10px] rounded-[10px] px-[10px] text-left transition-colors',
+                  'min-h-[44px] py-[12px] md:min-h-0 md:py-[8px]',
+                  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/40',
+                  isLastVisible ? 'cursor-default' : 'hover:bg-white/[0.06]',
+                )}
+              >
+                <span
+                  className="size-[10px] shrink-0 rounded-[3px]"
+                  style={{ backgroundColor: cat.color, opacity: cat.visible ? 1 : 0.4 }}
+                />
+                <span
+                  className="body-m text-[#C9CED4]"
+                  style={{ opacity: cat.visible ? 1 : 0.4 }}
+                >
+                  {cat.label}
+                </span>
+                <span className="label-s-type1 ml-auto text-[#9B9EA3]">
+                  {counts.get(cat.id) ?? 0}
+                </span>
+                <span
+                  className={cn(
+                    'shrink-0 text-[#6D7073] transition-colors',
+                    !isLastVisible && 'group-hover:text-[#C9CED4]',
+                  )}
+                  aria-hidden
+                >
+                  {cat.visible ? <Eye size={16} strokeWidth={1.25} /> : <EyeOff size={16} strokeWidth={1.25} />}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+/**
+ * The palette preview on the trigger: overlapping discs, each ringed in the
+ * page background so they read as separate. Always shows every category
+ * regardless of visibility — it is an affordance, not a status readout.
+ */
+function CategoryDots({ categories }: { categories: CategoryConfig[] }) {
+  return (
+    <span className="flex shrink-0 items-center" aria-hidden>
+      {categories.map((cat, i) => (
+        <span
+          key={cat.id}
+          className="size-[7px] shrink-0 rounded-full md:size-[8px]"
+          style={{
+            backgroundColor: cat.color,
+            boxShadow: '0 0 0 1px #0A0A0A',
+            marginLeft: i === 0 ? 0 : -2,
+          }}
+        />
+      ))}
+    </span>
+  )
+}

--- a/src/components/Navigation/GlobalNav.tsx
+++ b/src/components/Navigation/GlobalNav.tsx
@@ -1,9 +1,5 @@
 import { type CSSProperties } from 'react'
-import {
-  PanelLeft,
-  SquarePen,
-  SquarePlay,
-} from 'lucide-react'
+import { PanelLeft } from 'lucide-react'
 import { useSidePanel } from '@/hooks/useSidePanel'
 import { supabase } from '@/lib/supabase'
 import { Button } from '@/components/ui/button'
@@ -26,9 +22,9 @@ interface GlobalNavProps {
   /** Save status — only rendered on variant="timeline" */
   saveStatus?: SaveStatus
   lastSavedTime?: Date
-  /** Edit/View mode toggle — only rendered on variant="timeline" */
+  /** Edit/View mode. The toggle itself lives in the dock (FloatingToolbar);
+      this only decides whether the title is editable. */
   mode?: 'edit' | 'view'
-  onModeChange?: (mode: 'edit' | 'view') => void
 }
 
 export function GlobalNav({
@@ -43,7 +39,6 @@ export function GlobalNav({
   saveStatus,
   lastSavedTime,
   mode = 'edit',
-  onModeChange,
 }: GlobalNavProps) {
   const { isOpen: isPanelOpen, toggle: togglePanel } = useSidePanel()
 
@@ -143,12 +138,10 @@ export function GlobalNav({
         </div>
 
         {/* Right cluster. The legend survives below `md` as a floating icon
-            button; everything else is desktop-only — `mode` is unpersisted
-            state that defaults to 'edit' (App.tsx), so hiding the toggle can't
-            strand a phone in view mode, and FloatingToolbar already carries the
-            editing affordances there. Below `md` the legend is out of flow, so
-            this wrapper contributes no width next to the full-width left
-            cluster. */}
+            button; Share is desktop-only. Below `md` the legend is out of flow,
+            so this wrapper contributes no width next to the full-width left
+            cluster. The Edit/Present toggle used to live here and now sits in
+            the dock, so the dock is the only place that switches modes. */}
         <div className="ml-auto flex items-center gap-2">
           {variant === 'timeline' && categories && onCategoriesChange && (
             <CategoryLegend
@@ -164,9 +157,6 @@ export function GlobalNav({
                 <SaveStatusIndicator status={saveStatus} lastSaved={lastSavedTime} />
               </div>
             )}
-            {variant === 'timeline' && onModeChange && (
-              <ModeToggle mode={mode} onChange={onModeChange} />
-            )}
             {variant === 'timeline' && (
               <Button
                 variant="glass-sm"
@@ -181,82 +171,5 @@ export function GlobalNav({
         </div>
       </div>
     </div>
-  )
-}
-
-interface ModeToggleProps {
-  mode: 'edit' | 'view'
-  onChange: (mode: 'edit' | 'view') => void
-}
-
-// Edit / Present segmented toggle. Each segment is fixed-width to match the
-// design spec (Edit = 72px, Present = 94px). The selected segment fills with
-// #262626; the unselected segment is transparent and dims its label/icon.
-function ModeToggle({ mode, onChange }: ModeToggleProps) {
-  const isEdit = mode === 'edit'
-  return (
-    <div className="flex items-start p-[4px] h-[40px] bg-[#171717] border border-[#262626] rounded-[10px]">
-      <ModeToggleSegment
-        active={isEdit}
-        // When this segment is unselected, the spec uses a slightly different
-        // grey (#9B9EA3) than the inverse case (#A3A3A3). Match exactly.
-        inactiveColor="#9B9EA3"
-        onClick={() => onChange('edit')}
-        icon={<SquarePen size={16} strokeWidth={1} />}
-        label="Edit"
-        width={72}
-      />
-      <ModeToggleSegment
-        active={!isEdit}
-        inactiveColor="#A3A3A3"
-        onClick={() => onChange('view')}
-        icon={<SquarePlay size={16} strokeWidth={1} />}
-        label="Present"
-        width={94}
-      />
-    </div>
-  )
-}
-
-interface ModeToggleSegmentProps {
-  active: boolean
-  inactiveColor: string
-  onClick: () => void
-  icon: React.ReactNode
-  label: string
-  width: number
-}
-
-function ModeToggleSegment({
-  active,
-  inactiveColor,
-  onClick,
-  icon,
-  label,
-  width,
-}: ModeToggleSegmentProps) {
-  // Selected: bg #262626, label #C9CED4 / #D4D4D4 (label / icon).
-  // Unselected: no bg, label and icon both share `inactiveColor`.
-  const color = active ? '#D4D4D4' : inactiveColor
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-pressed={active}
-      className={`flex items-center justify-center gap-[6px] h-[32px] min-w-[60px] px-[12px] py-[6px] rounded-[6px] transition-colors ${
-        active ? 'bg-[#262626]' : 'bg-transparent hover:bg-white/[0.04]'
-      }`}
-      style={{ width, color }}
-    >
-      <span className="shrink-0" style={{ color }} aria-hidden>
-        {icon}
-      </span>
-      <span
-        className="font-['Avenir',sans-serif] font-normal text-[14px] leading-[20px]"
-        style={{ color: active ? '#C9CED4' : inactiveColor }}
-      >
-        {label}
-      </span>
-    </button>
   )
 }

--- a/src/components/Navigation/GlobalNav.tsx
+++ b/src/components/Navigation/GlobalNav.tsx
@@ -7,9 +7,10 @@ import {
 import { useSidePanel } from '@/hooks/useSidePanel'
 import { supabase } from '@/lib/supabase'
 import { Button } from '@/components/ui/button'
+import { CategoryLegend } from '@/components/Navigation/CategoryLegend'
 import { SaveStatusIndicator, type SaveStatus } from '@/components/SaveStatusIndicator/SaveStatusIndicator'
 import { getTimelineYearRange } from '@/utils/timelineUtils'
-import type { TimelineEvent } from '@/types/event'
+import type { CategoryConfig, TimelineEvent } from '@/types/event'
 
 interface GlobalNavProps {
   variant?: 'default' | 'timeline'
@@ -18,6 +19,9 @@ interface GlobalNavProps {
   timelineTitle?: string
   onTimelineTitleChange?: (title: string) => void
   events?: TimelineEvent[]
+  /** Category legend — only rendered on variant="timeline", and only with a setter */
+  categories?: CategoryConfig[]
+  onCategoriesChange?: (categories: CategoryConfig[]) => void
   timelineAccentColor?: string
   /** Save status — only rendered on variant="timeline" */
   saveStatus?: SaveStatus
@@ -33,6 +37,8 @@ export function GlobalNav({
   timelineTitle,
   onTimelineTitleChange,
   events = [],
+  categories,
+  onCategoriesChange,
   timelineAccentColor = '#4196E4',
   saveStatus,
   lastSavedTime,
@@ -89,8 +95,12 @@ export function GlobalNav({
             </button>
           </div>
 
+          {/* The title cluster's mobile gutter clears both floating buttons:
+              the panel toggle on the left (16px + 28px) and the legend on the
+              right (16px + 36px), so it has to be at least 52px for the centred
+              title not to run under either. */}
           {showTitleCluster && (
-            <div className="flex flex-col gap-0 min-w-0 w-full items-center text-center px-10 md:gap-[2px] md:w-auto md:items-start md:text-left md:px-0">
+            <div className="flex flex-col gap-0 min-w-0 w-full items-center text-center px-[52px] md:gap-[2px] md:w-auto md:items-start md:text-left md:px-0">
               {onTimelineTitleChange && mode === 'edit' ? (
                 <input
                   type="text"
@@ -132,31 +142,42 @@ export function GlobalNav({
           )}
         </div>
 
-        {/* Right cluster: save status + action buttons. Hidden below `md` —
-            the mobile header is title-only. `mode` is unpersisted state that
-            defaults to 'edit' (App.tsx), so hiding the toggle can't strand a
-            phone in view mode, and FloatingToolbar already carries the editing
-            affordances there. */}
-        <div className="ml-auto hidden md:flex items-center gap-2">
-          {/* SaveStatusIndicator hidden for now — keeping wiring in place for future reuse */}
-          {SHOW_SAVE_STATUS && variant === 'timeline' && saveStatus && (
-            <div className="hidden md:block mr-2">
-              <SaveStatusIndicator status={saveStatus} lastSaved={lastSavedTime} />
-            </div>
+        {/* Right cluster. The legend survives below `md` as a floating icon
+            button; everything else is desktop-only — `mode` is unpersisted
+            state that defaults to 'edit' (App.tsx), so hiding the toggle can't
+            strand a phone in view mode, and FloatingToolbar already carries the
+            editing affordances there. Below `md` the legend is out of flow, so
+            this wrapper contributes no width next to the full-width left
+            cluster. */}
+        <div className="ml-auto flex items-center gap-2">
+          {variant === 'timeline' && categories && onCategoriesChange && (
+            <CategoryLegend
+              categories={categories}
+              events={events}
+              onCategoriesChange={onCategoriesChange}
+            />
           )}
-          {variant === 'timeline' && onModeChange && (
-            <ModeToggle mode={mode} onChange={onModeChange} />
-          )}
-          {variant === 'timeline' && (
-            <Button
-              variant="glass-sm"
-              size="none"
-              onClick={handleShare}
-              disabled={!timelineId}
-            >
-              Share
-            </Button>
-          )}
+          <div className="hidden md:flex items-center gap-2">
+            {/* SaveStatusIndicator hidden for now — keeping wiring in place for future reuse */}
+            {SHOW_SAVE_STATUS && variant === 'timeline' && saveStatus && (
+              <div className="mr-2">
+                <SaveStatusIndicator status={saveStatus} lastSaved={lastSavedTime} />
+              </div>
+            )}
+            {variant === 'timeline' && onModeChange && (
+              <ModeToggle mode={mode} onChange={onModeChange} />
+            )}
+            {variant === 'timeline' && (
+              <Button
+                variant="glass-sm"
+                size="none"
+                onClick={handleShare}
+                disabled={!timelineId}
+              >
+                Share
+              </Button>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -9,19 +9,35 @@ const PopoverTrigger = PopoverPrimitive.Trigger
 
 const PopoverAnchor = PopoverPrimitive.Anchor
 
+const DEFAULT_CONTENT_CLASS =
+  "z-50 w-auto rounded-lg border bg-popover p-0 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
+
+interface PopoverContentProps
+  extends React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> {
+  /**
+   * Drop the default surface and animation classes and use `className` alone.
+   *
+   * The defaults above include `tailwindcss-animate` utilities (`zoom-in-95`,
+   * `slide-in-from-top-2`) which set the same CSS custom properties as any
+   * override. `twMerge` has no rule group for them, so both survive the merge
+   * and stylesheet order — not class order — decides the winner. A panel that
+   * needs its own motion has to replace the string, not layer over it. It also
+   * frees the panel from `bg-popover`, the blue-tinted slate that
+   * `dropdown-menu.tsx` warns against.
+   */
+  unstyled?: boolean
+}
+
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "start", sideOffset = 4, ...props }, ref) => (
+  PopoverContentProps
+>(({ className, align = "start", sideOffset = 4, unstyled = false, ...props }, ref) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}
       sideOffset={sideOffset}
-      className={cn(
-        "z-50 w-auto rounded-lg border bg-popover p-0 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        className
-      )}
+      className={unstyled ? className : cn(DEFAULT_CONTENT_CLASS, className)}
       {...props}
     />
   </PopoverPrimitive.Portal>

--- a/src/utils/categoryCounts.ts
+++ b/src/utils/categoryCounts.ts
@@ -1,0 +1,18 @@
+interface CategoryEvent {
+  category?: string | null
+}
+
+/**
+ * Count events per category id. Ignores category visibility — a hidden
+ * category still reports how many events it holds, which is what lets the
+ * legend tell you what you are about to hide.
+ */
+export function countEventsByCategory(
+  events: readonly CategoryEvent[],
+): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const e of events) {
+    if (e.category) counts.set(e.category, (counts.get(e.category) || 0) + 1)
+  }
+  return counts
+}

--- a/src/utils/dominantCategory.ts
+++ b/src/utils/dominantCategory.ts
@@ -1,4 +1,5 @@
 import type { CategoryConfig } from '@/types/event'
+import { countEventsByCategory } from '@/utils/categoryCounts'
 
 export const DEFAULT_DOT_COLOR = '#4196E4'
 
@@ -12,10 +13,7 @@ export function computeDominantCategoryColor(
 ): string {
   if (events.length === 0) return DEFAULT_DOT_COLOR
 
-  const counts = new Map<string, number>()
-  for (const e of events) {
-    if (e.category) counts.set(e.category, (counts.get(e.category) || 0) + 1)
-  }
+  const counts = countEventsByCategory(events)
   if (counts.size === 0) return DEFAULT_DOT_COLOR
 
   let dominantId = ''


### PR DESCRIPTION
Two related pieces of timeline-editor chrome. The first commit adds the Legend; the second moves the mode switch out of the nav, which leaves the nav holding just the Legend and Share.

---

## 1. Category legend popover (`98bceac`)

A **Legend** control in the nav's right cluster: the trigger previews the palette as overlapping dots, and the popover lists every category with its swatch, label, live event count, and an eye toggle.

**No new state, no schema change.** Visibility reuses the existing `CategoryConfig.visible` flag — already required on the type, already persisted, already inside `metaFingerprint`, and already what `Timeline.tsx:80-89` filters on. The legend is a second, *live* entry point into `updateCategories`, so a toggle here behaves exactly like one in the Categories tab, autosave and side-panel reorder included.

Rows key off `cat.id` and are driven entirely by the `categories` array, so categories minted through the events modal (whose ids are slugified labels, not `category_N`) work without special-casing. Hiding the last visible category is blocked, which also keeps `getTimelineRange` from being handed an empty set.

Two supporting changes: `PopoverContent` gains an `unstyled` opt-out (its default class string carries `tailwindcss-animate` utilities that set the same custom properties as any override, and `twMerge` has no rule group for them, so stylesheet order rather than class order would decide the winner); and `countEventsByCategory` is factored out of `computeDominantCategoryColor`, which already built that map and discarded it.

## 2. Edit/Present moves into the dock (`68f58f0`)

Built from the linked Figma. The toggle becomes an icon-only segmented control inside the dock, and the dock now renders in **both** modes — unmounting it in view mode would leave no way back.

| | Dock |
|---|---|
| Edit | `[+ Add Event] [Events] [Settings] [✏|▶]` |
| Present | `[Events] [✏|▶]` — Add Event and Settings fade out, pill animates narrower |

**The width animation.** The pill carried a hand-measured `w-[373px]` matched to exactly three labels, which no conditional button could survive. It is now content-derived: with width auto the pill re-lays out from its content every frame and `translateX(-50%)` resolves against its own border box, so collapsing a child animates the pill's width *and* keeps it centred — no `width` transition on the container at all. Each collapsing button sits in a wrapper that measures its child's `scrollWidth` for the open `max-width`; a literal would either clip the label or spend the start of the animation shrinking empty space, and these are set in whatever sans the OS supplies since Avenir never loads. The collapse classes must live on that wrapper rather than the button — `min-width` beats `max-width` in CSS, and every dock button carries `min-w-[80px]` from the `glass` variant.

**Reuse.** The Figma's buttons are the existing `glass` variant unchanged (h-42 / min-w-80 / px-17 / gap-6 / rounded-12, same border, shadow, blur and colour), and all five icons were already lucide glyphs in use in these two files. The only genuinely new markup is the tab group.

**Read-only events modal.** Events stays reachable while presenting, so `EventTableEditor` gains a `mode` prop: Categories page absent, cells static, delete column and its header spacer removed together, no Add or Save. Cancel becomes **Close** rather than dropping the footer — this dialog is hand-assembled from `DialogPrimitive.Content` and so has no close X, leaving that button the only way out. The rail's category *filter* stays, since filtering is a reading affordance; it just loses drag-to-reorder by widening the existing narrow-viewport escape hatch.

**Mobile** keeps its three buttons and gains the tabs only when already in view mode — Present can't be entered from a phone (four controls don't fit), but a desktop window narrowed while presenting can always get back.

## Notes

- `App.tsx`'s switch-to-view cleanup (close Settings, close Add Event) is defensive only: both render a modal backdrop above the dock, so neither can be open at the moment the tabs are clicked. Worth knowing before someone deletes it as dead code.
- The Settings panel's `inset-0 z-40` backdrop blocks the dock while open. Confirmed pre-existing — it blocked the nav's toggle the same way (`navShareReachable: false` with it open).
- `TimelineViewer.tsx:101-105` still force-resets every category to `visible: true`, so a category hidden in the editor reappears on the public `/view/:id` link. Deliberately out of scope.
- `src/TIMELINE_ARCHITECTURE.md`'s Edit/View table is updated — it was the canonical description and is now wrong in two places without it.

## Verification

- `npm run lint` and `npm run build` clean, no Tailwind ambiguity warnings.
- `npx tsc --noEmit -p tsconfig.app.json` — 16 errors, all pre-existing in untouched files, identical count before and after. (`npm run build` is `vite build` alone and never typechecks, so these have been passing through silently.)
- Driven in real Chromium at 1440px and 390px against a seeded 12-event timeline. **17 assertions for the legend**, **36 for the dock**, all passing — including: the pill measurably narrowing and staying centred across the switch and across a side-panel toggle; Add Event and Settings going `aria-hidden` / `pointer-events-none` / `tabIndex=-1`; the read-only modal having no Categories tab, no Save, no date pickers, no comboboxes, no delete buttons, and `readOnly` title inputs while the category filter still works; a canvas click opening the detail panel rather than the actions menu in Present; and the collapse transition resolving to `transition-property: none` under `prefers-reduced-motion`.