### PR TITLE
Add a blue enter button to the desktop search field

### DIFF
--- a/src/components/NewTimeline/NewTimelineScreen.tsx
+++ b/src/components/NewTimeline/NewTimelineScreen.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
+import { CornerDownLeft } from 'lucide-react'
 import type { SubjectType } from '@/constants/pillDefinitions'
 import { SubjectSuggestions } from '@/components/AIMode/SubjectSuggestions'
 import { GeneratingIndicator } from '@/components/NewTimeline/GeneratingIndicator'
@@ -52,6 +53,23 @@ const SEARCH_FIELD_FONT =
 
 /** Box padding. Shared with the ghost overlay, for the same reason. */
 const SEARCH_FIELD_PADDING = 'px-[11px] py-[9px] md:p-[11px]'
+
+/**
+ * Room at the field's right edge for the enter button: 12px inset + 38px button
+ * + a 10px gap. Reserved permanently rather than toggled with the button, so
+ * text long enough to have scrolled the input never jumps sideways when it
+ * appears.
+ *
+ * Input-only, deliberately not folded into `SEARCH_FIELD_PADDING`: the ghost
+ * overlay renders only while the field is empty and the button only while it is
+ * not, so the ghost has no button to make room for — and taking the reserve
+ * anyway would narrow the box its placeholder animates in from 416px to 367px,
+ * cutting the longest name's headroom ('Civil Rights Movement', ~302px) from
+ * 114px to 65px to buy nothing. Right padding cannot move left-anchored text,
+ * so the two still agree on every metric the ghost actually depends on: type,
+ * left padding, vertical padding.
+ */
+const SEARCH_FIELD_ENTER_RESERVE = 'md:pr-[60px]'
 
 function BackgroundGrid() {
   return (
@@ -247,6 +265,11 @@ export function NewTimelineScreen({
     name.trim().length >= MIN_SUGGESTION_QUERY_LENGTH &&
     (suggestions.length > 0 || suggestionsLoading)
 
+  // Gated on `renderDropdown` rather than `dropdownVisible` for the same reason
+  // the chips are: it keeps the button away through the panel's 180ms exit
+  // animation instead of popping it back under a panel that is still fading.
+  const showEnterButton = name.trim().length > 0 && !renderDropdown && !isWorking
+
   useEffect(() => {
     if (dropdownVisible) {
       setRenderDropdown(true)
@@ -300,13 +323,44 @@ export function NewTimelineScreen({
                   autoCorrect="off"
                   spellCheck={false}
                   enterKeyHint="search"
-                  className={`w-full rounded-[8px] border border-[#404040] bg-surface-secondary outline-none transition-shadow text-text-secondary focus-visible:ring-1 focus-visible:ring-white/40 disabled:opacity-70 ${SEARCH_FIELD_PADDING} ${SEARCH_FIELD_FONT} ${
+                  className={`w-full rounded-[8px] border border-[#404040] bg-surface-secondary outline-none transition-shadow text-text-secondary focus-visible:ring-1 focus-visible:ring-white/40 disabled:opacity-70 ${SEARCH_FIELD_PADDING} ${SEARCH_FIELD_ENTER_RESERVE} ${SEARCH_FIELD_FONT} ${
                     hasEngaged
                       ? 'shadow-[0px_8px_16px_0px_rgba(155,158,163,0.04)]'
                       : 'shadow-[0px_8px_16px_0px_rgba(0,0,0,0.4)]'
                   }`}
                   aria-label="Subject for timeline generation"
                 />
+
+                {/* `type="submit"` is the whole point: the Enter key and this
+                    button reach `handleSubmit` through one path — the form's
+                    default button — rather than two copies of it that could
+                    drift.
+
+                    Which is also why it must never be `disabled`. A disabled
+                    default button has no activation behaviour, so implicit
+                    submission fires nothing and the Enter key dies with it —
+                    including below `md`, where the button is not even rendered.
+                    Empty and in-flight queries are already refused inside
+                    `handleSubmit`; visibility is carried by `invisible` (the
+                    chips' idiom, which drops it from hit-testing and the tab
+                    order in one property) so the control stays mounted and the
+                    Enter path never changes shape.
+
+                    `top-[12px] h-[40px]` measures the input's *content* box —
+                    1px border plus 11px padding, then 32px type at 1.25
+                    line-height — rather than stretching to the wrapper, whose
+                    height an inline-block input can pad with a baseline
+                    descender. Tied to `SEARCH_FIELD_FONT`'s `md` metrics; if
+                    those move, this moves with them. */}
+                <button
+                  type="submit"
+                  aria-label="Generate timeline"
+                  className={`hidden md:flex absolute right-[12px] top-[12px] h-[40px] items-center justify-center px-[9px] rounded-[6px] bg-[rgba(37,99,235,0.8)] border border-white/[0.15] shadow-[0px_8px_32px_rgba(0,0,0,0.4),inset_0px_1px_0px_rgba(255,255,255,0.1)] text-[#dadee5] hover:bg-[rgba(37,99,235,0.9)] transition-colors outline-none focus-visible:ring-1 focus-visible:ring-white/40 ${
+                    showEnterButton ? '' : 'invisible'
+                  }`}
+                >
+                  <CornerDownLeft size={20} aria-hidden="true" />
+                </button>
 
                 {/* `border border-transparent` is load-bearing: the input has a
                     1px border and an inset-0 overlay does not, so without it the
@@ -336,10 +390,13 @@ export function NewTimelineScreen({
                 )}
               </div>
 
-              {/* `type="button"` is required, not tidiness: the form has no
-                  submit control, so Enter works only through HTML's implicit
-                  submission, and a chip left as the default `submit` would
-                  become the form's default button and silently take it over.
+              {/* `type="button"` is required, not tidiness: a chip left as the
+                  default `submit` would fire `handleSubmit` with whatever is in
+                  the field on top of `handleQuickSearch`, generating the typed
+                  query rather than the chip's subject. The enter button holds
+                  default-button status regardless — it comes first in tree order
+                  — but that only settles which control the Enter key reaches,
+                  not what a click on a chip does.
 
                   `invisible` rather than a fade, because it also takes the chips
                   out of the tab order — right for controls sitting under an open


### PR DESCRIPTION
Implements the enter button from Figma [node `5480:13919`](https://www.figma.com/design/UOK8iRF59saXCjSEbHVooR/Timeline.academy?node-id=5480-13919) — *AI Mode Text Input / Desktop / Completed*.

## Why

The AI-mode search field had **no submit control of any kind**. Enter worked only through HTML's implicit form submission, so nothing on screen told a visitor how to start a timeline, and a field holding a freshly-picked suggestion just sat there looking inert.

## What

A blue `corner-down-left` button inside the field's right edge, at `md` and above, visible whenever the field holds text and the suggestions panel is not on screen.

Pressing Enter and clicking the button are the same action — **structurally**, not by duplication. The button is `type="submit"`, so it becomes the form's default button and both routes land in the existing `handleSubmit`. Two consequences worth flagging for review:

- **It must never be `disabled`.** A disabled default button has no activation behaviour, so implicit submission fires nothing and the Enter key dies with it — including below `md`, where the button isn't rendered at all. Empty and in-flight queries are already refused inside `handleSubmit`, and visibility rides on `invisible` (the quick-search chips' idiom) so the control stays mounted and the Enter path never changes shape.
- **The chips' `type="button"` comment needed rewriting.** Its stated premise — *"the form has no submit control"* — is what this change makes untrue. The attribute is still required, for a different reason, now recorded there.

The right-edge reserve is a **separate constant** from `SEARCH_FIELD_PADDING` rather than folded into it. That constant is deliberately shared with the typewriter ghost so their metrics stay identical, but the ghost renders only while the field is empty and the button only while it is not — so the ghost has no button to make room for, and taking the reserve anyway would narrow the box its placeholder animates in for nothing. Right padding cannot move left-anchored text, so the two still agree on the type and the left/vertical padding the ghost actually depends on.

Figma's `backdrop-blur-[12px]` is dropped: the field's fill (`--surface-color-secondary: #171717`) is fully opaque, so it would buy a compositing layer and no pixels.

## Files

`src/components/NewTimeline/NewTimelineScreen.tsx` — the only file touched. No change to `SubjectSuggestions`, `useSubjectSuggestions`, `useAIMode`, or the generation path.

## Behaviour note

`useSubjectSuggestions` sets `isLoading = true` synchronously, before its 200 ms debounce, and nothing in the typing path closes the panel. So for any 2+ character query matching anything on Wikipedia the panel stays open **throughout typing** — meaning in practice the button appears once the user has *settled*: after picking a suggestion, after Escape or a click outside, or when Wikipedia returns nothing. That is the intended trigger, but it is worth seeing on screen before merge. A one-character query opens no panel, so the button shows and then hides on the second keystroke — the same transition the chips already make.

## Verification

`npm run lint` and `npm run build` both clean. No test framework is configured, so the rest was checked by driving the real app in Chromium at 1280px and 390px:

| Check | Result |
|---|---|
| Enter key vs. button click | Both reach the same gate |
| Empty field + Enter | No-op |
| Tab order | input → button → chips |
| <768px | Button absent, Enter still submits |
| Panel open → hidden; pick a result → shown | As designed |
| Ghost overlay vs. input | Identical type, text origin aligned to 0px |
| Longest placeholder (`Civil Rights Movement`) | 302px in a 416px box, un-clipped |
| CSS ordering | `md:pr-[60px]` emitted after `md:p-[11px]`, so the reserve wins deterministically |

Rendered output matches the Figma node: 38×38 button (`px-[9px]` around a 20px icon), 12px in from the field's border, filling the input's 40px content box.

## Out of scope

`SubjectSuggestions` tracks a `highlight` index for ArrowUp/ArrowDown but never reads it on Enter, so arrow-keying to a suggestion and pressing Enter submits the *typed* text rather than the highlighted row. Pre-existing and confirmed not to newly conflict — the arrow listener never touches Enter. Worth a follow-up.