### PR TITLE
Filter facet articles and dedupe redundant search suggestions

### DIFF
--- a/src/services/wikipediaSearch.ts
+++ b/src/services/wikipediaSearch.ts
@@ -22,13 +22,58 @@ const JUNK_DESCRIPTION_EXACT = [
   'family name',
 ]
 
-const JUNK_DESCRIPTION_SUBSTRINGS = ['given name', 'family name']
+const JUNK_DESCRIPTION_SUBSTRINGS = ['given name', 'family name', 'mythology']
+
+// Geographic and natural-world subjects rarely make promising timelines.
+// Wikipedia short descriptions for these are formulaic enough to match on
+// their opening words ("City in northern Syria", "Capital of Karnataka,
+// India", "Species of mammal"). Countries are deliberately left in — a
+// country's history is a legitimate topic timeline in a way a mid-size
+// city's isn't.
+const JUNK_DESCRIPTION_PREFIXES = [
+  'city in',
+  'city and',
+  'city of',
+  'capital of',
+  'capital and',
+  'capital city',
+  'town in',
+  'village in',
+  'place in',
+  'human settlement',
+  'municipality',
+  'commune in',
+  'borough',
+  'suburb',
+  'neighbourhood',
+  'neighborhood',
+  'county in',
+  'county of',
+  'district in',
+  'district of',
+  'province in',
+  'province of',
+  'region in',
+  'region of',
+  'u.s. state',
+  'census-designated place',
+  'airport in',
+  'river in',
+  'mountain in',
+  'mountain range',
+  'lake in',
+  'island in',
+  'species of',
+  'genus of',
+  'breed of',
+]
 
 function isJunkDescription(description: string | undefined): boolean {
   if (!description) return false
   const lower = description.toLowerCase()
   if (JUNK_DESCRIPTION_EXACT.includes(lower)) return true
   if (JUNK_DESCRIPTION_SUBSTRINGS.some((s) => lower.includes(s))) return true
+  if (JUNK_DESCRIPTION_PREFIXES.some((p) => lower.startsWith(p))) return true
   return false
 }
 

--- a/src/services/wikipediaSearch.ts
+++ b/src/services/wikipediaSearch.ts
@@ -34,6 +34,8 @@ const JUNK_DESCRIPTION_PREFIXES = [
   'city in',
   'city and',
   'city of',
+  'largest city',
+  'most populous city',
   'capital of',
   'capital and',
   'capital city',
@@ -101,8 +103,9 @@ function isFacetTitle(title: string): boolean {
 }
 
 // Name particles that legitimately extend another result's name — "John F.
-// Kennedy Jr." is a distinct subject, not a facet of "John F. Kennedy".
-const NAME_SUFFIX_TOKENS = new Set(['jr', 'sr', 'ii', 'iii', 'iv'])
+// Kennedy Jr." is a distinct subject, not a facet of "John F. Kennedy",
+// and "World War I" is not a facet of the generic "World war" article.
+const NAME_SUFFIX_TOKENS = new Set(['jr', 'sr', 'i', 'ii', 'iii', 'iv', 'v'])
 
 function isLetterOrDigit(ch: string | undefined): boolean {
   return ch !== undefined && /[\p{L}\p{N}]/u.test(ch)
@@ -115,14 +118,21 @@ function isLetterOrDigit(ch: string | undefined): boolean {
  * is a name suffix, which marks a different person rather than a facet.
  */
 function isFacetOf(candidate: string, base: string): boolean {
-  const lowerCandidate = candidate.toLowerCase()
   const lowerBase = base.toLowerCase()
+  // A single-word base is too promiscuous an anchor — bare "Queen" would
+  // swallow "Queen Victoria" and "Queen (band)".
+  if (!lowerBase.includes(' ')) return false
+  const lowerCandidate = candidate.toLowerCase()
   const idx = lowerCandidate.indexOf(lowerBase)
   if (idx < 0) return false
   if (isLetterOrDigit(lowerCandidate[idx - 1])) return false
   if (isLetterOrDigit(lowerCandidate[idx + lowerBase.length])) return false
-  const rest =
-    lowerCandidate.slice(0, idx) + ' ' + lowerCandidate.slice(idx + lowerBase.length)
+  const suffix = lowerCandidate.slice(idx + lowerBase.length)
+  // "Base (qualifier)" is Wikipedia's disambiguation convention for a
+  // distinct subject sharing the name — "Michael Jackson (writer)" is not
+  // a facet of "Michael Jackson".
+  if (idx === 0 && /^ \([^()]+\)$/.test(suffix)) return false
+  const rest = lowerCandidate.slice(0, idx) + ' ' + suffix
   const restTokens = rest.split(/[^\p{L}\p{N}]+/u).filter(Boolean)
   if (restTokens.length === 0) return false
   return !restTokens.every((token) => NAME_SUFFIX_TOKENS.has(token))

--- a/src/services/wikipediaSearch.ts
+++ b/src/services/wikipediaSearch.ts
@@ -32,12 +32,65 @@ function isJunkDescription(description: string | undefined): boolean {
   return false
 }
 
+// Facet/meta articles about a subject rather than subjects in their own right —
+// "Adolf Hitler in popular culture" doesn't make a timeline distinct from
+// "Adolf Hitler".
+const FACET_TITLE_SUBSTRINGS = [
+  'in popular culture',
+  'cultural depictions of',
+  'in fiction',
+  '(disambiguation)',
+  'discography',
+  'filmography',
+]
+
+// Prefix-only: a contains-match on "list of" would filter legitimate works
+// like "The List of Adrian Messenger".
+const FACET_TITLE_PREFIXES = ['list of', 'bibliography of']
+
+function isFacetTitle(title: string): boolean {
+  const lower = title.toLowerCase()
+  if (FACET_TITLE_SUBSTRINGS.some((s) => lower.includes(s))) return true
+  if (FACET_TITLE_PREFIXES.some((p) => lower.startsWith(p))) return true
+  return false
+}
+
+// Name particles that legitimately extend another result's name — "John F.
+// Kennedy Jr." is a distinct subject, not a facet of "John F. Kennedy".
+const NAME_SUFFIX_TOKENS = new Set(['jr', 'sr', 'ii', 'iii', 'iv'])
+
+function isLetterOrDigit(ch: string | undefined): boolean {
+  return ch !== undefined && /[\p{L}\p{N}]/u.test(ch)
+}
+
+/**
+ * True when `candidate` reads as a facet of `base`: it contains the whole of
+ * `base` on word boundaries plus extra words ("Religious views of Adolf
+ * Hitler", "Adolf Hitler's rise to power") — unless everything beyond `base`
+ * is a name suffix, which marks a different person rather than a facet.
+ */
+function isFacetOf(candidate: string, base: string): boolean {
+  const lowerCandidate = candidate.toLowerCase()
+  const lowerBase = base.toLowerCase()
+  const idx = lowerCandidate.indexOf(lowerBase)
+  if (idx < 0) return false
+  if (isLetterOrDigit(lowerCandidate[idx - 1])) return false
+  if (isLetterOrDigit(lowerCandidate[idx + lowerBase.length])) return false
+  const rest =
+    lowerCandidate.slice(0, idx) + ' ' + lowerCandidate.slice(idx + lowerBase.length)
+  const restTokens = rest.split(/[^\p{L}\p{N}]+/u).filter(Boolean)
+  if (restTokens.length === 0) return false
+  return !restTokens.every((token) => NAME_SUFFIX_TOKENS.has(token))
+}
+
 export async function searchWikipedia(
   query: string,
   options?: WikipediaSearchOptions
 ): Promise<SubjectSuggestion[]> {
   const limit = options?.limit ?? 6
-  const fetchLimit = Math.min(limit * 2, 20)
+  // Over-fetch so the facet and dedupe filters below can still fill `limit`
+  // slots on queries dominated by sub-articles of one subject.
+  const fetchLimit = Math.min(limit * 3, 20)
   const url = `https://en.wikipedia.org/w/rest.php/v1/search/title?q=${encodeURIComponent(
     query
   )}&limit=${fetchLimit}`
@@ -49,17 +102,23 @@ export async function searchWikipedia(
     const data = (await response.json()) as WikipediaRestResponse
     if (!data || !Array.isArray(data.pages)) return []
 
-    const results: SubjectSuggestion[] = []
+    // Collect every viable candidate before deduping: the base article can
+    // rank below one of its facets, and the dedupe pass must see both.
+    const candidates: SubjectSuggestion[] = []
     for (const page of data.pages as WikipediaRestPage[]) {
       if (!page || typeof page.title !== 'string') continue
       const description = typeof page.description === 'string' && page.description.length > 0
         ? page.description
         : undefined
       if (isJunkDescription(description)) continue
-      results.push({ title: page.title, description })
-      if (results.length >= limit) break
+      if (isFacetTitle(page.title)) continue
+      candidates.push({ title: page.title, description })
     }
-    return results
+
+    const results = candidates.filter(
+      (c) => !candidates.some((other) => other !== c && isFacetOf(c.title, other.title))
+    )
+    return results.slice(0, limit)
   } catch (err) {
     if (err instanceof Error && err.name === 'AbortError') throw err
     return []


### PR DESCRIPTION
## Problem

The subject search dropdown passes Wikipedia's title search through almost untouched, so it surfaces suggestions that don't map to promising timelines: facet articles about the same subject ("Adolf Hitler in popular culture" alongside "Adolf Hitler"), and popularity-ranked matches that aren't timeline subjects at all ("Kobe — City in Kansai region, Japan", "Kob — Species of mammal").

## Changes

All in `src/services/wikipediaSearch.ts`, pure string logic (no new requests, no API/UI change):

- **Facet-title blocklist**, styled after the existing junk-description filter: drops titles containing `in popular culture`, `cultural depictions of`, `in fiction`, `(disambiguation)`, `discography`, `filmography`, or starting with `list of` / `bibliography of` (prefix-only, so works like *The List of Adrian Messenger* survive a contains-match).
- **Containment dedupe**: a candidate whose title contains another surviving candidate's full title on word boundaries plus extra words ("Death of Adolf Hitler", "Assassination of John F. Kennedy", "Adolf Hitler's rise to power") is dropped in favor of the base article. Three guards keep distinct same-name subjects alive: the base must be multi-word (bare "Queen" must not swallow "Queen Victoria" or "Queen (band)"), a trailing parenthetical qualifier is Wikipedia's convention for a distinct subject ("Michael Jackson (writer)"), and name suffixes (Jr., Sr., I–V) are exempt ("John F. Kennedy Jr.", "World War I" next to the generic "World war" article).
- **Description blocklist for places, species, and mythology**: Wikipedia short descriptions are formulaic enough to match on opening words, so a prefix list drops settlements, administrative divisions, geographic features ("city in", "capital of", "place in", "river in", …), species ("species of", "genus of", "breed of"), plus a "mythology" substring. Countries are deliberately left in — a country's history is a legitimate topic timeline in a way a mid-size city's isn't. "Kobe" (city) is dropped while "Kobe Bryant" (person) survives.
- Candidates are collected in full before deduping (the base article can rank below one of its facets), and the over-fetch widens from 2× to 3× the display limit so heavy-facet queries still fill six slots.

Known tradeoffs: derived-name subjects like "John F. Kennedy International Airport" are deduped away, and description matching is best-effort — new junk categories need new patterns. Both acceptable for a product steering toward people and eras; Wikidata entity typing remains the principled follow-up if leaks keep appearing.

## Testing

- Fixture-driven run of the real `searchWikipedia` with a stubbed `fetch` (live Wikipedia is unreachable from the sandbox), covering both reported screenshots plus adversarial cases: the `hitler` case drops its facets while keeping Adolf Hitler / Alois Hitler / Hitler Youth / Hitler Diaries; `ben` drops Bengaluru and keeps the five people; `kob` drops three cities, the antelope, and the kobold while keeping Kris Kobach and Kobe Bryant; `queen` keeps Queen Victoria, Queen Latifah, and Queen (band); `michael jackson` keeps the writer while dropping "Death of Michael Jackson"; all numbered World Wars survive next to the generic "World war" article; Jr./Sr. names survive dedupe; discography/filmography/disambiguation pages are dropped.
- `npm run lint` and `npm run build` both clean.